### PR TITLE
Remove leb128 dep

### DIFF
--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leb128 = "0.2.5"

--- a/wasm/src/decoder/code_section.rs
+++ b/wasm/src/decoder/code_section.rs
@@ -1,25 +1,25 @@
 use super::common::CodeBlock;
 use super::util;
 use crate::error::Result;
+use crate::varint::decode_u32;
 
 pub fn decode_code_section<R: crate::Reader>(reader: &mut R) -> Result<CodeBlock> {
-    let body_size = util::decode_u32(reader)? as u64;
-    let offset = reader.seek(std::io::SeekFrom::Current(0))?;
+    let body_size = decode_u32(reader)?.0;
 
     let v = util::decode_vec(reader, |x| {
-        Ok((util::decode_u32(x)?, util::decode_kind(x)?))
+        Ok((decode_u32(x)?, util::decode_kind(x)?))
     })?;
 
     let mut locals = Vec::new();
-    for x in v {
-        for _ in 0..x.0 {
-            locals.push(x.1);
+    let mut read = 0;
+    for ((count, consumed), kind) in v {
+        for _ in 0..count {
+            locals.push(kind);
         }
+        read += consumed as u32;
     }
 
-    let read = reader.seek(std::io::SeekFrom::Current(0))?;
-
-    let instruction_size = body_size - (read - offset);
+    let instruction_size = body_size - read;
 
     let mut instructions = Vec::with_capacity(instruction_size as usize);
 

--- a/wasm/src/decoder/mod.rs
+++ b/wasm/src/decoder/mod.rs
@@ -5,6 +5,7 @@ mod util;
 
 use crate::error::Error;
 use crate::error::Result;
+use crate::varint::decode_u32;
 
 pub enum Section {
     Type(Vec<common::FnType>),
@@ -65,7 +66,7 @@ pub fn decode_any_section<R: crate::Reader>(reader: &mut R) -> Result<Section> {
     // };
 
     // Consume length. Maybe useful later
-    leb128::read::unsigned(reader)?;
+    decode_u32(reader)?;
     let section = match section_id_byte[0] {
         0x01 => {
             let vec = util::decode_vec(reader, type_section::decode_type_section)?;
@@ -76,7 +77,7 @@ pub fn decode_any_section<R: crate::Reader>(reader: &mut R) -> Result<Section> {
         //     Section::Import(vec)
         // }
         0x03 => {
-            let vec = util::decode_vec(reader, |r| util::decode_u32(r))?;
+            let vec = util::decode_vec(reader, |r| Ok(decode_u32(r)?.0))?;
             Section::Function(vec)
         }
         // 0x03 => Section::Function(section_data),

--- a/wasm/src/decoder/util.rs
+++ b/wasm/src/decoder/util.rs
@@ -1,17 +1,14 @@
 use super::common;
 use crate::error::Error;
 use crate::error::Result;
-use leb128::read;
-
+use crate::varint::decode_u32;
 pub(crate) fn decode_vec<T, R, F>(reader: &mut R, func: F) -> Result<Vec<T>>
 where
     R: std::io::Read,
     F: Fn(&mut R) -> Result<T>,
 {
-    let length = read::unsigned(reader)? as usize;
-    if length > u32::MAX as usize {
-        return Err(Error::ArrayTooLarge);
-    }
+    // This is fine. It's already range checked by `decode_u32`
+    let length = decode_u32(reader)?.0 as usize;
 
     let mut v = Vec::with_capacity(length);
 
@@ -30,21 +27,4 @@ pub fn decode_kind<R: std::io::Read>(reader: &mut R) -> Result<common::ValueKind
         Ok(v) => Ok(v),
         Err(_) => Err(Error::InvalidValueKind),
     }
-}
-
-pub fn decode_u32<R: crate::Reader>(reader: &mut R) -> Result<u32> {
-    let s = reader.seek(std::io::SeekFrom::Current(0))?;
-    let length = read::unsigned(reader)?;
-    // This is so wacky to do. Replacing it with a better system should be done at some point
-    let end = reader.seek(std::io::SeekFrom::Current(0))?;
-
-    if length > u32::MAX as u64 {
-        // The `as u8` is fine here because the max that `read::unsigned` reads is 10 bytes.
-        return Err(Error::TooManyBytes {
-            expected: 5,
-            found: (end - s) as u8,
-        });
-    }
-
-    Ok(length as u32)
 }

--- a/wasm/src/error.rs
+++ b/wasm/src/error.rs
@@ -1,5 +1,3 @@
-use leb128::read;
-
 pub type Result<T> = std::result::Result<T, crate::error::Error>;
 
 #[repr(u8)]
@@ -42,18 +40,5 @@ impl std::error::Error for Error {}
 impl From<std::io::Error> for Error {
     fn from(v: std::io::Error) -> Self {
         Self::IoError(v)
-    }
-}
-
-impl From<read::Error> for Error {
-    fn from(v: read::Error) -> Self {
-        match v {
-            read::Error::IoError(e) => Self::IoError(e),
-            // Atleast 11 bytes were encoded
-            read::Error::Overflow => Self::TooManyBytes {
-                expected: 10,
-                found: 11,
-            },
-        }
     }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,5 +1,6 @@
 mod decoder;
 pub mod error;
+mod varint;
 
 pub trait Reader: std::io::Read + std::io::Seek {}
 

--- a/wasm/src/varint.rs
+++ b/wasm/src/varint.rs
@@ -1,0 +1,94 @@
+use crate::error::Error;
+
+const SEGMENT_BITS: u8 = 0x7F;
+const CONTINUE_BIT: u8 = 0x80;
+
+pub fn decode_u32<R: std::io::Read>(reader: &mut R) -> Result<(u32, u8), Error> {
+    let mut length = 0;
+    let mut value = 0;
+
+    loop {
+        let mut bytes: [u8; 1] = [0 ;1];
+        reader.read_exact(&mut bytes)?;
+        value |= ((bytes[0] & SEGMENT_BITS) as u32) << length;
+
+        length += 7;
+        if bytes[0] & CONTINUE_BIT == 0 {
+            break;
+        }
+
+        if length > 32 {
+            print!("{length}");
+            return Err(Error::TooManyBytes { expected: 5, found: length / 7 + 1})
+        }
+    }
+
+    length += length / 7;
+    Ok((value, length / 8))
+}
+
+pub fn decode_u64<R: std::io::Read>(reader: &mut R) -> Result<(u64, u8), Error> {
+    let mut length = 0;
+    let mut value = 0;
+
+    loop {
+        let mut bytes: [u8; 1] = [0 ;1];
+        reader.read_exact(&mut bytes)?;
+        value |= ((bytes[0] & SEGMENT_BITS) as u64) << length;
+
+        length += 7;
+        if bytes[0] & CONTINUE_BIT == 0 {
+            break;
+        }
+
+        if length > 64 {
+            return Err(Error::TooManyBytes { expected: 5, found: length / 8})
+        }
+    }
+
+    Ok((value, length / 8))
+}
+
+#[cfg(test)]
+mod test {
+    use crate::error::Error;
+    #[test]
+    fn decode_u32() {
+        let mut bytes: &[u8] = &[0x00];
+        let mut res = super::decode_u32(&mut bytes).unwrap();
+        assert_eq!(res, (0, 1));
+
+        bytes = &[0x01];
+        res = super::decode_u32(&mut bytes).unwrap();
+        assert_eq!(res, (1, 1));
+
+        bytes = &[0x80, 0x01];
+        res = super::decode_u32(&mut bytes).unwrap();
+        assert_eq!(res, (128, 2));
+
+        bytes = &[0xDD ,0xC7, 0x01];
+        res = super::decode_u32(&mut bytes).unwrap();
+        assert_eq!(res, (25565, 3));
+
+        bytes = &[0xFF, 0xFF, 0xFF, 0xFF, 0x07];
+        res = super::decode_u32(&mut bytes).unwrap();
+        assert_eq!(res, (i32::MAX as u32, 5));
+
+        bytes = &[0xFF, 0xFF, 0xFF, 0xFF, 0x0F];
+        res = super::decode_u32(&mut bytes).unwrap();
+        assert_eq!(res, (u32::MAX, 5));
+    }
+
+    #[test]
+    fn decode_32_over_u32_max() {
+        let mut bytes: &[u8] = &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01];
+        let res = super::decode_u32(&mut bytes).unwrap_err();
+        match res {
+            Error::TooManyBytes {expected, found } => {
+                assert_eq!(expected, 5);
+                assert_eq!(found, 6);
+            }
+            _ => unreachable!()
+        }
+    }
+}


### PR DESCRIPTION
Removes leb128 dep in favor of our own 2 decode functions.
This allows us not to use a wacky `Seek::stream_pos` or `Seek::seek(SeekFrom::Current(0))`
But rather just return the consumed byte count directly