### PR TITLE
chore: Remove duplicate PropertyKey enum

### DIFF
--- a/nova_vm/src/heap.rs
+++ b/nova_vm/src/heap.rs
@@ -37,16 +37,14 @@ use self::{
     indexes::{BaseIndex, FunctionIndex, NumberIndex, ObjectIndex, StringIndex},
     math::initialize_math_object,
     number::{initialize_number_heap, NumberHeapData},
-    object::{
-        initialize_object_heap, ObjectEntry, ObjectHeapData, PropertyDescriptor, PropertyKey,
-    },
+    object::{initialize_object_heap, ObjectEntry, ObjectHeapData, PropertyDescriptor},
     regexp::{initialize_regexp_heap, RegExpHeapData},
     string::initialize_string_heap,
     symbol::{initialize_symbol_heap, SymbolHeapData},
 };
 use crate::{
     execution::{Environments, Realm, RealmIdentifier},
-    types::{Function, Number, Object, String, StringHeapData, Value},
+    types::{Function, Number, Object, PropertyKey, String, StringHeapData, Value},
 };
 use wtf8::{Wtf8, Wtf8Buf};
 
@@ -275,7 +273,7 @@ impl<'ctx, 'host> Heap<'ctx, 'host> {
         &mut self,
         name: Value,
         length: u8,
-        uses_arguments: bool,
+        _uses_arguments: bool,
         // behaviour: Behaviour,
     ) -> FunctionIndex {
         let entries = vec![

--- a/nova_vm/src/heap/array.rs
+++ b/nova_vm/src/heap/array.rs
@@ -1,18 +1,17 @@
+use super::{
+    element_array::ElementsVector,
+    function::FunctionHeapData,
+    heap_constants::WellKnownSymbolIndexes,
+    indexes::{FunctionIndex, ObjectIndex},
+    object::ObjectEntry,
+};
 use crate::{
     execution::JsResult,
     heap::{
         heap_constants::{get_constructor_index, BuiltinObjectIndexes},
         Heap, PropertyDescriptor,
     },
-    types::{Object, Value},
-};
-
-use super::{
-    element_array::ElementsVector,
-    function::FunctionHeapData,
-    heap_constants::WellKnownSymbolIndexes,
-    indexes::{FunctionIndex, ObjectIndex},
-    object::{ObjectEntry, PropertyKey},
+    types::{Object, PropertyKey, Value},
 };
 
 #[derive(Debug, Clone, Copy)]

--- a/nova_vm/src/heap/array_buffer.rs
+++ b/nova_vm/src/heap/array_buffer.rs
@@ -1,16 +1,13 @@
 use super::{
-    function::FunctionHeapData,
-    heap_constants::WellKnownSymbolIndexes,
-    indexes::{ArrayBufferIndex, ObjectIndex},
-    object::{ObjectEntry, PropertyKey},
+    function::FunctionHeapData, heap_constants::WellKnownSymbolIndexes, indexes::ObjectIndex,
+    object::ObjectEntry,
 };
 use crate::{
-    execution::JsResult,
     heap::{
         heap_constants::{get_constructor_index, BuiltinObjectIndexes},
         Heap, PropertyDescriptor,
     },
-    types::{Object, Value},
+    types::{Object, PropertyKey, Value},
 };
 use std::{
     alloc::{alloc_zeroed, handle_alloc_error, Layout},

--- a/nova_vm/src/heap/bigint.rs
+++ b/nova_vm/src/heap/bigint.rs
@@ -3,9 +3,9 @@ use crate::{
     execution::JsResult,
     heap::{
         heap_constants::{get_constructor_index, BuiltinObjectIndexes},
-        FunctionHeapData, Heap, ObjectEntry, PropertyDescriptor, PropertyKey,
+        FunctionHeapData, Heap, ObjectEntry, PropertyDescriptor,
     },
-    types::{Object, Value},
+    types::{Object, PropertyKey, Value},
 };
 use num_bigint_dig::BigInt;
 

--- a/nova_vm/src/heap/boolean.rs
+++ b/nova_vm/src/heap/boolean.rs
@@ -1,15 +1,11 @@
+use super::{object::ObjectEntry, Heap};
 use crate::{
     execution::JsResult,
     heap::{
         heap_constants::{get_constructor_index, BuiltinObjectIndexes},
         FunctionHeapData, PropertyDescriptor,
     },
-    types::{Object, Value},
-};
-
-use super::{
-    object::{ObjectEntry, PropertyKey},
-    Heap,
+    types::{Object, PropertyKey, Value},
 };
 
 pub fn initialize_boolean_heap(heap: &mut Heap) {

--- a/nova_vm/src/heap/date.rs
+++ b/nova_vm/src/heap/date.rs
@@ -1,20 +1,18 @@
-use std::time::SystemTime;
-
+use super::{
+    function::FunctionHeapData,
+    heap_constants::WellKnownSymbolIndexes,
+    indexes::{FunctionIndex, ObjectIndex},
+    object::ObjectEntry,
+};
 use crate::{
     execution::JsResult,
     heap::{
         heap_constants::{get_constructor_index, BuiltinObjectIndexes},
         Heap, PropertyDescriptor,
     },
-    types::{Object, Value},
+    types::{Object, PropertyKey, Value},
 };
-
-use super::{
-    function::FunctionHeapData,
-    heap_constants::WellKnownSymbolIndexes,
-    indexes::{FunctionIndex, ObjectIndex},
-    object::{ObjectEntry, PropertyKey},
-};
+use std::time::SystemTime;
 
 #[derive(Debug, Clone, Copy)]
 pub struct DateHeapData {

--- a/nova_vm/src/heap/element_array.rs
+++ b/nova_vm/src/heap/element_array.rs
@@ -1,10 +1,10 @@
 use super::{
     indexes::{ElementIndex, FunctionIndex},
-    object::{ObjectEntry, PropertyDescriptor, PropertyKey},
+    object::{ObjectEntry, PropertyDescriptor},
 };
-use crate::{types::Value, Heap};
+use crate::types::{PropertyKey, Value};
 use core::panic;
-use std::{collections::HashMap, mem::MaybeUninit, num::NonZeroU16, vec};
+use std::{collections::HashMap, mem::MaybeUninit, num::NonZeroU16};
 
 #[derive(Debug, Clone, Copy)]
 pub enum ElementArrayKey {
@@ -789,8 +789,8 @@ impl ElementArrays {
             let (maybe_descriptor, maybe_value) =
                 ElementDescriptor::from_property_descriptor(value);
             let key = match key {
+                PropertyKey::Integer(data) => Value::Integer(data),
                 PropertyKey::SmallString(data) => Value::SmallString(data),
-                PropertyKey::Smi(data) => Value::from(data),
                 PropertyKey::String(data) => Value::String(data),
                 PropertyKey::Symbol(data) => Value::Symbol(data),
             };

--- a/nova_vm/src/heap/error.rs
+++ b/nova_vm/src/heap/error.rs
@@ -1,16 +1,15 @@
+use super::{
+    function::FunctionHeapData,
+    indexes::{FunctionIndex, ObjectIndex},
+    object::ObjectEntry,
+};
 use crate::{
     execution::JsResult,
     heap::{
         heap_constants::{get_constructor_index, BuiltinObjectIndexes},
         Heap, PropertyDescriptor,
     },
-    types::{Object, Value},
-};
-
-use super::{
-    function::FunctionHeapData,
-    indexes::{FunctionIndex, ObjectIndex},
-    object::{ObjectEntry, PropertyKey},
+    types::{Object, PropertyKey, Value},
 };
 
 #[derive(Debug, Clone, Copy)]

--- a/nova_vm/src/heap/function.rs
+++ b/nova_vm/src/heap/function.rs
@@ -1,17 +1,15 @@
+use super::{
+    heap_constants::WellKnownSymbolIndexes,
+    indexes::{FunctionIndex, ObjectIndex},
+    object::ObjectEntry,
+};
 use crate::{
-    builtins::Behaviour,
     execution::JsResult,
     heap::{
         heap_constants::{get_constructor_index, BuiltinObjectIndexes},
         Heap, PropertyDescriptor,
     },
-    types::{Object, Value},
-};
-
-use super::{
-    heap_constants::WellKnownSymbolIndexes,
-    indexes::{FunctionIndex, ObjectIndex},
-    object::{ObjectEntry, PropertyKey},
+    types::{Object, PropertyKey, Value},
 };
 
 #[derive(Debug, Clone)]

--- a/nova_vm/src/heap/heap_bits.rs
+++ b/nova_vm/src/heap/heap_bits.rs
@@ -1,7 +1,3 @@
-use std::sync::atomic::AtomicBool;
-
-use crate::types::Value;
-
 use super::{
     indexes::{
         ArrayBufferIndex, ArrayIndex, BigIntIndex, DateIndex, ElementIndex, ErrorIndex,
@@ -9,6 +5,8 @@ use super::{
     },
     Heap,
 };
+use crate::types::Value;
+use std::sync::atomic::AtomicBool;
 
 pub struct HeapBits {
     pub e_2_4: Box<[AtomicBool]>,

--- a/nova_vm/src/heap/heap_gc.rs
+++ b/nova_vm/src/heap/heap_gc.rs
@@ -1,7 +1,3 @@
-use std::sync::atomic::Ordering;
-
-use crate::types::Value;
-
 use super::{
     element_array::ElementArrayKey,
     heap_bits::{HeapBits, WorkQueues},
@@ -11,6 +7,8 @@ use super::{
     },
     ElementsVector, Heap,
 };
+use crate::types::Value;
+use std::sync::atomic::Ordering;
 
 pub fn heap_gc(heap: &mut Heap) {
     let bits = HeapBits::new(heap);

--- a/nova_vm/src/heap/math.rs
+++ b/nova_vm/src/heap/math.rs
@@ -1,9 +1,11 @@
-use crate::{execution::JsResult, types::Value};
-
 use super::{
     heap_constants::WellKnownSymbolIndexes,
-    object::{ObjectEntry, PropertyDescriptor, PropertyKey},
+    object::{ObjectEntry, PropertyDescriptor},
     Heap,
+};
+use crate::{
+    execution::JsResult,
+    types::{PropertyKey, Value},
 };
 
 pub(super) fn initialize_math_object(heap: &mut Heap) {

--- a/nova_vm/src/heap/number.rs
+++ b/nova_vm/src/heap/number.rs
@@ -1,14 +1,11 @@
-use super::{
-    object::{ObjectEntry, PropertyKey},
-    Heap,
-};
+use super::{object::ObjectEntry, Heap};
 use crate::{
     execution::JsResult,
     heap::{
         heap_constants::{get_constructor_index, BuiltinObjectIndexes},
         FunctionHeapData, PropertyDescriptor,
     },
-    types::{Object, Value},
+    types::{Object, PropertyKey, Value},
 };
 
 #[derive(Debug, Clone, Copy)]

--- a/nova_vm/src/heap/object.rs
+++ b/nova_vm/src/heap/object.rs
@@ -1,6 +1,6 @@
 use super::{
     element_array::ElementsVector,
-    indexes::{FunctionIndex, ObjectIndex, StringIndex, SymbolIndex},
+    indexes::{FunctionIndex, ObjectIndex, SymbolIndex},
 };
 use crate::{
     execution::JsResult,
@@ -8,8 +8,7 @@ use crate::{
         heap_constants::{get_constructor_index, BuiltinObjectIndexes},
         FunctionHeapData, Heap,
     },
-    types::{Object, Value},
-    SmallString,
+    types::{Object, PropertyKey, Value},
 };
 use std::{fmt::Debug, vec};
 
@@ -34,7 +33,7 @@ impl ObjectEntry {
         let key = PropertyKey::from_str(heap, name);
         let name = match key {
             PropertyKey::SmallString(data) => Value::SmallString(data.clone()),
-            PropertyKey::Smi(_) => unreachable!("No prototype functions should have SMI names"),
+            PropertyKey::Integer(_) => unreachable!("No prototype functions should have SMI names"),
             PropertyKey::String(idx) => Value::String(idx),
             PropertyKey::Symbol(idx) => Value::Symbol(idx),
         };
@@ -74,24 +73,6 @@ impl ObjectEntry {
         ObjectEntry {
             key: PropertyKey::from_str(heap, key),
             value: PropertyDescriptor::roh(value),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum PropertyKey {
-    SmallString(SmallString),
-    Smi(i32),
-    String(StringIndex),
-    Symbol(SymbolIndex),
-}
-
-impl PropertyKey {
-    pub fn from_str(heap: &mut Heap, str: &str) -> Self {
-        if let Ok(ascii_string) = SmallString::try_from(str) {
-            PropertyKey::SmallString(ascii_string)
-        } else {
-            PropertyKey::String(heap.alloc_string(str))
         }
     }
 }

--- a/nova_vm/src/heap/regexp.rs
+++ b/nova_vm/src/heap/regexp.rs
@@ -1,17 +1,16 @@
+use super::{
+    function::FunctionHeapData,
+    heap_constants::WellKnownSymbolIndexes,
+    indexes::{FunctionIndex, ObjectIndex},
+    object::ObjectEntry,
+};
 use crate::{
     execution::JsResult,
     heap::{
         heap_constants::{get_constructor_index, BuiltinObjectIndexes},
         Heap, PropertyDescriptor,
     },
-    types::{Object, Value},
-};
-
-use super::{
-    function::FunctionHeapData,
-    heap_constants::WellKnownSymbolIndexes,
-    indexes::{FunctionIndex, ObjectIndex},
-    object::{ObjectEntry, PropertyKey},
+    types::{Object, PropertyKey, Value},
 };
 
 #[derive(Debug, Clone, Copy)]

--- a/nova_vm/src/heap/symbol.rs
+++ b/nova_vm/src/heap/symbol.rs
@@ -1,15 +1,14 @@
+use super::{
+    indexes::{FunctionIndex, StringIndex, SymbolIndex},
+    object::ObjectEntry,
+};
 use crate::{
     execution::JsResult,
     heap::{
         heap_constants::{get_constructor_index, BuiltinObjectIndexes, WellKnownSymbolIndexes},
         FunctionHeapData, Heap, PropertyDescriptor,
     },
-    types::{Object, Value},
-};
-
-use super::{
-    indexes::{FunctionIndex, StringIndex, SymbolIndex},
-    object::{ObjectEntry, PropertyKey},
+    types::{Object, PropertyKey, Value},
 };
 
 #[derive(Debug, Clone, Copy)]

--- a/nova_vm/src/types/language/object/property_key.rs
+++ b/nova_vm/src/types/language/object/property_key.rs
@@ -1,67 +1,31 @@
 use crate::{
     execution::Agent,
-    heap::{indexes::StringIndex, GetHeapData},
+    heap::{
+        indexes::{StringIndex, SymbolIndex},
+        GetHeapData,
+    },
     types::{String, Value},
-    SmallInteger, SmallString,
+    Heap, SmallInteger, SmallString,
 };
 
 #[derive(Debug, Clone, Copy)]
 pub enum PropertyKey {
-    String(StringIndex),
+    Integer(SmallInteger),
     SmallString(SmallString),
-    SmallInteger(SmallInteger),
-}
-
-impl From<StringIndex> for PropertyKey {
-    fn from(value: StringIndex) -> Self {
-        PropertyKey::String(value)
-    }
-}
-
-impl From<SmallString> for PropertyKey {
-    fn from(value: SmallString) -> Self {
-        PropertyKey::SmallString(value)
-    }
-}
-
-impl From<SmallInteger> for PropertyKey {
-    fn from(value: SmallInteger) -> Self {
-        PropertyKey::SmallInteger(value)
-    }
-}
-
-impl From<String> for PropertyKey {
-    fn from(value: String) -> Self {
-        match value {
-            String::String(x) => PropertyKey::String(x),
-            String::SmallString(x) => PropertyKey::SmallString(x),
-        }
-    }
-}
-
-impl TryFrom<Value> for PropertyKey {
-    type Error = ();
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
-        match value {
-            Value::String(x) => Ok(PropertyKey::String(x)),
-            Value::SmallString(x) => Ok(PropertyKey::SmallString(x)),
-            Value::Integer(x) => Ok(PropertyKey::SmallInteger(x)),
-            _ => Err(()),
-        }
-    }
-}
-
-impl From<PropertyKey> for Value {
-    fn from(value: PropertyKey) -> Self {
-        match value {
-            PropertyKey::String(x) => Value::String(x),
-            PropertyKey::SmallString(x) => Value::SmallString(x),
-            PropertyKey::SmallInteger(x) => Value::Integer(x),
-        }
-    }
+    String(StringIndex),
+    Symbol(SymbolIndex),
 }
 
 impl PropertyKey {
+    // FIXME: This API is not necessarily in the right place.
+    pub fn from_str(heap: &mut Heap, str: &str) -> Self {
+        if let Ok(ascii_string) = SmallString::try_from(str) {
+            PropertyKey::SmallString(ascii_string)
+        } else {
+            PropertyKey::String(heap.alloc_string(str))
+        }
+    }
+
     pub fn into_value(self) -> Value {
         self.into()
     }
@@ -85,7 +49,7 @@ impl PropertyKey {
             (PropertyKey::SmallString(s1), PropertyKey::SmallString(s2)) => {
                 s1.as_str() == s2.as_str()
             }
-            (PropertyKey::String(s), PropertyKey::SmallInteger(n)) => {
+            (PropertyKey::String(s), PropertyKey::Integer(n)) => {
                 let s = agent.heap.get(s);
 
                 let Some(s) = s.as_str() else {
@@ -94,14 +58,69 @@ impl PropertyKey {
 
                 Self::is_str_eq_num(s, n.into_i64())
             }
-            (PropertyKey::SmallString(s), PropertyKey::SmallInteger(n)) => {
+            (PropertyKey::SmallString(s), PropertyKey::Integer(n)) => {
                 Self::is_str_eq_num(s.as_str(), n.into_i64())
             }
-            (PropertyKey::SmallInteger(n1), PropertyKey::SmallInteger(n2)) => {
-                n1.into_i64() == n2.into_i64()
-            }
-            (PropertyKey::SmallInteger(_), _) => y.equals(agent, self),
+            (PropertyKey::Integer(n1), PropertyKey::Integer(n2)) => n1.into_i64() == n2.into_i64(),
+            (PropertyKey::Integer(_), _) => y.equals(agent, self),
             _ => false,
+        }
+    }
+}
+
+impl From<SmallInteger> for PropertyKey {
+    fn from(value: SmallInteger) -> Self {
+        PropertyKey::Integer(value)
+    }
+}
+
+impl From<SmallString> for PropertyKey {
+    fn from(value: SmallString) -> Self {
+        PropertyKey::SmallString(value)
+    }
+}
+
+impl From<StringIndex> for PropertyKey {
+    fn from(value: StringIndex) -> Self {
+        PropertyKey::String(value)
+    }
+}
+
+impl From<SymbolIndex> for PropertyKey {
+    fn from(value: SymbolIndex) -> Self {
+        PropertyKey::Symbol(value)
+    }
+}
+
+impl From<String> for PropertyKey {
+    fn from(value: String) -> Self {
+        match value {
+            String::String(x) => PropertyKey::String(x),
+            String::SmallString(x) => PropertyKey::SmallString(x),
+        }
+    }
+}
+
+impl From<PropertyKey> for Value {
+    fn from(value: PropertyKey) -> Self {
+        match value {
+            PropertyKey::Integer(x) => Value::Integer(x),
+            PropertyKey::SmallString(x) => Value::SmallString(x),
+            PropertyKey::String(x) => Value::String(x),
+            PropertyKey::Symbol(x) => Value::Symbol(x),
+        }
+    }
+}
+
+impl TryFrom<Value> for PropertyKey {
+    type Error = ();
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Integer(x) => Ok(PropertyKey::Integer(x)),
+            Value::SmallString(x) => Ok(PropertyKey::SmallString(x)),
+            Value::String(x) => Ok(PropertyKey::String(x)),
+            Value::Symbol(x) => Ok(PropertyKey::Symbol(x)),
+            _ => Err(()),
         }
     }
 }


### PR DESCRIPTION
Take the `types/language/object/property_key.rs` PropertyKey into use.