### PR TITLE
feat(ecmascript): Implement ArrayBuffer Object sub-type

### DIFF
--- a/nova_vm/src/ecmascript/builtins.rs
+++ b/nova_vm/src/ecmascript/builtins.rs
@@ -13,6 +13,7 @@ pub mod ordinary;
 
 pub(crate) use array::ArrayHeapData;
 pub use array::{Array, ArrayConstructor};
+pub use array_buffer::ArrayBuffer;
 pub(crate) use array_buffer::ArrayBufferHeapData;
 pub use builtin_function::{
     create_builtin_function, todo_builtin, ArgumentsList, Behaviour, Builtin, BuiltinFunctionArgs,

--- a/nova_vm/src/ecmascript/builtins/array.rs
+++ b/nova_vm/src/ecmascript/builtins/array.rs
@@ -94,7 +94,7 @@ impl OrdinaryObjectInternalSlots for Array {
     fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         if let Some(object_index) = agent.heap.get(*self).object_index {
             OrdinaryObject::from(object_index).set_prototype(agent, prototype)
-        } else if prototype != Some(agent.current_realm().intrinsics().array_prototype()) {
+        } else {
             // Create array base object with custom prototype
             todo!()
         }

--- a/nova_vm/src/ecmascript/builtins/array_buffer.rs
+++ b/nova_vm/src/ecmascript/builtins/array_buffer.rs
@@ -1,23 +1,53 @@
 //! ## [25.1 ArrayBuffer Objects](https://tc39.es/ecma262/#sec-arraybuffer-objects)
 
 mod data;
-
+use self::data::InternalBuffer;
+use super::{ordinary::ordinary_set_prototype_of_check_loop, Array};
 use crate::{
     ecmascript::{
-        abstract_operations::operations_on_objects::get,
+        abstract_operations::{
+            operations_on_objects::get, testing_and_comparison::same_value_non_number,
+        },
         execution::{agent::JsError, Agent, JsResult},
-        types::{DataBlock, Function, InternalMethods, Number, Object, PropertyKey, Value},
+        types::{
+            DataBlock, Function, InternalMethods, Number, Object, OrdinaryObject,
+            OrdinaryObjectInternalSlots, PropertyDescriptor, PropertyKey, Value,
+        },
     },
     heap::{indexes::ArrayBufferIndex, GetHeapData},
     Heap,
 };
-
 pub use data::ArrayBufferHeapData;
-
-use self::data::InternalBuffer;
+use std::ops::Deref;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct ArrayBuffer(ArrayBufferIndex);
+
+impl From<ArrayBufferIndex> for ArrayBuffer {
+    fn from(value: ArrayBufferIndex) -> Self {
+        ArrayBuffer(value)
+    }
+}
+
+impl From<ArrayBuffer> for Object {
+    fn from(value: ArrayBuffer) -> Self {
+        Self::ArrayBuffer(value.0)
+    }
+}
+
+impl From<ArrayBuffer> for Value {
+    fn from(value: ArrayBuffer) -> Self {
+        Self::ArrayBuffer(value.0)
+    }
+}
+
+impl Deref for ArrayBuffer {
+    type Target = ArrayBufferIndex;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 pub struct DetachKey {}
 
@@ -476,5 +506,183 @@ impl ArrayBuffer {
         // b. Let rawBytesModified be op(rawBytesRead, rawBytes).
         // c. Store the individual bytes of rawBytesModified into block, starting at block[byteIndex].
         // 10. Return RawBytesToNumeric(type, rawBytesRead, isLittleEndian).
+    }
+}
+
+fn create_array_buffer_base_object(agent: &mut Agent, array_buffer: ArrayBuffer) -> OrdinaryObject {
+    // TODO: An issue crops up if multiple realms are in play:
+    // The prototype should not be dependent on the realm we're operating in
+    // but should instead be bound to the realm the object was created in.
+    // We'll have to cross this bridge at a later point, likely be designating
+    // a "default realm" and making non-default realms always initialize ObjectHeapData.
+    let prototype = agent.current_realm().intrinsics().array_buffer_prototype();
+    let object_index = agent.heap.create_object_with_prototype(prototype.into());
+    agent.heap.get_mut(*array_buffer).object_index = Some(object_index);
+    OrdinaryObject::from(object_index)
+}
+
+impl OrdinaryObjectInternalSlots for ArrayBuffer {
+    fn extensible(self, agent: &Agent) -> bool {
+        if let Some(object_index) = agent.heap.get(*self).object_index {
+            OrdinaryObject::from(object_index).extensible(agent)
+        } else {
+            true
+        }
+    }
+
+    fn set_extensible(self, agent: &mut Agent, value: bool) {
+        if let Some(object_index) = agent.heap.get(*self).object_index {
+            OrdinaryObject::from(object_index).set_extensible(agent, value)
+        } else {
+            debug_assert!(!value);
+            create_array_buffer_base_object(agent, self).set_extensible(agent, value)
+        }
+    }
+
+    fn prototype(self, agent: &Agent) -> Option<Object> {
+        if let Some(object_index) = agent.heap.get(*self).object_index {
+            OrdinaryObject::from(object_index).prototype(agent)
+        } else {
+            Some(
+                agent
+                    .current_realm()
+                    .intrinsics()
+                    .array_buffer_prototype()
+                    .into(),
+            )
+        }
+    }
+
+    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+        if let Some(object_index) = agent.heap.get(*self).object_index {
+            OrdinaryObject::from(object_index).set_prototype(agent, prototype)
+        } else {
+            // Create ArrayBuffer base object with custom prototype
+            let object_index = if let Some(prototype) = prototype {
+                debug_assert!(ordinary_set_prototype_of_check_loop(
+                    agent,
+                    prototype,
+                    Some(self.into())
+                ));
+                agent.heap.create_object_with_prototype(prototype)
+            } else {
+                agent.heap.create_null_object(vec![])
+            };
+            agent.heap.get_mut(*self).object_index = Some(object_index);
+        }
+    }
+}
+
+impl InternalMethods for ArrayBuffer {
+    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.prototype(agent))
+    }
+
+    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+        if let Some(object_index) = agent.heap.get(*self).object_index {
+            OrdinaryObject::from(object_index).set_prototype_of(agent, prototype)
+        } else {
+            // If we're setting %ArrayBuffer.prototype% then we can still avoid creating the ObjectHeapData.
+            let current = agent.current_realm().intrinsics().array_buffer_prototype();
+            if let Some(v) = prototype {
+                if same_value_non_number(agent, v, current.into()) {
+                    return Ok(true);
+                }
+            };
+            if ordinary_set_prototype_of_check_loop(agent, current.into(), prototype) {
+                // OrdinarySetPrototypeOf 7.b.i: Setting prototype would cause a loop to occur.
+                return Ok(false);
+            }
+            self.set_prototype(agent, prototype);
+            Ok(true)
+        }
+    }
+
+    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.extensible(agent))
+    }
+
+    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.set_extensible(agent, false);
+        Ok(true)
+    }
+
+    fn get_own_property(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+    ) -> JsResult<Option<PropertyDescriptor>> {
+        if let Some(object_index) = agent.heap.get(*self).object_index {
+            OrdinaryObject::from(object_index).get_own_property(agent, property_key)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn define_own_property(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        property_descriptor: crate::ecmascript::types::PropertyDescriptor,
+    ) -> JsResult<bool> {
+        create_array_buffer_base_object(agent, self).define_own_property(
+            agent,
+            property_key,
+            property_descriptor,
+        )
+    }
+
+    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+        if let Some(object_index) = agent.heap.get(*self).object_index {
+            OrdinaryObject::from(object_index).has_property(agent, property_key)
+        } else {
+            agent
+                .current_realm()
+                .intrinsics()
+                .array_buffer_prototype()
+                .has_property(agent, property_key)
+        }
+    }
+
+    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
+        if let Some(object_index) = agent.heap.get(*self).object_index {
+            OrdinaryObject::from(object_index).get(agent, property_key, receiver)
+        } else {
+            agent
+                .current_realm()
+                .intrinsics()
+                .array_buffer_prototype()
+                .get(agent, property_key, receiver)
+        }
+    }
+
+    fn set(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        value: Value,
+        receiver: Value,
+    ) -> JsResult<bool> {
+        create_array_buffer_base_object(agent, self).set(agent, property_key, value, receiver)
+    }
+
+    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+        if let Some(object_index) = agent.heap.get(*self).object_index {
+            OrdinaryObject::from(object_index).delete(agent, property_key)
+        } else {
+            // OrdinaryDelete essentially returns "didn't exist or was deleted":
+            // We know properties didn't exist in this branch.
+            Ok(true)
+        }
+    }
+
+    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+        if let Some(object_index) = agent.heap.get(*self).object_index {
+            OrdinaryObject::from(object_index).own_property_keys(agent)
+        } else {
+            // OrdinaryDelete essentially returns "didn't exist or was deleted":
+            // We know properties didn't exist in this branch.
+            Ok(vec![])
+        }
     }
 }

--- a/nova_vm/src/ecmascript/execution/realm/intrinsics.rs
+++ b/nova_vm/src/ecmascript/execution/realm/intrinsics.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ecmascript::types::{Function, Object},
+    ecmascript::types::{Function, Object, OrdinaryObject},
     heap::{
         indexes::{FunctionIndex, ObjectIndex},
         BuiltinObjectIndexes,
@@ -223,7 +223,7 @@ impl Intrinsics {
     ) -> Object {
         match intrinsic_default_proto {
             ProtoIntrinsics::Array => self.array_prototype(),
-            ProtoIntrinsics::ArrayBuffer => self.array_buffer_prototype(),
+            ProtoIntrinsics::ArrayBuffer => self.array_buffer_prototype().into(),
             ProtoIntrinsics::BigInt => self.big_int_prototype(),
             ProtoIntrinsics::Boolean => self.boolean_prototype(),
             ProtoIntrinsics::Error => self.error_prototype(),
@@ -257,8 +257,8 @@ impl Intrinsics {
     }
 
     /// %ArrayBuffer.prototype%
-    pub const fn array_buffer_prototype(&self) -> Object {
-        Object::Object(self.array_buffer_prototype)
+    pub const fn array_buffer_prototype(&self) -> OrdinaryObject {
+        OrdinaryObject::new(self.array_buffer_prototype)
     }
 
     /// %BigInt%

--- a/nova_vm/src/ecmascript/types/language/object/property_key.rs
+++ b/nova_vm/src/ecmascript/types/language/object/property_key.rs
@@ -10,7 +10,7 @@ use crate::{
     Heap, SmallInteger, SmallString,
 };
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PropertyKey {
     Integer(SmallInteger),
     SmallString(SmallString),


### PR DESCRIPTION
Implements `ArrayBuffer` properly as a sub-type of `Object` (and `Value`). This PR should serve as a good guideline on how `Object` sub-types are implemented at their most basic, though `ArrayBuffer` is probably the only one that is quite as simple as this.