### PR TITLE
fix(ecmascript) Fix Number::is_nonzero

### DIFF
--- a/nova_vm/src/ecmascript/types/language/number.rs
+++ b/nova_vm/src/ecmascript/types/language/number.rs
@@ -160,12 +160,9 @@ impl Number {
 
     pub fn is_nonzero(self, agent: &mut Agent) -> bool {
         match self {
-            Number::Number(n) => {
-                let n = *agent.heap.get(n);
-                !n.is_sign_negative() && !n.is_sign_positive()
-            }
+            Number::Number(n) => 0.0 != *agent.heap.get(n),
             Number::Integer(_) => true,
-            Number::Float(n) => !n.is_sign_negative() && !n.is_sign_positive(),
+            Number::Float(n) => 0.0 != n,
         }
     }
 

--- a/nova_vm/src/ecmascript/types/language/number.rs
+++ b/nova_vm/src/ecmascript/types/language/number.rs
@@ -120,17 +120,17 @@ impl Number {
 
     pub fn is_pos_zero(self, agent: &mut Agent) -> bool {
         match self {
-            Number::Number(n) => agent.heap.get(n).is_sign_positive(),
+            Number::Number(n) => f64::to_bits(0.0) == f64::to_bits(agent.heap.get(n)),
             Number::Integer(n) => 0i64 == n.into(),
-            Number::Float(n) => n.is_sign_positive(),
+            Number::Float(n) => f32::to_bits(0.0) == f32::to_bits(n),
         }
     }
 
     pub fn is_neg_zero(self, agent: &mut Agent) -> bool {
         match self {
-            Number::Number(n) => agent.heap.get(n).is_sign_negative(),
+            Number::Number(n) => f64::to_bits(-0.0) == f64::to_bits(agent.heap.get(n)),
             Number::Integer(_) => false,
-            Number::Float(n) => n.is_sign_negative(),
+            Number::Float(n) => f32::to_bits(-0.0) == f32::to_bits(n),
         }
     }
 

--- a/nova_vm/src/ecmascript/types/language/number.rs
+++ b/nova_vm/src/ecmascript/types/language/number.rs
@@ -120,7 +120,7 @@ impl Number {
 
     pub fn is_pos_zero(self, agent: &mut Agent) -> bool {
         match self {
-            Number::Number(n) => f64::to_bits(0.0) == f64::to_bits(agent.heap.get(n)),
+            Number::Number(n) => f64::to_bits(0.0) == f64::to_bits(*agent.heap.get(n)),
             Number::Integer(n) => 0i64 == n.into(),
             Number::Float(n) => f32::to_bits(0.0) == f32::to_bits(n),
         }
@@ -128,7 +128,7 @@ impl Number {
 
     pub fn is_neg_zero(self, agent: &mut Agent) -> bool {
         match self {
-            Number::Number(n) => f64::to_bits(-0.0) == f64::to_bits(agent.heap.get(n)),
+            Number::Number(n) => f64::to_bits(-0.0) == f64::to_bits(*agent.heap.get(n)),
             Number::Integer(_) => false,
             Number::Float(n) => f32::to_bits(-0.0) == f32::to_bits(n),
         }

--- a/nova_vm/src/ecmascript/types/language/number.rs
+++ b/nova_vm/src/ecmascript/types/language/number.rs
@@ -161,7 +161,7 @@ impl Number {
     pub fn is_nonzero(self, agent: &mut Agent) -> bool {
         match self {
             Number::Number(n) => 0.0 != *agent.heap.get(n),
-            Number::Integer(_) => true,
+            Number::Integer(n) => 0i64 != n.into(),
             Number::Float(n) => 0.0 != n,
         }
     }


### PR DESCRIPTION
https://github.com/trynova/nova/blob/main/nova_vm/src/ecmascript/types/language/number.rs#L165

`!n.is_sign_negative() && !n.is_sign_positive()` is always false.