### PR TITLE
Finish Number::SameValue

### DIFF
--- a/nova_vm/src/ecmascript/types/language/number.rs
+++ b/nova_vm/src/ecmascript/types/language/number.rs
@@ -400,7 +400,7 @@ impl Number {
                 Number::pos_inf()
             }
             // b. If abs(ℝ(base)) = 1, return NaN.
-            else if todo!("implement number comparisons") /*base.is(agent, Number::from(1))*/ {
+            else if base.same_value(agent, Number::from(1)) {
                 Number::nan()
             }
             // c. If abs(ℝ(base)) < 1, return +0𝔽.
@@ -461,7 +461,7 @@ impl Number {
         }
 
         // 3. If x is y, return false.
-        if todo!("implement number comparisons") /*x.is(agent, y)*/ {
+        if x.same_value(agent, y) {
             return Some(false);
         }
 
@@ -530,7 +530,7 @@ impl Number {
         }
 
         // 3. If x is y, return true.
-        if todo!("implement number comparisons") /*x.is(agent, y)*/ {
+        if x.same_value(agent, y) {
             return true;
         }
 
@@ -569,7 +569,7 @@ impl Number {
         }
 
         // 4. If x is y, return true.
-        if todo!("implement number comparisons") /*x.is(agent, y)*/ {
+        if x.same_value(agent, y) {
             return true;
         }
 
@@ -598,7 +598,7 @@ impl Number {
         }
 
         // 4. If x is y, return true.
-        if todo!("implement number comparisons") /*x.is(agent, y)*/ {
+        if x.same_value(agent, y) {
             return true;
         }
 

--- a/nova_vm/src/ecmascript/types/language/number.rs
+++ b/nova_vm/src/ecmascript/types/language/number.rs
@@ -198,9 +198,27 @@ impl Number {
     }
 
     /// A minimal version of ObjectIs when you know the arguments are numbers.
-    pub fn is(self, agent: &mut Agent, y: Self) -> bool {
-        // TODO: Add in spec from Object.is pertaining to numbers.
+    /// https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-numeric-types-number-sameValue
+    pub fn same_value(self, agent: &mut Agent, y: Self) -> bool {
+        // If x is NaN and y is NaN, return true.
+        // If x is +0𝔽 and y is -0𝔽, return false.
+        // If x is -0𝔽 and y is +0𝔽, return false.
+        // If x is y, return true.
+        // Return false.
+
         let x = self;
+
+        if x.is_nan() && y.is_nan() {
+            return true;
+        }
+
+        if !x.is_nonzero() & !y.is_nonzero() {
+            let x: f32 = x.into();
+            let y: f32 = y.into();
+            let sign_of_x = f32::copysign(0.0, x);
+            let sign_of_y = f32::copysign(0.0, y);
+            return sign_of_x == sign_of_y;
+        }
 
         match (x, y) {
             (Number::Number(x), Number::Number(y)) => agent.heap.get(x) == agent.heap.get(y),
@@ -382,7 +400,7 @@ impl Number {
                 Number::pos_inf()
             }
             // b. If abs(ℝ(base)) = 1, return NaN.
-            else if base.is(agent, Number::from(1)) {
+            else if todo!("implement number comparisons") /*base.is(agent, Number::from(1))*/ {
                 Number::nan()
             }
             // c. If abs(ℝ(base)) < 1, return +0𝔽.
@@ -443,7 +461,7 @@ impl Number {
         }
 
         // 3. If x is y, return false.
-        if x.is(agent, y) {
+        if todo!("implement number comparisons") /*x.is(agent, y)*/ {
             return Some(false);
         }
 
@@ -512,7 +530,7 @@ impl Number {
         }
 
         // 3. If x is y, return true.
-        if x.is(agent, y) {
+        if todo!("implement number comparisons") /*x.is(agent, y)*/ {
             return true;
         }
 
@@ -551,7 +569,7 @@ impl Number {
         }
 
         // 4. If x is y, return true.
-        if x.is(agent, y) {
+        if todo!("implement number comparisons") /*x.is(agent, y)*/ {
             return true;
         }
 
@@ -580,7 +598,7 @@ impl Number {
         }
 
         // 4. If x is y, return true.
-        if x.is(agent, y) {
+        if todo!("implement number comparisons") /*x.is(agent, y)*/ {
             return true;
         }
 


### PR DESCRIPTION
this fixes a `todo` comment in `Number::is` referring to the spec for `Object.is`.
`Object.is` is implemented via `SameValue(x, y)`, which in turn has a separate branch for numbers: `Number::SameValue`.

This is the rest of the implementation.

I also identified that `Number::is` was being used in places where the spec wanted pretty much simple equality, as opposed to `SameValue`? Although they would both fit.

We should try to get some helpers for comparisons and operations soon, the code is overtly verbose. I'll write some ideas on the Discord server.
