### PR TITLE
feat(vm): Add conversions from integer types to `SmallInteger`

### DIFF
--- a/nova_vm/src/ecmascript/types/language/number.rs
+++ b/nova_vm/src/ecmascript/types/language/number.rs
@@ -41,7 +41,7 @@ impl From<SmallInteger> for Number {
 
 impl From<i32> for Number {
     fn from(value: i32) -> Self {
-        Number::Integer(SmallInteger::from_i64_unchecked(value as i64))
+        Number::Integer(SmallInteger::from(value))
     }
 }
 
@@ -50,7 +50,7 @@ impl From<i64> for Number {
         let n = value
             .min(SmallInteger::MAX_NUMBER)
             .max(SmallInteger::MIN_NUMBER);
-        Number::Integer(SmallInteger::from_i64_unchecked(n))
+        Number::Integer(SmallInteger::try_from(n).unwrap())
     }
 }
 
@@ -257,7 +257,7 @@ impl Number {
             }
             Number::Integer(n) => {
                 let n = n.into_i64();
-                Number::Integer(SmallInteger::from_i64_unchecked(n.abs()))
+                Number::Integer(SmallInteger::try_from(n.abs()).unwrap())
             }
             Number::Float(n) => Number::Float(n.abs()),
         }
@@ -279,7 +279,7 @@ impl Number {
                 let value = *agent.heap.get(n);
                 agent.heap.create(-value)
             }
-            Number::Integer(n) => SmallInteger::from_i64_unchecked(-n.into_i64()).into(),
+            Number::Integer(n) => SmallInteger::try_from(-n.into_i64()).unwrap().into(),
             Number::Float(n) => (-n).into(),
         }
     }

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -346,8 +346,7 @@ macro_rules! impl_value_from_n {
     ($size: ty) => {
         impl From<$size> for Value {
             fn from(value: $size) -> Self {
-                let n: i64 = value.into();
-                Value::Integer(SmallInteger::from_i64_unchecked(n))
+                Value::Integer(SmallInteger::from(value))
             }
         }
     };

--- a/nova_vm/src/engine/small_integer.rs
+++ b/nova_vm/src/engine/small_integer.rs
@@ -28,7 +28,7 @@ impl SmallInteger {
         }
     }
 
-    pub fn from_i64_unchecked(value: i64) -> SmallInteger {
+    fn from_i64_unchecked(value: i64) -> SmallInteger {
         debug_assert!((Self::MIN_BIGINT..=Self::MAX_BIGINT).contains(&value));
         let bytes = i64::to_ne_bytes(value);
 
@@ -50,12 +50,63 @@ impl TryFrom<i64> for SmallInteger {
     type Error = ();
     fn try_from(value: i64) -> Result<Self, Self::Error> {
         if (Self::MIN_BIGINT..=Self::MAX_BIGINT).contains(&value) {
-            Ok(Self::from_i64_unchecked(value))
+            // SAFETY: We just checked the valid range.
+            Ok(unsafe { Self::from_i64_unchecked(value) })
         } else {
             Err(())
         }
     }
 }
+
+impl TryFrom<u64> for SmallInteger {
+    type Error = ();
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        if value <= (Self::MAX_BIGINT as u64) {
+            // SAFETY: Since Self::MIN_NUMBER is negative and Self::MAX_NUMBER
+            // positive, we know that value is within the valid range.
+            // Furthermore, since value is within a range that is valid for i64,
+            // we know that value is representable as i64.
+            Ok(unsafe { Self::from_i64_unchecked(value as i64) })
+        } else {
+            Err(())
+        }
+    }
+}
+
+macro_rules! from_numeric_type {
+    ($numtype:ty) => {
+        // Checking at compile-time that $numtype fully fits within the range.
+        const _: () = {
+            assert!(
+                <$numtype>::MIN as i64 >= SmallInteger::MIN_BIGINT,
+                concat!(
+                    stringify!($numtype),
+                    " is outside of the SmallInteger range (min)"
+                )
+            );
+            assert!(
+                <$numtype>::MAX as i64 <= SmallInteger::MAX_BIGINT,
+                concat!(
+                    stringify!($numtype),
+                    " is outside of the SmallInteger range (max)"
+                )
+            );
+        };
+        impl From<$numtype> for SmallInteger {
+            fn from(value: $numtype) -> Self {
+                // SAFETY: All values of $numtype fit in the {MIN,MAX}_BIGINT
+                // range, which we have verified at compile time above.
+                unsafe { Self::from_i64_unchecked(i64::from(value)) }
+            }
+        }
+    };
+}
+from_numeric_type!(u8);
+from_numeric_type!(i8);
+from_numeric_type!(u16);
+from_numeric_type!(i16);
+from_numeric_type!(u32);
+from_numeric_type!(i32);
 
 impl From<SmallInteger> for i64 {
     fn from(value: SmallInteger) -> Self {

--- a/nova_vm/src/engine/small_integer.rs
+++ b/nova_vm/src/engine/small_integer.rs
@@ -50,8 +50,7 @@ impl TryFrom<i64> for SmallInteger {
     type Error = ();
     fn try_from(value: i64) -> Result<Self, Self::Error> {
         if (Self::MIN_BIGINT..=Self::MAX_BIGINT).contains(&value) {
-            // SAFETY: We just checked the valid range.
-            Ok(unsafe { Self::from_i64_unchecked(value) })
+            Ok(Self::from_i64_unchecked(value))
         } else {
             Err(())
         }
@@ -62,11 +61,7 @@ impl TryFrom<u64> for SmallInteger {
     type Error = ();
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         if value <= (Self::MAX_BIGINT as u64) {
-            // SAFETY: Since Self::MIN_NUMBER is negative and Self::MAX_NUMBER
-            // positive, we know that value is within the valid range.
-            // Furthermore, since value is within a range that is valid for i64,
-            // we know that value is representable as i64.
-            Ok(unsafe { Self::from_i64_unchecked(value as i64) })
+            Ok(Self::from_i64_unchecked(value as i64))
         } else {
             Err(())
         }
@@ -94,9 +89,7 @@ macro_rules! from_numeric_type {
         };
         impl From<$numtype> for SmallInteger {
             fn from(value: $numtype) -> Self {
-                // SAFETY: All values of $numtype fit in the {MIN,MAX}_BIGINT
-                // range, which we have verified at compile time above.
-                unsafe { Self::from_i64_unchecked(i64::from(value)) }
+                Self::from_i64_unchecked(i64::from(value))
             }
         }
     };


### PR DESCRIPTION
This patch also makes `SmallInteger::from_i64_unchecked` a private method, to prevent misuse.

-----------

This PR depends on #58 and should not land before it.
