### PR TITLE
refactor: use better `Value` and sub-enum names

### DIFF
--- a/nova_vm/src/ecmascript/abstract_operations/type_conversion.rs
+++ b/nova_vm/src/ecmascript/abstract_operations/type_conversion.rs
@@ -475,11 +475,11 @@ pub(crate) fn to_object(_agent: &mut Agent, argument: Value) -> JsResult<Object>
         Value::Symbol(_) => todo!("SymbolObject"),
         // Return a new Number object whose [[NumberData]] internal slot is set to argument.
         Value::Number(_) => todo!("NumberObject"),
-        Value::Integer(_) => todo!("NumberObject"),
-        Value::Float(_) => todo!("NumberObject"),
+        Value::NumberI56(_) => todo!("NumberObject"),
+        Value::NumberF32(_) => todo!("NumberObject"),
         // Return a new BigInt object whose [[BigIntData]] internal slot is set to argument.
         Value::BigInt(_) => todo!("BigIntObject"),
-        Value::SmallBigInt(_) => todo!("BigIntObject"),
+        Value::BigIntI56(_) => todo!("BigIntObject"),
         _ => Ok(Object::try_from(argument).unwrap()),
     }
 }

--- a/nova_vm/src/ecmascript/builtins/number.rs
+++ b/nova_vm/src/ecmascript/builtins/number.rs
@@ -8,7 +8,7 @@ use crate::{
         types::{Number, Object, PropertyDescriptor, Value},
     },
     heap::CreateHeapData,
-    SmallInteger,
+    I56,
 };
 
 pub struct NumberConstructor;
@@ -52,7 +52,7 @@ impl Builtin for NumberConstructor {
             object,
             "MAX_SAFE_INTEGER",
             PropertyDescriptor {
-                value: Some(Number::from(SmallInteger::MAX_NUMBER).into()),
+                value: Some(Number::from(I56::MAX_NUMBER).into()),
                 writable: Some(false),
                 enumerable: Some(false),
                 configurable: Some(false),
@@ -80,7 +80,7 @@ impl Builtin for NumberConstructor {
             object,
             "MIN_SAFE_INTEGER",
             PropertyDescriptor {
-                value: Some(Number::from(SmallInteger::MIN_NUMBER).into()),
+                value: Some(Number::from(I56::MIN_NUMBER).into()),
                 writable: Some(false),
                 enumerable: Some(false),
                 configurable: Some(false),

--- a/nova_vm/src/engine.rs
+++ b/nova_vm/src/engine.rs
@@ -1,3 +1,3 @@
 mod bytecode;
-pub mod small_integer;
+pub mod i56;
 pub mod small_string;

--- a/nova_vm/src/engine/i56.rs
+++ b/nova_vm/src/engine/i56.rs
@@ -1,16 +1,16 @@
 /// 56-bit signed integer.
 #[derive(Clone, Copy, PartialEq)]
-pub struct SmallInteger {
+pub struct I56 {
     data: [u8; 7],
 }
 
-impl std::fmt::Debug for SmallInteger {
+impl std::fmt::Debug for I56 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", Into::<i64>::into(*self))
     }
 }
 
-impl SmallInteger {
+impl I56 {
     pub const MIN_BIGINT: i64 = -(2i64.pow(55));
     pub const MAX_BIGINT: i64 = 2i64.pow(55) - 1;
 
@@ -22,13 +22,13 @@ impl SmallInteger {
         self.into()
     }
 
-    pub const fn zero() -> SmallInteger {
+    pub const fn zero() -> I56 {
         Self {
             data: [0, 0, 0, 0, 0, 0, 0],
         }
     }
 
-    fn from_i64_unchecked(value: i64) -> SmallInteger {
+    fn from_i64_unchecked(value: i64) -> I56 {
         debug_assert!((Self::MIN_BIGINT..=Self::MAX_BIGINT).contains(&value));
         let bytes = i64::to_ne_bytes(value);
 
@@ -46,7 +46,7 @@ impl SmallInteger {
     }
 }
 
-impl std::ops::Neg for SmallInteger {
+impl std::ops::Neg for I56 {
     type Output = Self;
 
     /// ## Panics
@@ -56,7 +56,7 @@ impl std::ops::Neg for SmallInteger {
     }
 }
 
-impl std::ops::Not for SmallInteger {
+impl std::ops::Not for I56 {
     type Output = Self;
     fn not(self) -> Self::Output {
         // NOTE: This is safe because the bitwise not of any number in the range
@@ -65,7 +65,7 @@ impl std::ops::Not for SmallInteger {
     }
 }
 
-impl TryFrom<i64> for SmallInteger {
+impl TryFrom<i64> for I56 {
     type Error = ();
     fn try_from(value: i64) -> Result<Self, Self::Error> {
         if (Self::MIN_BIGINT..=Self::MAX_BIGINT).contains(&value) {
@@ -76,7 +76,7 @@ impl TryFrom<i64> for SmallInteger {
     }
 }
 
-impl TryFrom<i128> for SmallInteger {
+impl TryFrom<i128> for I56 {
     type Error = ();
     fn try_from(value: i128) -> Result<Self, Self::Error> {
         if (Self::MIN_BIGINT as i128..=Self::MAX_BIGINT as i128).contains(&value) {
@@ -87,7 +87,7 @@ impl TryFrom<i128> for SmallInteger {
     }
 }
 
-impl TryFrom<u64> for SmallInteger {
+impl TryFrom<u64> for I56 {
     type Error = ();
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         if value <= (Self::MAX_BIGINT as u64) {
@@ -103,21 +103,15 @@ macro_rules! from_numeric_type {
         // Checking at compile-time that $numtype fully fits within the range.
         const _: () = {
             assert!(
-                <$numtype>::MIN as i64 >= SmallInteger::MIN_BIGINT,
-                concat!(
-                    stringify!($numtype),
-                    " is outside of the SmallInteger range (min)"
-                )
+                <$numtype>::MIN as i64 >= I56::MIN_BIGINT,
+                concat!(stringify!($numtype), " is outside of the I56 range (min)")
             );
             assert!(
-                <$numtype>::MAX as i64 <= SmallInteger::MAX_BIGINT,
-                concat!(
-                    stringify!($numtype),
-                    " is outside of the SmallInteger range (max)"
-                )
+                <$numtype>::MAX as i64 <= I56::MAX_BIGINT,
+                concat!(stringify!($numtype), " is outside of the I56 range (max)")
             );
         };
-        impl From<$numtype> for SmallInteger {
+        impl From<$numtype> for I56 {
             fn from(value: $numtype) -> Self {
                 Self::from_i64_unchecked(i64::from(value))
             }
@@ -131,9 +125,9 @@ from_numeric_type!(i16);
 from_numeric_type!(u32);
 from_numeric_type!(i32);
 
-impl From<SmallInteger> for i64 {
-    fn from(value: SmallInteger) -> Self {
-        let SmallInteger { data } = value;
+impl From<I56> for i64 {
+    fn from(value: I56) -> Self {
+        let I56 { data } = value;
 
         #[repr(u8)]
         enum Repr {
@@ -153,48 +147,34 @@ impl From<SmallInteger> for i64 {
 
 #[test]
 fn valid_small_integers() {
-    assert_eq!(0i64, SmallInteger::try_from(0).unwrap().into());
-    assert_eq!(5i64, SmallInteger::try_from(5).unwrap().into());
-    assert_eq!(23i64, SmallInteger::try_from(23).unwrap().into());
+    assert_eq!(0i64, I56::try_from(0).unwrap().into());
+    assert_eq!(5i64, I56::try_from(5).unwrap().into());
+    assert_eq!(23i64, I56::try_from(23).unwrap().into());
     assert_eq!(
-        SmallInteger::MAX_NUMBER + 1,
-        SmallInteger::try_from(SmallInteger::MAX_NUMBER + 1)
-            .unwrap()
-            .into()
+        I56::MAX_NUMBER + 1,
+        I56::try_from(I56::MAX_NUMBER + 1).unwrap().into()
     );
     assert_eq!(
-        SmallInteger::MAX_BIGINT,
-        SmallInteger::try_from(SmallInteger::MAX_BIGINT)
-            .unwrap()
-            .into()
+        I56::MAX_BIGINT,
+        I56::try_from(I56::MAX_BIGINT).unwrap().into()
     );
 
-    assert_eq!(-5i64, SmallInteger::try_from(-5).unwrap().into());
-    assert_eq!(-59i64, SmallInteger::try_from(-59).unwrap().into());
+    assert_eq!(-5i64, I56::try_from(-5).unwrap().into());
+    assert_eq!(-59i64, I56::try_from(-59).unwrap().into());
     assert_eq!(
-        SmallInteger::MIN_NUMBER - 1,
-        SmallInteger::try_from(SmallInteger::MIN_NUMBER - 1)
-            .unwrap()
-            .into()
+        I56::MIN_NUMBER - 1,
+        I56::try_from(I56::MIN_NUMBER - 1).unwrap().into()
     );
     assert_eq!(
-        SmallInteger::MIN_BIGINT,
-        SmallInteger::try_from(SmallInteger::MIN_BIGINT)
-            .unwrap()
-            .into()
+        I56::MIN_BIGINT,
+        I56::try_from(I56::MIN_BIGINT).unwrap().into()
     );
 }
 
 #[test]
 fn invalid_small_integers() {
-    assert_eq!(
-        SmallInteger::try_from(SmallInteger::MAX_BIGINT + 1),
-        Err(())
-    );
-    assert_eq!(SmallInteger::try_from(i64::MAX), Err(()));
-    assert_eq!(
-        SmallInteger::try_from(SmallInteger::MIN_BIGINT - 1),
-        Err(())
-    );
-    assert_eq!(SmallInteger::try_from(i64::MIN), Err(()));
+    assert_eq!(I56::try_from(I56::MAX_BIGINT + 1), Err(()));
+    assert_eq!(I56::try_from(i64::MAX), Err(()));
+    assert_eq!(I56::try_from(I56::MIN_BIGINT - 1), Err(()));
+    assert_eq!(I56::try_from(i64::MIN), Err(()));
 }

--- a/nova_vm/src/heap.rs
+++ b/nova_vm/src/heap.rs
@@ -295,7 +295,7 @@ impl<'ctx, 'host> Heap<'ctx, 'host> {
     /// Allocate a 64-bit floating point number onto the Agent heap
     ///
     /// SAFETY: The number being allocated must not be representable
-    /// as a SmallInteger or f32. All stack-allocated numbers must be
+    /// as a I56 or f32. All stack-allocated numbers must be
     /// inequal to any heap-allocated number.
     pub unsafe fn alloc_number(&mut self, number: f64) -> NumberIndex {
         debug_assert!(number.fract() != 0.0 || number as f32 as f64 != number);

--- a/nova_vm/src/heap/bigint.rs
+++ b/nova_vm/src/heap/bigint.rs
@@ -65,13 +65,13 @@ fn bigint_constructor(_heap: &mut Heap, _this: Value, _args: &[Value]) -> JsResu
     //     // TODO: Throw TypeError
     //     return Err(Value::Error(ErrorIndex::from_index(0)));
     // } else {
-    //      Ok(Value::SmallBigInt(3))
+    //      Ok(Value::BigIntI56(3))
     // }
     Ok(Value::Null)
 }
 
 fn bigint_as_int_n(_heap: &mut Heap, _this: Value, _args: &[Value]) -> JsResult<Value> {
-    // Ok(Value::SmallBigInt(3))
+    // Ok(Value::BigIntI56(3))
     Ok(Value::Null)
 }
 

--- a/nova_vm/src/heap/element_array.rs
+++ b/nova_vm/src/heap/element_array.rs
@@ -733,7 +733,7 @@ impl ElementArrays {
             let (maybe_descriptor, maybe_value) =
                 ElementDescriptor::from_property_descriptor(value);
             let key = match key {
-                PropertyKey::Integer(data) => Value::Integer(data),
+                PropertyKey::NumberI56(data) => Value::NumberI56(data),
                 PropertyKey::SmallString(data) => Value::SmallString(data),
                 PropertyKey::String(data) => Value::String(data),
                 PropertyKey::Symbol(data) => Value::Symbol(data),

--- a/nova_vm/src/heap/heap_bits.rs
+++ b/nova_vm/src/heap/heap_bits.rs
@@ -121,13 +121,13 @@ impl WorkQueues {
             Value::Object(idx) => self.objects.push(idx),
             Value::RegExp(idx) => self.regexps.push(idx),
             Value::SmallString(_) => {}
-            Value::SmallBigInt(_) => {}
+            Value::BigIntI56(_) => {}
             // Value::StringObject(_) => todo!(),
             Value::Symbol(idx) => self.symbols.push(idx),
             // Value::SymbolObject(_) => todo!(),
             Value::Undefined => {}
-            Value::Integer(_) => {}
-            Value::Float(_) => {}
+            Value::NumberI56(_) => {}
+            Value::NumberF32(_) => {}
         }
     }
 

--- a/nova_vm/src/heap/number.rs
+++ b/nova_vm/src/heap/number.rs
@@ -8,7 +8,7 @@ use crate::{
         heap_constants::{get_constructor_index, BuiltinObjectIndexes},
         FunctionHeapData, PropertyDescriptor,
     },
-    SmallInteger,
+    I56,
 };
 
 pub fn initialize_number_heap(heap: &mut Heap) {
@@ -23,7 +23,7 @@ pub fn initialize_number_heap(heap: &mut Heap) {
         ObjectEntry::new_prototype_function_entry(heap, "isSafeInteger", 1, false),
         ObjectEntry::new(
             PropertyKey::from_str(heap, "MAX_SAFE_INTEGER"),
-            PropertyDescriptor::roh(Number::try_from(SmallInteger::MAX_NUMBER).unwrap().into()),
+            PropertyDescriptor::roh(Number::try_from(I56::MAX_NUMBER).unwrap().into()),
         ),
         ObjectEntry::new(
             PropertyKey::from_str(heap, "MAX_VALUE"),
@@ -31,7 +31,7 @@ pub fn initialize_number_heap(heap: &mut Heap) {
         ),
         ObjectEntry::new(
             PropertyKey::from_str(heap, "MIN_SAFE_INTEGER"),
-            PropertyDescriptor::roh(Number::try_from(SmallInteger::MIN_NUMBER).unwrap().into()),
+            PropertyDescriptor::roh(Number::try_from(I56::MIN_NUMBER).unwrap().into()),
         ),
         ObjectEntry::new(
             PropertyKey::from_str(heap, "MIN_VALUE"),

--- a/nova_vm/src/heap/object.rs
+++ b/nova_vm/src/heap/object.rs
@@ -32,7 +32,9 @@ impl ObjectEntry {
         let key = PropertyKey::from_str(heap, name);
         let name = match key {
             PropertyKey::SmallString(data) => Value::SmallString(data),
-            PropertyKey::Integer(_) => unreachable!("No prototype functions should have SMI names"),
+            PropertyKey::NumberI56(_) => {
+                unreachable!("No prototype functions should have SMI names")
+            }
             PropertyKey::String(idx) => Value::String(idx),
             PropertyKey::Symbol(idx) => Value::Symbol(idx),
         };

--- a/nova_vm/src/lib.rs
+++ b/nova_vm/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod ecmascript;
 pub mod engine;
 pub mod heap;
-pub use engine::small_integer::SmallInteger;
+pub use engine::i56::I56;
 pub use engine::small_string::SmallString;
 pub use heap::Heap;


### PR DESCRIPTION
This should make a lot of our code easier to understand by displaying the number of bits in the name of our `I56` type used to niche `Number` and `BigInt`. Furthermore, I made the niches start with the original type in the `Value` enum and their subtypes (`Number` and `BigInt`) which should also help with readability.