### PR TITLE
feat(vm): implement `ComputedMemberExpression` and `StaticMemberExpression`

### DIFF
--- a/nova_vm/src/ecmascript/execution.rs
+++ b/nova_vm/src/ecmascript/execution.rs
@@ -13,7 +13,7 @@ pub(crate) use environments::{
     ObjectEnvironmentIndex, PrivateEnvironment, PrivateEnvironmentIndex, ThisBindingStatus,
 };
 pub(crate) use execution_context::*;
-pub use realm::{create_realm, initialize_host_defined_realm, set_realm_global_object, initialize_default_realm};
-pub(crate) use realm::{
-    Intrinsics, ProtoIntrinsics, Realm, RealmIdentifier,
+pub use realm::{
+    create_realm, initialize_default_realm, initialize_host_defined_realm, set_realm_global_object,
 };
+pub(crate) use realm::{Intrinsics, ProtoIntrinsics, Realm, RealmIdentifier};

--- a/nova_vm/src/ecmascript/execution.rs
+++ b/nova_vm/src/ecmascript/execution.rs
@@ -13,5 +13,7 @@ pub(crate) use environments::{
     ObjectEnvironmentIndex, PrivateEnvironment, PrivateEnvironmentIndex, ThisBindingStatus,
 };
 pub(crate) use execution_context::*;
-pub use realm::{create_realm, set_realm_global_object};
-pub(crate) use realm::{Intrinsics, ProtoIntrinsics, Realm, RealmIdentifier};
+pub use realm::{create_realm, initialize_host_defined_realm, set_realm_global_object, initialize_default_realm};
+pub(crate) use realm::{
+    Intrinsics, ProtoIntrinsics, Realm, RealmIdentifier,
+};

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -437,8 +437,8 @@ mod test {
         abstract_operations::operations_on_objects::create_data_property_or_throw,
         builtins::{create_builtin_function, ArgumentsList, Behaviour, BuiltinFunctionArgs},
         execution::{
-            agent::Options, create_realm, initialize_default_realm,
-            set_realm_global_object, Agent, DefaultHostHooks, ExecutionContext,
+            agent::Options, create_realm, initialize_default_realm, set_realm_global_object, Agent,
+            DefaultHostHooks, ExecutionContext,
         },
         scripts_and_modules::script::{parse_script, script_evaluation},
         types::{InternalMethods, IntoValue, Number, Object, PropertyKey, Value},

--- a/nova_vm/src/engine/bytecode/executable.rs
+++ b/nova_vm/src/engine/bytecode/executable.rs
@@ -605,7 +605,6 @@ impl CompileEvaluation for ast::ComputedMemberExpression<'_> {
         if is_reference(&self.expression) {
             ctx.exe.add_instruction(Instruction::GetValue);
         }
-        ctx.exe.add_instruction(Instruction::Load);
 
         ctx.exe.add_instruction_with_constant(
             Instruction::EvaluatePropertyAccessWithExpressionKey,
@@ -623,7 +622,6 @@ impl CompileEvaluation for ast::StaticMemberExpression<'_> {
         if is_reference(&self.object) {
             ctx.exe.add_instruction(Instruction::GetValue);
         }
-        ctx.exe.add_instruction(Instruction::Load);
 
         // 4. Return EvaluatePropertyAccessWithIdentifierKey(baseValue, IdentifierName, strict).
         ctx.exe.add_instruction_with_identifier_and_constant(

--- a/nova_vm/src/engine/bytecode/executable.rs
+++ b/nova_vm/src/engine/bytecode/executable.rs
@@ -606,10 +606,8 @@ impl CompileEvaluation for ast::ComputedMemberExpression<'_> {
             ctx.exe.add_instruction(Instruction::GetValue);
         }
 
-        ctx.exe.add_instruction_with_constant(
-            Instruction::EvaluatePropertyAccessWithExpressionKey,
-            true,
-        );
+        ctx.exe
+            .add_instruction(Instruction::EvaluatePropertyAccessWithExpressionKey);
     }
 }
 
@@ -624,10 +622,9 @@ impl CompileEvaluation for ast::StaticMemberExpression<'_> {
         }
 
         // 4. Return EvaluatePropertyAccessWithIdentifierKey(baseValue, IdentifierName, strict).
-        ctx.exe.add_instruction_with_identifier_and_constant(
+        ctx.exe.add_instruction_with_identifier(
             Instruction::EvaluatePropertyAccessWithIdentifierKey,
             self.property.name.clone(),
-            true,
         );
     }
 }

--- a/nova_vm/src/engine/bytecode/instructions.rs
+++ b/nova_vm/src/engine/bytecode/instructions.rs
@@ -130,13 +130,12 @@ pub enum Instruction {
 impl Instruction {
     pub fn argument_count(self) -> u8 {
         match self {
-            Self::EvaluatePropertyAccessWithIdentifierKey => 2,
             Self::ArraySetLength
             | Self::ArraySetValue
             | Self::CreateCatchBinding
             | Self::EvaluateCall
             | Self::EvaluateNew
-            | Self::EvaluatePropertyAccessWithExpressionKey
+            | Self::EvaluatePropertyAccessWithIdentifierKey
             | Self::InstantiateArrowFunctionExpression
             | Self::InstantiateOrdinaryFunctionExpression
             | Self::Jump
@@ -150,13 +149,7 @@ impl Instruction {
     }
 
     pub fn has_constant_index(self) -> bool {
-        matches!(
-            self,
-            Self::LoadConstant
-                | Self::StoreConstant
-                | Self::EvaluatePropertyAccessWithExpressionKey
-                | Self::EvaluatePropertyAccessWithIdentifierKey
-        )
+        matches!(self, Self::LoadConstant | Self::StoreConstant)
     }
 
     pub fn has_identifier_index(self) -> bool {

--- a/nova_vm/src/engine/bytecode/instructions.rs
+++ b/nova_vm/src/engine/bytecode/instructions.rs
@@ -145,7 +145,13 @@ impl Instruction {
     }
 
     pub fn has_constant_index(self) -> bool {
-        matches!(self, Self::LoadConstant | Self::StoreConstant)
+        matches!(
+            self,
+            Self::LoadConstant
+                | Self::StoreConstant
+                | Self::EvaluatePropertyAccessWithExpressionKey
+                | Self::EvaluatePropertyAccessWithIdentifierKey
+        )
     }
 
     pub fn has_identifier_index(self) -> bool {

--- a/nova_vm/src/engine/bytecode/instructions.rs
+++ b/nova_vm/src/engine/bytecode/instructions.rs
@@ -45,6 +45,11 @@ pub enum Instruction {
     EvaluatePropertyAccessWithIdentifierKey,
     /// Store [GetValue()](https://tc39.es/ecma262/#sec-getvalue) as the result
     /// value.
+    ///
+    /// #### Note
+    /// We only call `GetValue` on reference values. This can be statically
+    /// analysed from the AST. Non-reference values are already in the result
+    /// value so a `GetValue` call would be a no-op.
     GetValue,
     /// Compare the last two values on the stack using the '>' operator rules.
     GreaterThan,
@@ -115,8 +120,8 @@ pub enum Instruction {
     ToNumber,
     /// Store ToNumeric() as the result value.
     ToNumeric,
-    /// Apply the typeof operation to the evaluated expression and set it as
-    /// the result value.
+    /// Apply the typeof operation to the evaluated value expression and set it
+    /// as the result value.
     Typeof,
     /// Performs steps 3 and 4 from the [UnaryExpression - Runtime Semantics](https://tc39.es/ecma262/#sec-unary-minus-operator-runtime-semantics-evaluation).
     UnaryMinus,

--- a/nova_vm/src/engine/bytecode/instructions.rs
+++ b/nova_vm/src/engine/bytecode/instructions.rs
@@ -120,8 +120,8 @@ pub enum Instruction {
     ToNumber,
     /// Store ToNumeric() as the result value.
     ToNumeric,
-    /// Apply the typeof operation to the evaluated value expression and set it
-    /// as the result value.
+    /// Apply the typeof operation to the evaluated expression and set it as
+    /// the result value.
     Typeof,
     /// Performs steps 3 and 4 from the [UnaryExpression - Runtime Semantics](https://tc39.es/ecma262/#sec-unary-minus-operator-runtime-semantics-evaluation).
     UnaryMinus,

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -1,24 +1,29 @@
 use oxc_span::Atom;
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::ecmascript::{
-    abstract_operations::{
-        operations_on_objects::{call, create_data_property_or_throw},
-        testing_and_comparison::is_same_type,
-        type_conversion::{to_boolean, to_number, to_numeric, to_primitive, to_string},
+use crate::{
+    ecmascript::{
+        abstract_operations::{
+            operations_on_objects::{call, create_data_property_or_throw},
+            testing_and_comparison::is_same_type,
+            type_conversion::{
+                to_boolean, to_number, to_numeric, to_primitive, to_property_key, to_string,
+            },
+        },
+        builtins::{
+            ordinary::ordinary_object_create_with_intrinsics, ordinary_function_create,
+            ArgumentsList, OrdinaryFunctionCreateParams, ThisMode,
+        },
+        execution::{
+            agent::{resolve_binding, ExceptionType},
+            Agent, ECMAScriptCodeEvaluationState, JsResult, ProtoIntrinsics,
+        },
+        types::{
+            get_value, put_value, Base, BigInt, IntoValue, Number, Object, PropertyKey, Reference,
+            ReferencedName, String, Value,
+        },
     },
-    builtins::{
-        ordinary::ordinary_object_create_with_intrinsics, ordinary_function_create, ArgumentsList,
-        OrdinaryFunctionCreateParams, ThisMode,
-    },
-    execution::{
-        agent::{resolve_binding, ExceptionType},
-        Agent, ECMAScriptCodeEvaluationState, JsResult, ProtoIntrinsics,
-    },
-    types::{
-        get_value, put_value, Base, BigInt, IntoValue, Number, Object, PropertyKey, Reference,
-        String, Value,
-    },
+    heap::GetHeapData,
 };
 
 use super::{Executable, Instruction, InstructionIter};
@@ -248,6 +253,52 @@ impl Vm {
                     let func = vm.stack.pop().unwrap();
                     vm.result =
                         Some(call(agent, func, this_value, Some(ArgumentsList(&args))).unwrap());
+                }
+                Instruction::EvaluatePropertyAccessWithExpressionKey => {
+                    let property_name_value = vm.stack.pop().unwrap();
+                    let base_value = vm.stack.pop().unwrap();
+
+                    let Value::Boolean(strict) =
+                        vm.fetch_constant(executable, instr.args[0].unwrap() as usize)
+                    else {
+                        unreachable!()
+                    };
+
+                    let property_key = to_property_key(agent, property_name_value)?;
+
+                    vm.reference = Some(Reference {
+                        base: Base::Value(base_value),
+                        referenced_name: match property_key {
+                            PropertyKey::SmallString(s) => {
+                                ReferencedName::String(Atom::from(s.as_str()))
+                            }
+                            PropertyKey::String(s) => {
+                                let s = agent.heap.get(s);
+                                ReferencedName::String(Atom::from(s.clone().into_string().unwrap()))
+                            }
+                            _ => todo!("Implement symbol and integer property keys"),
+                        },
+                        strict,
+                        this_value: None,
+                    });
+                }
+                Instruction::EvaluatePropertyAccessWithIdentifierKey => {
+                    let property_name_string = vm
+                        .fetch_identifier(executable, instr.args[0].unwrap() as usize)
+                        .clone();
+                    let base_value = vm.stack.pop().unwrap();
+                    let Value::Boolean(strict) =
+                        vm.fetch_constant(executable, instr.args[1].unwrap() as usize)
+                    else {
+                        unreachable!()
+                    };
+
+                    vm.reference = Some(Reference {
+                        base: Base::Value(base_value),
+                        referenced_name: ReferencedName::String(property_name_string),
+                        strict,
+                        this_value: None,
+                    });
                 }
                 Instruction::JumpIfNot => {
                     let result = vm.result.take().unwrap();

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -265,11 +265,7 @@ impl Vm {
                     let property_name_value = vm.result.take().unwrap();
                     let base_value = vm.stack.pop().unwrap();
 
-                    let Value::Boolean(strict) =
-                        vm.fetch_constant(executable, instr.args[0].unwrap() as usize)
-                    else {
-                        unreachable!()
-                    };
+                    let strict = true;
 
                     let property_key = to_property_key(agent, property_name_value)?;
 
@@ -294,11 +290,7 @@ impl Vm {
                         .fetch_identifier(executable, instr.args[0].unwrap() as usize)
                         .clone();
                     let base_value = vm.result.take().unwrap();
-                    let Value::Boolean(strict) =
-                        vm.fetch_constant(executable, instr.args[1].unwrap() as usize)
-                    else {
-                        unreachable!()
-                    };
+                    let strict = true;
 
                     vm.reference = Some(Reference {
                         base: Base::Value(base_value),

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -262,7 +262,7 @@ impl Vm {
                         Some(call(agent, func, this_value, Some(ArgumentsList(&args))).unwrap());
                 }
                 Instruction::EvaluatePropertyAccessWithExpressionKey => {
-                    let property_name_value = vm.stack.pop().unwrap();
+                    let property_name_value = vm.result.take().unwrap();
                     let base_value = vm.stack.pop().unwrap();
 
                     let Value::Boolean(strict) =
@@ -293,7 +293,7 @@ impl Vm {
                     let property_name_string = vm
                         .fetch_identifier(executable, instr.args[0].unwrap() as usize)
                         .clone();
-                    let base_value = vm.stack.pop().unwrap();
+                    let base_value = vm.result.take().unwrap();
                     let Value::Boolean(strict) =
                         vm.fetch_constant(executable, instr.args[1].unwrap() as usize)
                     else {


### PR DESCRIPTION
Implements basic `StaticMemberExpression` (`object.identifier`) and `ComputedMemberExpression` (`object["expression"]`) member expressions. Still left to do is a few tests, and `integer`/`symbol` computed member expressions.