### PR TITLE
feat(vm): Lexical declarations

### DIFF
--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -894,8 +894,8 @@ mod test {
         .unwrap();
         let result = script_evaluation(&mut agent, script).unwrap();
         assert_eq!(result, Value::Undefined);
-        let global_env = agent.get_realm(realm).global_env.unwrap();
 
+        let global_env = agent.get_realm(realm).global_env.unwrap();
         assert!(global_env
             .has_binding(&mut agent, &Atom::new_inline("a"))
             .unwrap());
@@ -914,5 +914,28 @@ mod test {
                 .unwrap(),
             Value::from(3)
         );
+    }
+
+    #[test]
+    fn lexical_declarations_in_block() {
+        let allocator = Allocator::default();
+
+        let mut agent = Agent::new(Options::default(), &DefaultHostHooks);
+        let realm = create_realm(&mut agent);
+        initialize_default_realm(&mut agent, realm);
+
+        let script = parse_script(
+            &allocator,
+            "{ let i = 0; const a = 'foo'; i = 3; }".into(),
+            realm,
+            None,
+        )
+        .unwrap();
+        let result = script_evaluation(&mut agent, script).unwrap();
+        assert_eq!(result, Value::Undefined);
+
+        let global_env = agent.get_realm(realm).global_env.unwrap();
+        assert!(!global_env.has_lexical_declaration(&agent, &Atom::new_inline("a")));
+        assert!(!global_env.has_lexical_declaration(&agent, &Atom::new_inline("i")));
     }
 }

--- a/nova_vm/src/engine/bytecode/instructions.rs
+++ b/nova_vm/src/engine/bytecode/instructions.rs
@@ -129,9 +129,28 @@ pub enum Instruction {
     Typeof,
     /// Performs steps 3 and 4 from the [UnaryExpression - Runtime Semantics](https://tc39.es/ecma262/#sec-unary-minus-operator-runtime-semantics-evaluation).
     UnaryMinus,
+    /// Perform CreateImmutableBinding in the running execution context's
+    /// LexicalEnvironment with an identifier parameter and `true`
+    CreateImmutableBinding,
+    /// Perform CreateMutableBinding in the running execution context's
+    /// LexicalEnvironment with an identifier parameter and `false`
+    CreateMutableBinding,
     /// Perform InitializeReferencedBinding with parameters reference (V) and
     /// result (W).
     InitializeReferencedBinding,
+    /// Perform NewDeclarativeEnvironment with the running execution context's
+    /// LexicalEnvironment as the only parameter and set it as the running
+    /// execution context's LexicalEnvironment.
+    ///
+    /// #### Note
+    /// It is technically against the spec to immediately set the new
+    /// environment as the running execution context's LexicalEnvironment. The
+    /// spec requires that creation of bindings in the environment is done
+    /// first. This is immaterial because creating the bindings cannot fail.
+    EnterDeclarativeEnvironment,
+    /// Reset the running execution context's LexicalEnvironment to its current
+    /// value's \[\[OuterEnv]].
+    ExitDeclarativeEnvironment,
 }
 
 impl Instruction {
@@ -150,7 +169,9 @@ impl Instruction {
             | Self::LoadConstant
             | Self::PushExceptionJumpTarget
             | Self::StoreConstant
-            | Self::ResolveBinding => 1,
+            | Self::ResolveBinding
+            | Self::CreateImmutableBinding
+            | Self::CreateMutableBinding => 1,
             _ => 0,
         }
     }
@@ -165,6 +186,8 @@ impl Instruction {
             Self::CreateCatchBinding
                 | Self::EvaluatePropertyAccessWithIdentifierKey
                 | Self::ResolveBinding
+                | Self::CreateImmutableBinding
+                | Self::CreateMutableBinding
         )
     }
 

--- a/nova_vm/src/engine/bytecode/instructions.rs
+++ b/nova_vm/src/engine/bytecode/instructions.rs
@@ -129,6 +129,9 @@ pub enum Instruction {
     Typeof,
     /// Performs steps 3 and 4 from the [UnaryExpression - Runtime Semantics](https://tc39.es/ecma262/#sec-unary-minus-operator-runtime-semantics-evaluation).
     UnaryMinus,
+    /// Perform InitializeReferencedBinding with parameters reference (V) and
+    /// result (W).
+    InitializeReferencedBinding,
 }
 
 impl Instruction {


### PR DESCRIPTION
This PR adds support for lexical declarations, ie. `let` and `const`. At the same time the bytecode received the possibility of entering and exiting lexical scopes (lexical environments) as well as creating and initializing bindings in them. A smarter engine would probably precalculate these but we're not like the others! Ha! In your face!