### PR TITLE
chore(deps): use Cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,13 @@
 [workspace]
 resolver = "2"
-members = [
-    "nova_cli",
-    "nova_vm",
-    "common",
-    "wasm"
-]
+members = ["nova_cli", "nova_vm", "common", "wasm"]
+
+[workspace.dependencies]
+num-bigint = "0.4.4"
+oxc_parser = "0.6.0"
+oxc_span = "0.6.0"
+oxc_syntax = "0.6.0"
+oxc_ast = "0.6.0"
+oxc_allocator = "0.6.0"
+oxc_diagnostics = "0.6.0"
+wtf8 = "0.1"

--- a/nova_cli/Cargo.toml
+++ b/nova_cli/Cargo.toml
@@ -3,11 +3,9 @@ name = "nova_cli"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 clap = { version = "4.5.0", features = ["derive"] }
-oxc_parser = "0.6.0"
-oxc_ast = "0.6.0"
-oxc_span = "0.6.0"
 nova_vm = { path = "../nova_vm" }
+oxc_ast = { workspace = true }
+oxc_parser = { workspace = true }
+oxc_span = { workspace = true }

--- a/nova_vm/Cargo.toml
+++ b/nova_vm/Cargo.toml
@@ -3,15 +3,12 @@ name = "nova_vm"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-wtf8 = "0.1"
-oxc_parser = "0.6.0"
-oxc_span = "0.6.0"
-oxc_syntax = "0.6.0"
-oxc_ast = "0.6.0"
-oxc_allocator = "0.6.0"
-oxc_diagnostics = "0.6.0"
-num-bigint = "0.4.4"
-small_vec = "0.1.2"
+num-bigint = { workspace = true }
+oxc_parser = { workspace = true }
+oxc_span = { workspace = true }
+oxc_syntax = { workspace = true }
+oxc_ast = { workspace = true }
+oxc_allocator = { workspace = true }
+oxc_diagnostics = { workspace = true }
+wtf8 = { workspace = true }


### PR DESCRIPTION
This stops us from having to make manually sure all crates (currently 2) depend on the same version of each crate.