### PR TITLE
Refactor Intrinsics

### DIFF
--- a/nova_vm/src/ecmascript/builtins/arguments.rs
+++ b/nova_vm/src/ecmascript/builtins/arguments.rs
@@ -28,7 +28,7 @@ use crate::{
             create_data_property_or_throw, define_property_or_throw,
         },
         execution::{agent::Agent, ProtoIntrinsics},
-        types::{Number, Object, PropertyDescriptor, PropertyKey, Value},
+        types::{IntoFunction, Number, Object, PropertyDescriptor, PropertyKey, Value},
     },
     heap::WellKnownSymbolIndexes,
 };
@@ -183,9 +183,9 @@ pub(crate) fn create_unmapped_arguments_object(
         key,
         PropertyDescriptor {
             // [[Get]]: %ThrowTypeError%,
-            get: Some(throw_type_error),
+            get: Some(throw_type_error.into_function()),
             // [[Set]]: %ThrowTypeError%,
-            set: Some(throw_type_error),
+            set: Some(throw_type_error.into_function()),
             // [[Enumerable]]: false,
             enumerable: Some(false),
             // [[Configurable]]: false }).

--- a/nova_vm/src/ecmascript/builtins/array.rs
+++ b/nova_vm/src/ecmascript/builtins/array.rs
@@ -14,7 +14,6 @@ use super::{
 };
 use crate::{
     ecmascript::{
-        abstract_operations::testing_and_comparison::same_value_non_number,
         execution::{Agent, JsResult},
         types::{
             InternalMethods, IntoObject, IntoValue, Object, OrdinaryObject,
@@ -152,7 +151,13 @@ impl OrdinaryObjectInternalSlots for Array {
         if let Some(object_index) = agent.heap.get(*self).object_index {
             OrdinaryObject::from(object_index).prototype(agent)
         } else {
-            Some(agent.current_realm().intrinsics().array_prototype())
+            Some(
+                agent
+                    .current_realm()
+                    .intrinsics()
+                    .array_prototype()
+                    .into_object(),
+            )
         }
     }
 
@@ -171,7 +176,13 @@ impl InternalMethods for Array {
         if let Some(object_index) = agent.heap.get(*self).object_index {
             OrdinaryObject::from(object_index).get_prototype_of(agent)
         } else {
-            Ok(Some(agent.current_realm().intrinsics().array_prototype()))
+            Ok(Some(
+                agent
+                    .current_realm()
+                    .intrinsics()
+                    .array_prototype()
+                    .into_object(),
+            ))
         }
     }
 
@@ -182,7 +193,7 @@ impl InternalMethods for Array {
             // 1. Let current be O.[[Prototype]].
             let current = agent.current_realm().intrinsics().array_prototype();
             let object_index = if let Some(v) = prototype {
-                if same_value_non_number(agent, v, current) {
+                if v == current.into_object() {
                     return Ok(true);
                 } else {
                     // TODO: Proper handling

--- a/nova_vm/src/ecmascript/builtins/array/abstract_operations.rs
+++ b/nova_vm/src/ecmascript/builtins/array/abstract_operations.rs
@@ -6,7 +6,7 @@ use crate::{
         },
         builtins::ordinary::ordinary_define_own_property,
         execution::{agent::ExceptionType, Agent, JsResult},
-        types::{InternalMethods, Object, PropertyDescriptor, PropertyKey},
+        types::{InternalMethods, IntoObject, Object, PropertyDescriptor, PropertyKey},
     },
     heap::{indexes::ArrayIndex, GetHeapData},
 };
@@ -31,7 +31,13 @@ pub fn array_create(
     }
     // 2. If proto is not present, set proto to %Array.prototype%.
     let object_index = if let Some(proto) = proto {
-        if proto == agent.current_realm().intrinsics().array_prototype() {
+        if proto
+            == agent
+                .current_realm()
+                .intrinsics()
+                .array_prototype()
+                .into_object()
+        {
             None
         } else {
             Some(agent.heap.create_object_with_prototype(proto, vec![]))

--- a/nova_vm/src/ecmascript/builtins/array_buffer/abstract_operations.rs
+++ b/nova_vm/src/ecmascript/builtins/array_buffer/abstract_operations.rs
@@ -4,7 +4,7 @@ use crate::{
         abstract_operations::operations_on_objects::get,
         builtins::array_buffer::data::InternalBuffer,
         execution::{agent::JsError, Agent, JsResult},
-        types::{DataBlock, Function, Number, Object, PropertyKey, Value},
+        types::{DataBlock, Function, IntoFunction, Number, Object, PropertyKey, Value},
     },
     heap::{indexes::ArrayBufferIndex, GetHeapData},
     Heap,
@@ -159,8 +159,12 @@ pub(crate) fn clone_array_buffer(
     }
     let array_buffer_constructor = agent.current_realm().intrinsics().array_buffer();
     // 2. Let targetBuffer be ? AllocateArrayBuffer(%ArrayBuffer%, srcLength).
-    let target_buffer =
-        allocate_array_buffer(agent, array_buffer_constructor, src_length as u64, None)?;
+    let target_buffer = allocate_array_buffer(
+        agent,
+        array_buffer_constructor.into_function(),
+        src_length as u64,
+        None,
+    )?;
     let Heap { array_buffers, .. } = &mut agent.heap;
     let (target_buffer_data, array_buffers) = array_buffers.split_last_mut().unwrap();
     let target_buffer_data = target_buffer_data.as_mut().unwrap();

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -530,7 +530,13 @@ pub(crate) fn ordinary_function_create<'agent, 'program>(
         name: None,
     };
     if let Some(function_prototype) = params.function_prototype {
-        if function_prototype != agent.current_realm().intrinsics().function_prototype() {
+        if function_prototype
+            != agent
+                .current_realm()
+                .intrinsics()
+                .function_prototype()
+                .into_object()
+        {
             function.object_index = Some(
                 agent
                     .heap

--- a/nova_vm/src/ecmascript/builtins/ordinary.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary.rs
@@ -6,7 +6,7 @@ use crate::ecmascript::{
     builtins::ArgumentsList,
     execution::{Agent, JsResult, ProtoIntrinsics},
     types::{
-        Function, InternalMethods, Object, OrdinaryObject, OrdinaryObjectInternalSlots,
+        Function, InternalMethods, IntoObject, Object, OrdinaryObject, OrdinaryObjectInternalSlots,
         PropertyDescriptor, PropertyKey, String, Value,
     },
 };
@@ -779,7 +779,17 @@ pub(crate) fn ordinary_object_create_with_intrinsics(
         ProtoIntrinsics::EvalError => todo!(),
         ProtoIntrinsics::Function => todo!(),
         ProtoIntrinsics::Number => todo!(),
-        ProtoIntrinsics::Object => agent.heap.create_object(vec![]).into(),
+        ProtoIntrinsics::Object => agent
+            .heap
+            .create_object_with_prototype(
+                agent
+                    .current_realm()
+                    .intrinsics()
+                    .object_prototype()
+                    .into_object(),
+                vec![],
+            )
+            .into(),
         ProtoIntrinsics::RangeError => todo!(),
         ProtoIntrinsics::ReferenceError => todo!(),
         ProtoIntrinsics::String => todo!(),

--- a/nova_vm/src/ecmascript/execution/realm.rs
+++ b/nova_vm/src/ecmascript/execution/realm.rs
@@ -115,7 +115,7 @@ pub fn create_realm(agent: &mut Agent) -> RealmIdentifier {
     // 1. Let realmRec be a new Realm Record.
     let realm_rec = Realm {
         // 2. Perform CreateIntrinsics(realmRec).
-        intrinsics: create_intrinsics(),
+        intrinsics: create_intrinsics(agent),
 
         // 3. Set realmRec.[[AgentSignifier]] to AgentSignifier().
         agent_signifier: PhantomData,
@@ -142,7 +142,7 @@ pub fn create_realm(agent: &mut Agent) -> RealmIdentifier {
 ///
 /// The abstract operation CreateIntrinsics takes argument realmRec (a Realm
 /// Record) and returns UNUSED.
-pub(crate) fn create_intrinsics() -> Intrinsics {
+pub(crate) fn create_intrinsics(agent: &mut Agent) -> Intrinsics {
     // TODO: Follow the specification.
     // 1. Set realmRec.[[Intrinsics]] to a new Record.
     // 2. Set fields of realmRec.[[Intrinsics]] with the values listed in
@@ -167,7 +167,7 @@ pub(crate) fn create_intrinsics() -> Intrinsics {
     // NOTE: We divert from the specification to allow us to call
     //       CreateIntrinsics when we create the Realm.
 
-    Intrinsics::default()
+    Intrinsics::new(agent)
 }
 
 /// ### [9.3.3 SetRealmGlobalObject ( realmRec, globalObj, thisValue )](https://tc39.es/ecma262/#sec-setrealmglobalobject)
@@ -185,7 +185,7 @@ pub fn set_realm_global_object(
         Object::Object(
             agent
                 .heap
-                .create_object_with_prototype(intrinsics.object_prototype(), vec![]),
+                .create_object_with_prototype(intrinsics.object_prototype().into(), vec![]),
         )
     });
 

--- a/nova_vm/src/ecmascript/execution/realm/intrinsics.rs
+++ b/nova_vm/src/ecmascript/execution/realm/intrinsics.rs
@@ -1,100 +1,20 @@
 use crate::{
     ecmascript::{
         builtins::BuiltinFunction,
-        types::{Function, Object, OrdinaryObject},
+        execution::Agent,
+        types::{Object, OrdinaryObject},
     },
     heap::{
         indexes::{BuiltinFunctionIndex, ObjectIndex},
-        BuiltinObjectIndexes,
+        intrinsic_function_count, intrinsic_object_count, IntrinsicConstructorIndexes,
+        IntrinsicFunctionIndexes, IntrinsicObjectIndexes,
     },
 };
 
 #[derive(Debug, Clone)]
 pub(crate) struct Intrinsics {
-    /// %Array%
-    pub(crate) array: BuiltinFunctionIndex,
-    /// %Array.prototype%
-    pub(crate) array_prototype: ObjectIndex,
-    /// %ArrayBuffer%
-    pub(crate) array_buffer: BuiltinFunctionIndex,
-    /// %ArrayBuffer.prototype%
-    pub(crate) array_buffer_prototype: ObjectIndex,
-    /// %BigInt%
-    pub(crate) big_int: BuiltinFunctionIndex,
-    /// %BigInt.prototype%
-    pub(crate) big_int_prototype: ObjectIndex,
-    /// %Boolean%
-    pub(crate) boolean: BuiltinFunctionIndex,
-    /// %Boolean.prototype%
-    pub(crate) boolean_prototype: ObjectIndex,
-    /// %Error%
-    pub(crate) error: BuiltinFunctionIndex,
-    /// %Error.prototype%
-    pub(crate) error_prototype: ObjectIndex,
-    /// %eval%
-    pub(crate) eval: BuiltinFunctionIndex,
-    /// %EvalError%
-    pub(crate) eval_error: BuiltinFunctionIndex,
-    /// %EvalError.prototype%
-    pub(crate) eval_error_prototype: ObjectIndex,
-    /// %Function%
-    pub(crate) function: BuiltinFunctionIndex,
-    /// %Function.prototype%
-    ///
-    /// NOTE: This is not spec-compliant. Function prototype should
-    /// be a function that always returns undefined no matter how
-    /// it is called. That's stupid so we do not have that.
-    pub(crate) function_prototype: ObjectIndex,
-    /// %isFinite%
-    pub(crate) is_finite: BuiltinFunctionIndex,
-    /// %isNaN%
-    pub(crate) is_nan: BuiltinFunctionIndex,
-    /// %Math%
-    pub(crate) math: ObjectIndex,
-    /// %Number%
-    pub(crate) number: BuiltinFunctionIndex,
-    /// %Number.prototype%
-    pub(crate) number_prototype: ObjectIndex,
-    /// %Object%
-    pub(crate) object: BuiltinFunctionIndex,
-    /// %Object.prototype%
-    pub(crate) object_prototype: ObjectIndex,
-    /// %Object.prototype.toString%
-    pub(crate) object_prototype_to_string: BuiltinFunctionIndex,
-    pub(crate) parse_float: BuiltinFunctionIndex,
-    pub(crate) parse_int: BuiltinFunctionIndex,
-    /// %RangeError%
-    pub(crate) range_error: BuiltinFunctionIndex,
-    /// %RangeError.prototype%
-    pub(crate) range_error_prototype: ObjectIndex,
-    /// %ReferenceError%
-    pub(crate) reference_error: BuiltinFunctionIndex,
-    /// %ReferenceError.prototype%
-    pub(crate) reference_error_prototype: ObjectIndex,
-    /// %Reflect%
-    pub(crate) reflect: BuiltinFunctionIndex,
-    /// %String%
-    pub(crate) string: BuiltinFunctionIndex,
-    /// %String.prototype%
-    pub(crate) string_prototype: ObjectIndex,
-    /// %Symbol%
-    pub(crate) symbol: BuiltinFunctionIndex,
-    /// %Symbol.prototype%
-    pub(crate) symbol_prototype: ObjectIndex,
-    /// %SyntaxError%
-    pub(crate) syntax_error: BuiltinFunctionIndex,
-    /// %SyntaxError.prototype%
-    pub(crate) syntax_error_prototype: ObjectIndex,
-    /// %ThrowTypeError%
-    pub(crate) throw_type_error: BuiltinFunctionIndex,
-    /// %TypeError%
-    pub(crate) type_error: BuiltinFunctionIndex,
-    /// %TypeError.prototype%
-    pub(crate) type_error_prototype: ObjectIndex,
-    /// %URIError%
-    pub(crate) uri_error: BuiltinFunctionIndex,
-    /// %URIError.prototype%
-    pub(crate) uri_error_prototype: ObjectIndex,
+    object_index_base: ObjectIndex,
+    builtin_function_index_base: BuiltinFunctionIndex,
 }
 
 /// Enumeration of intrinsics intended to be used as the [[Prototype]] value of
@@ -118,340 +38,875 @@ pub(crate) enum ProtoIntrinsics {
     UriError,
 }
 
-impl Default for Intrinsics {
-    fn default() -> Self {
-        let array = BuiltinObjectIndexes::ArrayConstructor.into();
-        let array_prototype = BuiltinObjectIndexes::ArrayPrototype.into();
-        let array_buffer = BuiltinObjectIndexes::ArrayBufferConstructor.into();
-        let array_buffer_prototype = BuiltinObjectIndexes::ArrayBufferPrototype.into();
-        let big_int = BuiltinObjectIndexes::BigintConstructor.into();
-        let big_int_prototype = BuiltinObjectIndexes::BigintPrototype.into();
-        let boolean = BuiltinObjectIndexes::BooleanConstructor.into();
-        let boolean_prototype = BuiltinObjectIndexes::BooleanPrototype.into();
-        let error = BuiltinObjectIndexes::ErrorConstructor.into();
-        let error_prototype = BuiltinObjectIndexes::ErrorPrototype.into();
-        // TODO: Placeholder.
-        let eval = BuiltinFunctionIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let eval_error = BuiltinFunctionIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let eval_error_prototype = ObjectIndex::from_u32_index(0);
-        let function = BuiltinObjectIndexes::FunctionConstructor.into();
-        let function_prototype = BuiltinObjectIndexes::FunctionPrototype.into();
-        // TODO: Placeholder.
-        let is_finite = BuiltinFunctionIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let is_nan = BuiltinFunctionIndex::from_u32_index(0);
-        let math = BuiltinObjectIndexes::MathObject.into();
-        let number = BuiltinObjectIndexes::NumberConstructor.into();
-        let number_prototype = BuiltinObjectIndexes::NumberPrototype.into();
-        let object = BuiltinObjectIndexes::ObjectConstructor.into();
-        let object_prototype = BuiltinObjectIndexes::ObjectPrototype.into();
-        // TODO: Placeholder.
-        let object_prototype_to_string = BuiltinFunctionIndex::from_u32_index(0);
-        let parse_float = BuiltinFunctionIndex::from_u32_index(0);
-        let parse_int = BuiltinFunctionIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let range_error = BuiltinFunctionIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let range_error_prototype = ObjectIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let reference_error = BuiltinFunctionIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let reference_error_prototype = ObjectIndex::from_u32_index(0);
-        let reflect = BuiltinObjectIndexes::ReflectObject.into();
-        let string = BuiltinObjectIndexes::StringConstructor.into();
-        let string_prototype = BuiltinObjectIndexes::StringPrototype.into();
-        let symbol = BuiltinObjectIndexes::SymbolConstructor.into();
-        let symbol_prototype = BuiltinObjectIndexes::SymbolPrototype.into();
-        // TODO: Placeholder.
-        let syntax_error = BuiltinFunctionIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let syntax_error_prototype = ObjectIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let throw_type_error = BuiltinFunctionIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let type_error = BuiltinFunctionIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let type_error_prototype = ObjectIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let uri_error = BuiltinFunctionIndex::from_u32_index(0);
-        // TODO: Placeholder.
-        let uri_error_prototype = ObjectIndex::from_u32_index(0);
+impl Intrinsics {
+    pub(crate) fn new(agent: &mut Agent) -> Self {
+        // Use from_usize to index "one over the edge", ie. where new intrinsics will be created.
+        let object_index_base = ObjectIndex::from_index(agent.heap.objects.len());
+        let builtin_function_index_base =
+            BuiltinFunctionIndex::from_index(agent.heap.builtin_functions.len());
+
+        agent
+            .heap
+            .objects
+            .extend((0..intrinsic_object_count()).map(|_| None));
+        agent
+            .heap
+            .builtin_functions
+            .extend((0..intrinsic_function_count()).map(|_| None));
 
         Self {
-            array,
-            array_prototype,
-            array_buffer,
-            array_buffer_prototype,
-            big_int,
-            big_int_prototype,
-            boolean,
-            boolean_prototype,
-            error,
-            error_prototype,
-            eval,
-            eval_error,
-            eval_error_prototype,
-            function,
-            function_prototype,
-            is_finite,
-            is_nan,
-            math,
-            number,
-            number_prototype,
-            object,
-            object_prototype,
-            object_prototype_to_string,
-            parse_float,
-            parse_int,
-            range_error,
-            range_error_prototype,
-            reference_error,
-            reference_error_prototype,
-            reflect,
-            string,
-            string_prototype,
-            symbol,
-            symbol_prototype,
-            syntax_error,
-            syntax_error_prototype,
-            throw_type_error,
-            type_error,
-            type_error_prototype,
-            uri_error,
-            uri_error_prototype,
+            object_index_base,
+            builtin_function_index_base,
         }
     }
-}
 
-impl Intrinsics {
     pub(crate) fn get_intrinsic_default_proto(
         &self,
         intrinsic_default_proto: ProtoIntrinsics,
     ) -> Object {
         match intrinsic_default_proto {
-            ProtoIntrinsics::Array => self.array_prototype(),
+            ProtoIntrinsics::Array => self.array_prototype().into(),
             ProtoIntrinsics::ArrayBuffer => self.array_buffer_prototype().into(),
-            ProtoIntrinsics::BigInt => self.big_int_prototype(),
-            ProtoIntrinsics::Boolean => self.boolean_prototype(),
-            ProtoIntrinsics::Error => self.error_prototype(),
-            ProtoIntrinsics::EvalError => self.eval_error_prototype(),
-            ProtoIntrinsics::Function => self.function_prototype(),
-            ProtoIntrinsics::Number => self.number_prototype(),
-            ProtoIntrinsics::Object => self.object_prototype(),
-            ProtoIntrinsics::RangeError => self.range_error_prototype(),
-            ProtoIntrinsics::ReferenceError => self.reference_error_prototype(),
-            ProtoIntrinsics::String => self.string_prototype(),
-            ProtoIntrinsics::Symbol => self.symbol_prototype(),
-            ProtoIntrinsics::SyntaxError => self.syntax_error_prototype(),
-            ProtoIntrinsics::TypeError => self.type_error_prototype(),
-            ProtoIntrinsics::UriError => self.uri_error_prototype(),
+            ProtoIntrinsics::BigInt => self.big_int_prototype().into(),
+            ProtoIntrinsics::Boolean => self.boolean_prototype().into(),
+            ProtoIntrinsics::Error => self.error_prototype().into(),
+            ProtoIntrinsics::EvalError => self.eval_error_prototype().into(),
+            ProtoIntrinsics::Function => self.function_prototype().into(),
+            ProtoIntrinsics::Number => self.number_prototype().into(),
+            ProtoIntrinsics::Object => self.object_prototype().into(),
+            ProtoIntrinsics::RangeError => self.range_error_prototype().into(),
+            ProtoIntrinsics::ReferenceError => self.reference_error_prototype().into(),
+            ProtoIntrinsics::String => self.string_prototype().into(),
+            ProtoIntrinsics::Symbol => self.symbol_prototype().into(),
+            ProtoIntrinsics::SyntaxError => self.syntax_error_prototype().into(),
+            ProtoIntrinsics::TypeError => self.type_error_prototype().into(),
+            ProtoIntrinsics::UriError => self.uri_error_prototype().into(),
         }
     }
 
-    /// %Array%
-    pub const fn array(&self) -> Function {
-        Function::new_builtin_function(self.array)
+    /// %AggregateError.prototype%
+    pub(crate) fn aggregate_error_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::AggregateErrorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %AggregateError%
+    pub(crate) fn aggregate_error(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::AggregateError
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Array.prototype.sort%
+    pub(crate) fn array_prototype_sort(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::ArrayPrototypeSort
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Array.prototype.toString%
+    pub(crate) fn array_prototype_to_string(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::ArrayPrototypeToString
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Array.prototype.values%
+    pub(crate) fn array_prototype_values(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::ArrayPrototypeValues
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %Array.prototype%
-    pub const fn array_prototype(&self) -> Object {
-        Object::Object(self.array_prototype)
+    pub(crate) fn array_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::ArrayPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
-    /// %ArrayBuffer%
-    pub const fn array_buffer(&self) -> Function {
-        Function::new_builtin_function(self.array_buffer)
+    /// %Array%
+    pub(crate) fn array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Array
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %ArrayBuffer.prototype%
-    pub const fn array_buffer_prototype(&self) -> OrdinaryObject {
-        OrdinaryObject::new(self.array_buffer_prototype)
+    pub(crate) fn array_buffer_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::ArrayBufferPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
-    /// %BigInt%
-    pub const fn big_int(&self) -> Function {
-        Function::new_builtin_function(self.big_int)
+    /// %ArrayBuffer%
+    pub(crate) fn array_buffer(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::ArrayBuffer
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %ArrayIteratorPrototype%
+    pub(crate) fn array_iterator_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::ArrayIteratorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %AsyncFromSyncIteratorPrototype%
+    pub(crate) fn async_from_sync_iterator_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::AsyncFromSyncIteratorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %AsyncFunction.prototype%
+    pub(crate) fn async_function_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::AsyncFunctionPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %AsyncFunction%
+    pub(crate) fn async_function(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::AsyncFunction
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %AsyncGeneratorFunction.prototype.prototype%
+    pub(crate) fn async_generator_function_prototype_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::AsyncGeneratorFunctionPrototypePrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %AsyncGeneratorFunction.prototype%
+    pub(crate) fn async_generator_function_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::AsyncGeneratorFunctionPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %AsyncGeneratorFunction%
+    pub(crate) fn async_generator_function(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::AsyncGeneratorFunction
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %AsyncGeneratorPrototype%
+    pub(crate) fn async_generator_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::AsyncGeneratorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %AsyncIteratorPrototype%
+    pub(crate) fn async_iterator_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::AsyncIteratorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %Atomics%
+    pub(crate) fn atomics(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::AtomicsObject
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
     /// %BigInt.prototype%
-    pub const fn big_int_prototype(&self) -> Object {
-        Object::Object(self.big_int_prototype)
+    pub(crate) fn big_int_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::BigIntPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
-    /// %Boolean%
-    pub const fn boolean(&self) -> Function {
-        Function::new_builtin_function(self.boolean)
+    /// %BigInt%
+    pub(crate) fn big_int(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::BigInt
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %BigInt64Array%
+    pub(crate) fn big_int64_array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::BigInt64Array
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %BigUint64Array%
+    pub(crate) fn big_uint64_array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::BigUint64Array
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %Boolean.prototype%
-    pub const fn boolean_prototype(&self) -> Object {
-        Object::Object(self.boolean_prototype)
+    pub(crate) fn boolean_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::BooleanPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
-    /// %Error%
-    pub const fn error(&self) -> Function {
-        Function::new_builtin_function(self.error)
+    /// %Boolean%
+    pub(crate) fn boolean(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Boolean
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %DataView.prototype%
+    pub(crate) fn data_view_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::DataViewPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %DataView%
+    pub(crate) fn data_view(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::DataView
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Date.prototype.toUTCString%
+    pub(crate) fn date_prototype_to_utcstring(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::DatePrototypeToUTCString
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Date.prototype%
+    pub(crate) fn date_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::DatePrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %Date%
+    pub(crate) fn date(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Date
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %decodeURI%
+    pub(crate) fn decode_uri(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::DecodeURI
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %decodeURIComponent%
+    pub(crate) fn decode_uricomponent(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::DecodeURIComponent
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %encodeURI%
+    pub(crate) fn encode_uri(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::EncodeURI
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %encodeURIComponent%
+    pub(crate) fn encode_uri_component(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::EncodeURIComponent
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %Error.prototype%
-    pub const fn error_prototype(&self) -> Object {
-        Object::Object(self.error_prototype)
+    pub(crate) fn error_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::ErrorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %Error%
+    pub(crate) fn error(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Error
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %escape%
+    pub(crate) fn escape(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::Escape
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %eval%
-    pub const fn eval(&self) -> Function {
-        todo!()
-    }
-
-    /// %EvalError%
-    pub const fn eval_error(&self) -> Function {
-        Function::new_builtin_function(self.eval_error)
+    pub(crate) fn eval(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::Eval
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %EvalError.prototype%
-    pub const fn eval_error_prototype(&self) -> Object {
-        todo!()
+    pub(crate) fn eval_error_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::EvalErrorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %EvalError%
+    pub(crate) fn eval_error(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::EvalError
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %FinalizationRegistry.prototype%
+    pub(crate) fn finalization_registry_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::FinalizationRegistryPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %FinalizationRegistry%
+    pub(crate) fn finalization_registry(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::FinalizationRegistry
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Float32Array%
+    pub(crate) fn float32_array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Float32Array
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Float64Array%
+    pub(crate) fn float64_array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Float64Array
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %ForInIteratorPrototype%
+    pub(crate) fn for_in_iterator_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::ForInIteratorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// That's stupid so we do not have that.
+    pub(crate) fn function_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::FunctionPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
     /// %Function%
-    pub const fn function(&self) -> Function {
-        Function::new_builtin_function(self.function)
+    pub(crate) fn function(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Function
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
-    /// %Function.prototype%
-    pub const fn function_prototype(&self) -> Object {
-        Object::Object(self.function_prototype)
+    /// %GeneratorFunction.prototype.prototype.next%
+    pub(crate) fn generator_function_prototype_prototype_next(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::GeneratorFunctionPrototypePrototypeNext
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %GeneratorFunction.prototype.prototype%
+    pub(crate) fn generator_function_prototype_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::GeneratorFunctionPrototypePrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %GeneratorFunction.prototype%
+    pub(crate) fn generator_function_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::GeneratorFunctionPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %GeneratorFunction%
+    pub(crate) fn generator_function(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::GeneratorFunction
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %GeneratorPrototype%
+    pub(crate) fn generator_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::GeneratorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %Int16Array%
+    pub(crate) fn int16_array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Int16Array
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Int32Array%
+    pub(crate) fn int32_array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Int32Array
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Int8Array%
+    pub(crate) fn int8_array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Int8Array
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %isFinite%
-    pub const fn is_finite(&self) -> Function {
-        todo!()
+    pub(crate) fn is_finite(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::IsFinite
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %isNaN%
-    pub const fn is_nan(&self) -> Function {
-        todo!()
+    pub(crate) fn is_nan(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::IsNaN
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %IteratorPrototype%
+    pub(crate) fn iterator_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::IteratorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %JSON%
+    pub(crate) fn json(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::JSONObject
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %Map.prototype.entries%
+    pub(crate) fn map_prototype_entries(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::MapPrototypeEntries
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Map.prototype%
+    pub(crate) fn map_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::MapPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %Map%
+    pub(crate) fn map(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Map
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %MapIteratorPrototype%
+    pub(crate) fn map_iterator_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::MapIteratorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
     /// %Math%
-    pub const fn math(&self) -> Object {
-        Object::Object(self.math)
+    pub(crate) fn math(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::MathObject
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
-    /// %Number%
-    pub const fn number(&self) -> Function {
-        Function::new_builtin_function(self.number)
+    /// %NativeError.prototype%
+    pub(crate) fn native_error_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::NativeErrorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
     /// %Number.prototype%
-    pub const fn number_prototype(&self) -> Object {
-        Object::Object(self.number_prototype)
+    pub(crate) fn number_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::NumberPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
-    /// %Object%
-    pub const fn object(&self) -> Function {
-        Function::new_builtin_function(self.object)
-    }
-
-    /// %Object.prototype%
-    pub const fn object_prototype(&self) -> Object {
-        Object::Object(self.object_prototype)
+    /// %Number%
+    pub(crate) fn number(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Number
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %Object.prototype.toString%
-    pub const fn object_prototype_to_string(&self) -> Object {
-        todo!()
+    pub(crate) fn object_prototype_to_string(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::ObjectPrototypeToString
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Object.prototype%
+    pub(crate) fn object_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::ObjectPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %Object%
+    pub(crate) fn object(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Object
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %parseFloat%
-    pub const fn parse_float(&self) -> BuiltinFunction {
-        BuiltinFunction::from_index(self.parse_float)
+    pub(crate) fn parse_float(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::ParseFloat
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %parseInt%
-    pub const fn parse_int(&self) -> BuiltinFunction {
-        BuiltinFunction::from_index(self.parse_int)
+    pub(crate) fn parse_int(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::ParseInt
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
-    /// %RangeError%
-    pub const fn range_error(&self) -> Object {
-        todo!()
+    /// %Promise.prototype%
+    pub(crate) fn promise_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::PromisePrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %Promise%
+    pub(crate) fn promise(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Promise
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Proxy%
+    pub(crate) fn proxy(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Proxy
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %RangeError.prototype%
-    pub const fn range_error_prototype(&self) -> Object {
-        todo!()
+    pub(crate) fn range_error_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::RangeErrorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
-    /// %ReferenceError%
-    pub const fn reference_error(&self) -> Object {
-        todo!()
+    /// %RangeError%
+    pub(crate) fn range_error(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::RangeError
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %ReferenceError.prototype%
-    pub const fn reference_error_prototype(&self) -> Object {
-        todo!()
+    pub(crate) fn reference_error_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::ReferenceErrorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %ReferenceError%
+    pub(crate) fn reference_error(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::ReferenceError
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %Reflect%
-    pub const fn reflect(&self) -> Object {
-        todo!()
+    pub(crate) fn reflect(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::ReflectObject
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
-    /// %String%
-    pub const fn string(&self) -> Function {
-        Function::new_builtin_function(self.string)
+    /// %RegExp.prototype.exec%
+    pub(crate) fn reg_exp_prototype_exec(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::RegExpPrototypeExec
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %RegExp.prototype%
+    pub(crate) fn reg_exp_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::RegExpPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %RegExp%
+    pub(crate) fn reg_exp(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::RegExp
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %RegExpStringIteratorPrototype%
+    pub(crate) fn reg_exp_string_iterator_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::RegExpStringIteratorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %Set.prototype.values%
+    pub(crate) fn set_prototype_values(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::SetPrototypeValues
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Set.prototype%
+    pub(crate) fn set_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::SetPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %Set%
+    pub(crate) fn set(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Set
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %SetIteratorPrototype%
+    pub(crate) fn set_iterator_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::SetIteratorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %SharedArrayBuffer.prototype%
+    pub(crate) fn shared_array_buffer_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::SharedArrayBufferPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %SharedArrayBuffer%
+    pub(crate) fn shared_array_buffer(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::SharedArrayBuffer
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %String.prototype.trimEnd%
+    pub(crate) fn string_prototype_trim_end(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::StringPrototypeTrimEnd
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %String.prototype.trimStart%
+    pub(crate) fn string_prototype_trim_start(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::StringPrototypeTrimStart
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %String.prototype%
-    pub const fn string_prototype(&self) -> Object {
-        Object::Object(self.string_prototype)
+    pub(crate) fn string_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::StringPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
-    /// %Symbol%
-    pub const fn symbol(&self) -> Function {
-        Function::new_builtin_function(self.symbol)
+    /// %String%
+    pub(crate) fn string(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::String
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %StringIteratorPrototype%
+    pub(crate) fn string_iterator_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::StringIteratorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
     /// %Symbol.prototype%
-    pub const fn symbol_prototype(&self) -> Object {
-        Object::Object(self.symbol_prototype)
+    pub(crate) fn symbol_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::SymbolPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
-    /// %SyntaxError%
-    pub const fn syntax_error(&self) -> Object {
-        todo!()
+    /// %Symbol%
+    pub(crate) fn symbol(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Symbol
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %SyntaxError.prototype%
-    pub const fn syntax_error_prototype(&self) -> Object {
-        todo!()
+    pub(crate) fn syntax_error_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::SyntaxErrorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %SyntaxError%
+    pub(crate) fn syntax_error(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::SyntaxError
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %ThrowTypeError%
-    pub const fn throw_type_error(&self) -> Function {
-        Function::BuiltinFunction(self.throw_type_error)
+    pub(crate) fn throw_type_error(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::ThrowTypeError
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
-    /// %TypeError%
-    pub const fn type_error(&self) -> Object {
-        todo!()
+    /// %TypedArray.prototype.values%
+    pub(crate) fn typed_array_prototype_values(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::TypedArrayPrototypeValues
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %TypedArray.prototype%
+    pub(crate) fn typed_array_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::TypedArrayPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %TypedArray%
+    pub(crate) fn typed_array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::TypedArray
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %TypeError.prototype%
-    pub const fn type_error_prototype(&self) -> Object {
-        todo!()
+    pub(crate) fn type_error_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::TypeErrorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
     }
 
-    /// %URIError%
-    pub const fn uri_error(&self) -> Object {
-        todo!()
+    /// %TypeError%
+    pub(crate) fn type_error(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::TypeError
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Uint16Array%
+    pub(crate) fn uint16_array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Uint16Array
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Uint32Array%
+    pub(crate) fn uint32_array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Uint32Array
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Uint8Array%
+    pub(crate) fn uint8_array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Uint8Array
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %Uint8ClampedArray%
+    pub(crate) fn uint8_clamped_array(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::Uint8ClampedArray
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %unescape%
+    pub(crate) fn unescape(&self) -> BuiltinFunction {
+        IntrinsicFunctionIndexes::Unescape
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 
     /// %URIError.prototype%
-    pub const fn uri_error_prototype(&self) -> Object {
-        todo!()
+    pub(crate) fn uri_error_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::URIErrorPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %URIError%
+    pub(crate) fn uri_error(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::URIError
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %WeakMap.prototype%
+    pub(crate) fn weak_map_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::WeakMapPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %WeakMap%
+    pub(crate) fn weak_map(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::WeakMap
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %WeakRef.prototype%
+    pub(crate) fn weak_ref_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::WeakRefPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %WeakRef%
+    pub(crate) fn weak_ref(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::WeakRef
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
+    }
+
+    /// %WeakSet.prototype%
+    pub(crate) fn weak_set_prototype(&self) -> OrdinaryObject {
+        IntrinsicObjectIndexes::WeakSetPrototype
+            .get_object_index(self.object_index_base)
+            .into()
+    }
+
+    /// %WeakSet%
+    pub(crate) fn weak_set(&self) -> BuiltinFunction {
+        IntrinsicConstructorIndexes::WeakSet
+            .get_builtin_function_index(self.builtin_function_index_base)
+            .into()
     }
 }

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -157,7 +157,13 @@ impl OrdinaryObjectInternalSlots for Function {
         } {
             OrdinaryObject::from(object_index).prototype(agent)
         } else {
-            Some(agent.current_realm().intrinsics().function_prototype())
+            Some(
+                agent
+                    .current_realm()
+                    .intrinsics()
+                    .function_prototype()
+                    .into(),
+            )
         }
     }
 
@@ -168,7 +174,15 @@ impl OrdinaryObjectInternalSlots for Function {
             Function::ECMAScriptFunction(d) => agent.heap.get(d).object_index,
         } {
             OrdinaryObject::from(object_index).set_prototype(agent, prototype)
-        } else if prototype != Some(agent.current_realm().intrinsics().function_prototype()) {
+        } else if prototype
+            != Some(
+                agent
+                    .current_realm()
+                    .intrinsics()
+                    .function_prototype()
+                    .into(),
+            )
+        {
             // Create function base object with custom prototype
             todo!()
         }

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -12,7 +12,7 @@ use super::{
         ARRAY_BUFFER_DISCRIMINANT, ARRAY_DISCRIMINANT, BOUND_FUNCTION_DISCRIMINANT,
         BUILTIN_FUNCTION_DISCRIMINANT, ECMASCRIPT_FUNCTION_DISCRIMINANT, OBJECT_DISCRIMINANT,
     },
-    Function, Value,
+    Function, IntoValue, Value,
 };
 use crate::{
     ecmascript::{
@@ -54,7 +54,19 @@ pub enum Object {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct OrdinaryObject(ObjectIndex);
+pub struct OrdinaryObject(pub(crate) ObjectIndex);
+
+impl IntoObject for OrdinaryObject {
+    fn into_object(self) -> Object {
+        self.into()
+    }
+}
+
+impl IntoValue for OrdinaryObject {
+    fn into_value(self) -> Value {
+        self.into()
+    }
+}
 
 impl From<OrdinaryObject> for Object {
     fn from(value: OrdinaryObject) -> Self {
@@ -65,6 +77,12 @@ impl From<OrdinaryObject> for Object {
 impl From<ObjectIndex> for OrdinaryObject {
     fn from(value: ObjectIndex) -> Self {
         OrdinaryObject(value)
+    }
+}
+
+impl From<OrdinaryObject> for Value {
+    fn from(value: OrdinaryObject) -> Self {
+        Self::Object(value.0)
     }
 }
 

--- a/nova_vm/src/heap/array.rs
+++ b/nova_vm/src/heap/array.rs
@@ -1,201 +1,199 @@
-use super::{heap_constants::WellKnownSymbolIndexes, object::ObjectEntry};
 use crate::{
     ecmascript::{
-        builtins::{ArgumentsList, Behaviour},
-        execution::{Agent, JsResult, RealmIdentifier},
-        types::{BuiltinFunctionHeapData, Function, Object, PropertyKey, Value},
+        builtins::ArgumentsList,
+        execution::{Agent, JsResult},
+        types::{Object, Value},
     },
-    heap::{
-        heap_constants::{get_constructor_index, BuiltinObjectIndexes},
-        Heap, ObjectEntryPropertyDescriptor,
-    },
+    heap::Heap,
 };
 
-pub fn initialize_array_heap(heap: &mut Heap) {
-    let species_function_name = Value::from_str(heap, "get [Symbol.species]");
-    let at_key = PropertyKey::from_str(heap, "at");
-    let copy_within_key = PropertyKey::from_str(heap, "copyWithin");
-    let entries_key = PropertyKey::from_str(heap, "entries");
-    let fill_key = PropertyKey::from_str(heap, "fill");
-    let find_key = PropertyKey::from_str(heap, "find");
-    let find_index_key = PropertyKey::from_str(heap, "findIndex");
-    let find_last_key = PropertyKey::from_str(heap, "findLast");
-    let find_last_index_key = PropertyKey::from_str(heap, "findLastIndex");
-    let flat_key = PropertyKey::from_str(heap, "flat");
-    let flat_map_key = PropertyKey::from_str(heap, "flatMap");
-    let includes_key = PropertyKey::from_str(heap, "includes");
-    let keys_key = PropertyKey::from_str(heap, "keys");
-    let to_reversed_key = PropertyKey::from_str(heap, "toReversed");
-    let to_sorted_key = PropertyKey::from_str(heap, "toSorted");
-    let to_spliced_key = PropertyKey::from_str(heap, "toSpliced");
-    let values_key = PropertyKey::from_str(heap, "values");
-    let entries = vec![
-        ObjectEntry::new_prototype_function_entry(heap, "from", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "isArray", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "of", 0, true),
-        ObjectEntry::new_constructor_prototype_entry(
-            heap,
-            BuiltinObjectIndexes::ArrayPrototype.into(),
-        ),
-        ObjectEntry::new(
-            PropertyKey::Symbol(WellKnownSymbolIndexes::Species.into()),
-            ObjectEntryPropertyDescriptor::ReadOnly {
-                get: Function::BuiltinFunction(heap.create_function(
-                    species_function_name,
-                    0,
-                    false,
-                )),
-                enumerable: false,
-                configurable: true,
-            },
-        ),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::ArrayConstructor,
-        true,
-        Some(Object::BuiltinFunction(
-            BuiltinObjectIndexes::FunctionPrototype.into(),
-        )),
-        entries,
-    );
-    heap.builtin_functions
-        [get_constructor_index(BuiltinObjectIndexes::ArrayConstructor).into_index()] =
-        Some(BuiltinFunctionHeapData {
-            object_index: Some(BuiltinObjectIndexes::ArrayConstructor.into()),
-            length: 1,
-            initial_name: None,
-            behaviour: Behaviour::Constructor(constructor_binding),
-            realm: RealmIdentifier::from_index(0),
-        });
-    let entries = vec![
-        ObjectEntry::new_prototype_function_entry(heap, "at", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "concat", 1, true),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "constructor"),
-            ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
-                BuiltinObjectIndexes::ArrayConstructor,
-            ))),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "copyWithin", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "entries", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "every", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "fill", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "filter", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "find", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "findIndex", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "findLast", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "findLastIndex", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "flat", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "flatMap", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "forEach", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "includes", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "indexOf", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "join", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "keys", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "lastIndexOf", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "map", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "pop", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "push", 1, true),
-        ObjectEntry::new_prototype_function_entry(heap, "reduce", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "reduceRight", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "reverse", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "shift", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "slice", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "some", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "sort", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "splice", 2, true),
-        ObjectEntry::new_prototype_function_entry(heap, "toLocaleString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toReversed", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toSorted", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toSpliced", 2, true),
-        ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "unshift", 1, true),
-        ObjectEntry::new_prototype_function_entry(heap, "values", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "with", 2, false),
-        // TODO: These symbol function properties are actually rwxh, this helper generates roxh instead.
-        ObjectEntry::new_prototype_symbol_function_entry(
-            heap,
-            "[Symbol.iterator]",
-            WellKnownSymbolIndexes::Iterator.into(),
-            0,
-            false,
-        ),
-        ObjectEntry::new(
-            PropertyKey::Symbol(WellKnownSymbolIndexes::Unscopables.into()),
-            ObjectEntryPropertyDescriptor::roxh(Value::Object(heap.create_object(vec![
-                ObjectEntry::new(
-                    at_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    copy_within_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    entries_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    fill_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    find_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    find_index_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    find_last_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    find_last_index_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    flat_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    flat_map_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    includes_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    keys_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    to_reversed_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    to_sorted_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    to_spliced_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-                ObjectEntry::new(
-                    values_key,
-                    ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
-                ),
-            ]))),
-        ),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::ArrayPrototype,
-        true,
-        Some(Object::Object(BuiltinObjectIndexes::ObjectPrototype.into())),
-        entries,
-    );
+pub fn initialize_array_heap(_heap: &mut Heap) {
+    // let species_function_name = Value::from_str(heap, "get [Symbol.species]");
+    // let at_key = PropertyKey::from_str(heap, "at");
+    // let copy_within_key = PropertyKey::from_str(heap, "copyWithin");
+    // let entries_key = PropertyKey::from_str(heap, "entries");
+    // let fill_key = PropertyKey::from_str(heap, "fill");
+    // let find_key = PropertyKey::from_str(heap, "find");
+    // let find_index_key = PropertyKey::from_str(heap, "findIndex");
+    // let find_last_key = PropertyKey::from_str(heap, "findLast");
+    // let find_last_index_key = PropertyKey::from_str(heap, "findLastIndex");
+    // let flat_key = PropertyKey::from_str(heap, "flat");
+    // let flat_map_key = PropertyKey::from_str(heap, "flatMap");
+    // let includes_key = PropertyKey::from_str(heap, "includes");
+    // let keys_key = PropertyKey::from_str(heap, "keys");
+    // let to_reversed_key = PropertyKey::from_str(heap, "toReversed");
+    // let to_sorted_key = PropertyKey::from_str(heap, "toSorted");
+    // let to_spliced_key = PropertyKey::from_str(heap, "toSpliced");
+    // let values_key = PropertyKey::from_str(heap, "values");
+    // let entries = vec![
+    //     ObjectEntry::new_prototype_function_entry(heap, "from", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "isArray", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "of", 0, true),
+    //     ObjectEntry::new_constructor_prototype_entry(
+    //         heap,
+    //         IntrinsicObjectIndexes::ArrayPrototype.into(),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::Symbol(WellKnownSymbolIndexes::Species.into()),
+    //         ObjectEntryPropertyDescriptor::ReadOnly {
+    //             get: Function::BuiltinFunction(heap.create_function(
+    //                 species_function_name,
+    //                 0,
+    //                 false,
+    //             )),
+    //             enumerable: false,
+    //             configurable: true,
+    //         },
+    //     ),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::ArrayConstructor,
+    //     true,
+    //     Some(Object::BuiltinFunction(
+    //         IntrinsicObjectIndexes::FunctionPrototype.into(),
+    //     )),
+    //     entries,
+    // );
+    // heap.builtin_functions
+    //     [get_constructor_index(IntrinsicObjectIndexes::ArrayConstructor).into_index()] =
+    //     Some(BuiltinFunctionHeapData {
+    //         object_index: Some(IntrinsicObjectIndexes::ArrayConstructor.into()),
+    //         length: 1,
+    //         initial_name: None,
+    //         behaviour: Behaviour::Constructor(constructor_binding),
+    //         realm: RealmIdentifier::from_index(0),
+    //     });
+    // let entries = vec![
+    //     ObjectEntry::new_prototype_function_entry(heap, "at", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "concat", 1, true),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "constructor"),
+    //         ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
+    //             IntrinsicObjectIndexes::ArrayConstructor,
+    //         ))),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "copyWithin", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "entries", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "every", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "fill", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "filter", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "find", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "findIndex", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "findLast", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "findLastIndex", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "flat", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "flatMap", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "forEach", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "includes", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "indexOf", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "join", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "keys", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "lastIndexOf", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "map", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "pop", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "push", 1, true),
+    //     ObjectEntry::new_prototype_function_entry(heap, "reduce", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "reduceRight", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "reverse", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "shift", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "slice", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "some", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "sort", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "splice", 2, true),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toLocaleString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toReversed", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toSorted", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toSpliced", 2, true),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "unshift", 1, true),
+    //     ObjectEntry::new_prototype_function_entry(heap, "values", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "with", 2, false),
+    //     // TODO: These symbol function properties are actually rwxh, this helper generates roxh instead.
+    //     ObjectEntry::new_prototype_symbol_function_entry(
+    //         heap,
+    //         "[Symbol.iterator]",
+    //         WellKnownSymbolIndexes::Iterator.into(),
+    //         0,
+    //         false,
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::Symbol(WellKnownSymbolIndexes::Unscopables.into()),
+    //         ObjectEntryPropertyDescriptor::roxh(Value::Object(heap.create_object(vec![
+    //             ObjectEntry::new(
+    //                 at_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 copy_within_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 entries_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 fill_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 find_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 find_index_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 find_last_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 find_last_index_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 flat_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 flat_map_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 includes_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 keys_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 to_reversed_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 to_sorted_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 to_spliced_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //             ObjectEntry::new(
+    //                 values_key,
+    //                 ObjectEntryPropertyDescriptor::rwx(Value::Boolean(true)),
+    //             ),
+    //         ]))),
+    //     ),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::ArrayPrototype,
+    //     true,
+    //     Some(Object::Object(
+    //         IntrinsicObjectIndexes::ObjectPrototype.into(),
+    //     )),
+    //     entries,
+    // );
 }
 
 fn constructor_binding(

--- a/nova_vm/src/heap/array_buffer.rs
+++ b/nova_vm/src/heap/array_buffer.rs
@@ -1,82 +1,80 @@
-use super::{heap_constants::WellKnownSymbolIndexes, object::ObjectEntry};
 use crate::{
     ecmascript::{
-        builtins::{ArgumentsList, Behaviour},
-        execution::{Agent, JsResult, RealmIdentifier},
-        types::{BuiltinFunctionHeapData, Function, Object, PropertyKey, Value},
+        builtins::ArgumentsList,
+        execution::{Agent, JsResult},
+        types::{Object, Value},
     },
-    heap::{
-        heap_constants::{get_constructor_index, BuiltinObjectIndexes},
-        Heap, ObjectEntryPropertyDescriptor,
-    },
+    heap::Heap,
 };
 
-pub fn initialize_array_buffer_heap(heap: &mut Heap) {
-    let species_function_name = Value::from_str(heap, "get [Symbol.species]");
-    let byte_length_key = Value::from_str(heap, "get byteLength");
-    let entries = vec![
-        ObjectEntry::new_prototype_function_entry(heap, "isView", 1, false),
-        ObjectEntry::new_constructor_prototype_entry(
-            heap,
-            BuiltinObjectIndexes::ArrayBufferPrototype.into(),
-        ),
-        ObjectEntry::new(
-            PropertyKey::Symbol(WellKnownSymbolIndexes::Species.into()),
-            ObjectEntryPropertyDescriptor::ReadOnly {
-                get: Function::BuiltinFunction(heap.create_function(
-                    species_function_name,
-                    0,
-                    false,
-                )),
-                enumerable: false,
-                configurable: true,
-            },
-        ),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::ArrayBufferConstructor,
-        true,
-        Some(Object::BuiltinFunction(
-            BuiltinObjectIndexes::FunctionPrototype.into(),
-        )),
-        entries,
-    );
-    heap.builtin_functions
-        [get_constructor_index(BuiltinObjectIndexes::ArrayBufferConstructor).into_index()] =
-        Some(BuiltinFunctionHeapData {
-            object_index: Some(BuiltinObjectIndexes::ArrayBufferConstructor.into()),
-            length: 1,
-            initial_name: None,
-            behaviour: Behaviour::Constructor(constructor_binding),
-            realm: RealmIdentifier::from_index(0),
-        });
-    let entries = vec![
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "byteLength"),
-            ObjectEntryPropertyDescriptor::ReadOnly {
-                get: Function::BuiltinFunction(heap.create_function(byte_length_key, 0, false)),
-                enumerable: false,
-                configurable: true,
-            },
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "constructor"),
-            ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
-                BuiltinObjectIndexes::ArrayBufferConstructor,
-            ))),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "slice", 2, false),
-        ObjectEntry::new(
-            PropertyKey::Symbol(WellKnownSymbolIndexes::ToStringTag.into()),
-            ObjectEntryPropertyDescriptor::roxh(Value::from_str(heap, "ArrayBuffer")),
-        ),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::ArrayBufferPrototype,
-        true,
-        Some(Object::Object(BuiltinObjectIndexes::ObjectPrototype.into())),
-        entries,
-    );
+pub fn initialize_array_buffer_heap(_heap: &mut Heap) {
+    // let species_function_name = Value::from_str(heap, "get [Symbol.species]");
+    // let byte_length_key = Value::from_str(heap, "get byteLength");
+    // let entries = vec![
+    //     ObjectEntry::new_prototype_function_entry(heap, "isView", 1, false),
+    //     ObjectEntry::new_constructor_prototype_entry(
+    //         heap,
+    //         IntrinsicObjectIndexes::ArrayBufferPrototype.into(),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::Symbol(WellKnownSymbolIndexes::Species.into()),
+    //         ObjectEntryPropertyDescriptor::ReadOnly {
+    //             get: Function::BuiltinFunction(heap.create_function(
+    //                 species_function_name,
+    //                 0,
+    //                 false,
+    //             )),
+    //             enumerable: false,
+    //             configurable: true,
+    //         },
+    //     ),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::ArrayBufferConstructor,
+    //     true,
+    //     Some(Object::BuiltinFunction(
+    //         IntrinsicObjectIndexes::FunctionPrototype.into(),
+    //     )),
+    //     entries,
+    // );
+    // heap.builtin_functions
+    //     [get_constructor_index(IntrinsicObjectIndexes::ArrayBufferConstructor).into_index()] =
+    //     Some(BuiltinFunctionHeapData {
+    //         object_index: Some(IntrinsicObjectIndexes::ArrayBufferConstructor.into()),
+    //         length: 1,
+    //         initial_name: None,
+    //         behaviour: Behaviour::Constructor(constructor_binding),
+    //         realm: RealmIdentifier::from_index(0),
+    //     });
+    // let entries = vec![
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "byteLength"),
+    //         ObjectEntryPropertyDescriptor::ReadOnly {
+    //             get: Function::BuiltinFunction(heap.create_function(byte_length_key, 0, false)),
+    //             enumerable: false,
+    //             configurable: true,
+    //         },
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "constructor"),
+    //         ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
+    //             IntrinsicObjectIndexes::ArrayBufferConstructor,
+    //         ))),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "slice", 2, false),
+    //     ObjectEntry::new(
+    //         PropertyKey::Symbol(WellKnownSymbolIndexes::ToStringTag.into()),
+    //         ObjectEntryPropertyDescriptor::roxh(Value::from_str(heap, "ArrayBuffer")),
+    //     ),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::ArrayBufferPrototype,
+    //     true,
+    //     Some(Object::Object(
+    //         IntrinsicObjectIndexes::ObjectPrototype.into(),
+    //     )),
+    //     entries,
+    // );
 }
 
 fn constructor_binding(

--- a/nova_vm/src/heap/bigint.rs
+++ b/nova_vm/src/heap/bigint.rs
@@ -1,61 +1,59 @@
-use super::indexes::ObjectIndex;
 use crate::{
     ecmascript::{
-        builtins::{ArgumentsList, Behaviour},
-        execution::{Agent, JsResult, RealmIdentifier},
-        types::{Object, PropertyKey, Value},
+        builtins::ArgumentsList,
+        execution::{Agent, JsResult},
+        types::{Object, Value},
     },
-    heap::{
-        heap_constants::{get_constructor_index, BuiltinObjectIndexes},
-        BuiltinFunctionHeapData, Heap, ObjectEntry, ObjectEntryPropertyDescriptor,
-    },
+    heap::Heap,
 };
 
-pub fn initialize_bigint_heap(heap: &mut Heap) {
-    let entries = vec![
-        ObjectEntry::new_prototype_function_entry(heap, "asIntN", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "asUintN", 2, false),
-        ObjectEntry::new_constructor_prototype_entry(
-            heap,
-            BuiltinObjectIndexes::BigintPrototype.into(),
-        ),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::BigintConstructor,
-        true,
-        Some(Object::BuiltinFunction(
-            BuiltinObjectIndexes::FunctionPrototype.into(),
-        )),
-        entries,
-    );
-    heap.builtin_functions
-        [get_constructor_index(BuiltinObjectIndexes::BigintConstructor).into_index()] =
-        Some(BuiltinFunctionHeapData {
-            object_index: Some(ObjectIndex::last(&heap.objects)),
-            length: 1,
-            initial_name: None,
-            behaviour: Behaviour::Constructor(constructor_binding),
-            realm: RealmIdentifier::from_index(0),
-        });
-    let entries = vec![
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "constructor"),
-            ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
-                BuiltinObjectIndexes::BigintConstructor,
-            ))),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "toLocaleString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "valueOf", 0, false),
-        // @@ToStringTag
-        // ObjectEntry { key: PropertyKey::Symbol(), PropertyDescriptor }
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::BigintPrototype,
-        true,
-        Some(Object::Object(BuiltinObjectIndexes::ObjectPrototype.into())),
-        entries,
-    );
+pub fn initialize_bigint_heap(_heap: &mut Heap) {
+    // let entries = vec![
+    //     ObjectEntry::new_prototype_function_entry(heap, "asIntN", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "asUintN", 2, false),
+    //     ObjectEntry::new_constructor_prototype_entry(
+    //         heap,
+    //         IntrinsicObjectIndexes::BigIntPrototype.into(),
+    //     ),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::BigIntConstructor,
+    //     true,
+    //     Some(Object::BuiltinFunction(
+    //         IntrinsicObjectIndexes::FunctionPrototype.into(),
+    //     )),
+    //     entries,
+    // );
+    // heap.builtin_functions
+    //     [get_constructor_index(IntrinsicObjectIndexes::BigIntConstructor).into_index()] =
+    //     Some(BuiltinFunctionHeapData {
+    //         object_index: Some(ObjectIndex::last(&heap.objects)),
+    //         length: 1,
+    //         initial_name: None,
+    //         behaviour: Behaviour::Constructor(constructor_binding),
+    //         realm: RealmIdentifier::from_index(0),
+    //     });
+    // let entries = vec![
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "constructor"),
+    //         ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
+    //             IntrinsicObjectIndexes::BigIntConstructor,
+    //         ))),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toLocaleString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "valueOf", 0, false),
+    //     // @@ToStringTag
+    //     // ObjectEntry { key: PropertyKey::Symbol(), PropertyDescriptor }
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::BigIntPrototype,
+    //     true,
+    //     Some(Object::Object(
+    //         IntrinsicObjectIndexes::ObjectPrototype.into(),
+    //     )),
+    //     entries,
+    // );
 }
 
 fn constructor_binding(

--- a/nova_vm/src/heap/boolean.rs
+++ b/nova_vm/src/heap/boolean.rs
@@ -1,54 +1,50 @@
-use super::{object::ObjectEntry, Heap};
-use crate::{
-    ecmascript::{
-        builtins::{ArgumentsList, Behaviour},
-        execution::{Agent, JsResult, RealmIdentifier},
-        types::{Object, PropertyKey, Value},
-    },
-    heap::{
-        heap_constants::{get_constructor_index, BuiltinObjectIndexes},
-        BuiltinFunctionHeapData, ObjectEntryPropertyDescriptor,
-    },
+use super::Heap;
+use crate::ecmascript::{
+    builtins::ArgumentsList,
+    execution::{Agent, JsResult},
+    types::{Object, Value},
 };
 
-pub fn initialize_boolean_heap(heap: &mut Heap) {
-    let entries = vec![ObjectEntry::new_constructor_prototype_entry(
-        heap,
-        BuiltinObjectIndexes::BooleanPrototype.into(),
-    )];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::BooleanConstructor,
-        true,
-        Some(Object::BuiltinFunction(
-            BuiltinObjectIndexes::FunctionPrototype.into(),
-        )),
-        entries,
-    );
-    heap.builtin_functions
-        [get_constructor_index(BuiltinObjectIndexes::BooleanConstructor).into_index()] =
-        Some(BuiltinFunctionHeapData {
-            object_index: Some(BuiltinObjectIndexes::BooleanConstructor.into()),
-            length: 1,
-            initial_name: None,
-            behaviour: Behaviour::Constructor(constructor_binding),
-            realm: RealmIdentifier::from_index(0),
-        });
-    let entries = vec![
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "constructor"),
-            ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
-                BuiltinObjectIndexes::BooleanConstructor,
-            ))),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "valueOf", 0, false),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::BooleanPrototype,
-        true,
-        Some(Object::Object(BuiltinObjectIndexes::ObjectPrototype.into())),
-        entries,
-    );
+pub fn initialize_boolean_heap(_heap: &mut Heap) {
+    // let entries = vec![ObjectEntry::new_constructor_prototype_entry(
+    //     heap,
+    //     IntrinsicObjectIndexes::BooleanPrototype.into(),
+    // )];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::BooleanConstructor,
+    //     true,
+    //     Some(Object::BuiltinFunction(
+    //         IntrinsicObjectIndexes::FunctionPrototype.into(),
+    //     )),
+    //     entries,
+    // );
+    // heap.builtin_functions
+    //     [get_constructor_index(IntrinsicObjectIndexes::BooleanConstructor).into_index()] =
+    //     Some(BuiltinFunctionHeapData {
+    //         object_index: Some(IntrinsicObjectIndexes::BooleanConstructor.into()),
+    //         length: 1,
+    //         initial_name: None,
+    //         behaviour: Behaviour::Constructor(constructor_binding),
+    //         realm: RealmIdentifier::from_index(0),
+    //     });
+    // let entries = vec![
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "constructor"),
+    //         ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
+    //             IntrinsicObjectIndexes::BooleanConstructor,
+    //         ))),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "valueOf", 0, false),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::BooleanPrototype,
+    //     true,
+    //     Some(Object::Object(
+    //         IntrinsicObjectIndexes::ObjectPrototype.into(),
+    //     )),
+    //     entries,
+    // );
 }
 
 fn constructor_binding(

--- a/nova_vm/src/heap/date.rs
+++ b/nova_vm/src/heap/date.rs
@@ -1,14 +1,11 @@
-use super::{heap_constants::WellKnownSymbolIndexes, indexes::ObjectIndex, object::ObjectEntry};
+use super::indexes::ObjectIndex;
 use crate::{
     ecmascript::{
-        builtins::{ArgumentsList, Behaviour},
-        execution::{Agent, JsResult, RealmIdentifier},
-        types::{BuiltinFunctionHeapData, Object, PropertyKey, Value},
+        builtins::ArgumentsList,
+        execution::{Agent, JsResult},
+        types::{Object, Value},
     },
-    heap::{
-        heap_constants::{get_constructor_index, BuiltinObjectIndexes},
-        Heap, ObjectEntryPropertyDescriptor,
-    },
+    heap::Heap,
 };
 use std::time::SystemTime;
 
@@ -18,96 +15,98 @@ pub struct DateHeapData {
     pub(super) _date: SystemTime,
 }
 
-pub fn initialize_date_heap(heap: &mut Heap) {
-    let entries = vec![
-        ObjectEntry::new_prototype_function_entry(heap, "now", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "parse", 1, false),
-        ObjectEntry::new_constructor_prototype_entry(
-            heap,
-            BuiltinObjectIndexes::DatePrototype.into(),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "UTC", 7, false),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::DateConstructor,
-        true,
-        Some(Object::BuiltinFunction(
-            BuiltinObjectIndexes::FunctionPrototype.into(),
-        )),
-        entries,
-    );
-    heap.builtin_functions
-        [get_constructor_index(BuiltinObjectIndexes::DateConstructor).into_index()] =
-        Some(BuiltinFunctionHeapData {
-            object_index: Some(BuiltinObjectIndexes::DateConstructor.into()),
-            length: 1,
-            initial_name: None,
-            behaviour: Behaviour::Constructor(constructor_binding),
-            realm: RealmIdentifier::from_index(0),
-        });
-    let entries = vec![
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "constructor"),
-            ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
-                BuiltinObjectIndexes::DateConstructor,
-            ))),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "getDate", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getDay", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getFullYear", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getHours", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getMilliseconds", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getMinutes", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getMonth", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getSeconds", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getTime", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getTimezoneOffset", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getUTCDate", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getUTCDay", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getUTCFullYear", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getUTCHours", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getUTCMilliseconds", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getUTCMinutes", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getUTCMonth", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getUTCSeconds", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setDate", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setFullYear", 3, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setHours", 4, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setMilliseconds", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setMinutes", 3, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setMonth", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setSeconds", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setTime", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setUTCDate", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setUTCFullYear", 3, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setUTCHours", 4, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setUTCMilliseconds", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setUTCMinutes", 3, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setUTCMonth", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setUTCSeconds", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toDateString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toJSON", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toLocaleDateString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toLocaleString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toLocaleTimeString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toTimeString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toUTCString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "valueOf", 0, false),
-        ObjectEntry::new_prototype_symbol_function_entry(
-            heap,
-            "[Symbol.toPrimitive]",
-            WellKnownSymbolIndexes::ToPrimitive.into(),
-            1,
-            false,
-        ),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::DatePrototype,
-        true,
-        Some(Object::Object(BuiltinObjectIndexes::ObjectPrototype.into())),
-        entries,
-    );
+pub fn initialize_date_heap(_heap: &mut Heap) {
+    // let entries = vec![
+    //     ObjectEntry::new_prototype_function_entry(heap, "now", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "parse", 1, false),
+    //     ObjectEntry::new_constructor_prototype_entry(
+    //         heap,
+    //         IntrinsicObjectIndexes::DatePrototype.into(),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "UTC", 7, false),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::DateConstructor,
+    //     true,
+    //     Some(Object::BuiltinFunction(
+    //         IntrinsicObjectIndexes::FunctionPrototype.into(),
+    //     )),
+    //     entries,
+    // );
+    // heap.builtin_functions
+    //     [get_constructor_index(IntrinsicObjectIndexes::DateConstructor).into_index()] =
+    //     Some(BuiltinFunctionHeapData {
+    //         object_index: Some(IntrinsicObjectIndexes::DateConstructor.into()),
+    //         length: 1,
+    //         initial_name: None,
+    //         behaviour: Behaviour::Constructor(constructor_binding),
+    //         realm: RealmIdentifier::from_index(0),
+    //     });
+    // let entries = vec![
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "constructor"),
+    //         ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
+    //             IntrinsicObjectIndexes::DateConstructor,
+    //         ))),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getDate", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getDay", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getFullYear", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getHours", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getMilliseconds", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getMinutes", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getMonth", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getSeconds", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getTime", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getTimezoneOffset", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getUTCDate", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getUTCDay", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getUTCFullYear", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getUTCHours", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getUTCMilliseconds", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getUTCMinutes", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getUTCMonth", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getUTCSeconds", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setDate", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setFullYear", 3, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setHours", 4, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setMilliseconds", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setMinutes", 3, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setMonth", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setSeconds", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setTime", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setUTCDate", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setUTCFullYear", 3, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setUTCHours", 4, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setUTCMilliseconds", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setUTCMinutes", 3, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setUTCMonth", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setUTCSeconds", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toDateString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toJSON", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toLocaleDateString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toLocaleString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toLocaleTimeString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toTimeString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toUTCString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "valueOf", 0, false),
+    //     ObjectEntry::new_prototype_symbol_function_entry(
+    //         heap,
+    //         "[Symbol.toPrimitive]",
+    //         WellKnownSymbolIndexes::ToPrimitive.into(),
+    //         1,
+    //         false,
+    //     ),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::DatePrototype,
+    //     true,
+    //     Some(Object::Object(
+    //         IntrinsicObjectIndexes::ObjectPrototype.into(),
+    //     )),
+    //     entries,
+    // );
 }
 
 fn constructor_binding(

--- a/nova_vm/src/heap/error.rs
+++ b/nova_vm/src/heap/error.rs
@@ -1,15 +1,11 @@
-use super::{indexes::ObjectIndex, object::ObjectEntry};
+use super::indexes::ObjectIndex;
 use crate::{
     ecmascript::{
-        builtins::{ArgumentsList, Behaviour},
-        execution::{Agent, JsResult, RealmIdentifier},
-        static_strings::{EMPTY_STRING, ERROR_CLASS_NAME, NAME_KEY},
-        types::{BuiltinFunctionHeapData, Object, PropertyKey, Value},
+        builtins::ArgumentsList,
+        execution::{Agent, JsResult},
+        types::{Object, Value},
     },
-    heap::{
-        heap_constants::{get_constructor_index, BuiltinObjectIndexes},
-        Heap, ObjectEntryPropertyDescriptor,
-    },
+    heap::Heap,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -18,51 +14,53 @@ pub struct ErrorHeapData {
     // TODO: stack? name?
 }
 
-pub fn initialize_error_heap(heap: &mut Heap) {
-    let entries = vec![ObjectEntry::new_constructor_prototype_entry(
-        heap,
-        BuiltinObjectIndexes::ErrorPrototype.into(),
-    )];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::ErrorConstructor,
-        true,
-        Some(Object::BuiltinFunction(
-            BuiltinObjectIndexes::FunctionPrototype.into(),
-        )),
-        entries,
-    );
-    heap.builtin_functions
-        [get_constructor_index(BuiltinObjectIndexes::ErrorConstructor).into_index()] =
-        Some(BuiltinFunctionHeapData {
-            object_index: Some(BuiltinObjectIndexes::ErrorConstructor.into()),
-            length: 1,
-            initial_name: None,
-            behaviour: Behaviour::Constructor(constructor_binding),
-            realm: RealmIdentifier::from_index(0),
-        });
-    let entries = vec![
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "constructor"),
-            ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
-                BuiltinObjectIndexes::ErrorConstructor,
-            ))),
-        ),
-        ObjectEntry::new(
-            NAME_KEY.into(),
-            ObjectEntryPropertyDescriptor::rwx(EMPTY_STRING.into()),
-        ),
-        ObjectEntry::new(
-            NAME_KEY.into(),
-            ObjectEntryPropertyDescriptor::rwx(ERROR_CLASS_NAME.into()),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::ErrorPrototype,
-        true,
-        Some(Object::Object(BuiltinObjectIndexes::ObjectPrototype.into())),
-        entries,
-    );
+pub fn initialize_error_heap(_heap: &mut Heap) {
+    // let entries = vec![ObjectEntry::new_constructor_prototype_entry(
+    //     heap,
+    //     IntrinsicObjectIndexes::ErrorPrototype.into(),
+    // )];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::ErrorConstructor,
+    //     true,
+    //     Some(Object::BuiltinFunction(
+    //         IntrinsicObjectIndexes::FunctionPrototype.into(),
+    //     )),
+    //     entries,
+    // );
+    // heap.builtin_functions
+    //     [get_constructor_index(IntrinsicObjectIndexes::ErrorConstructor).into_index()] =
+    //     Some(BuiltinFunctionHeapData {
+    //         object_index: Some(IntrinsicObjectIndexes::ErrorConstructor.into()),
+    //         length: 1,
+    //         initial_name: None,
+    //         behaviour: Behaviour::Constructor(constructor_binding),
+    //         realm: RealmIdentifier::from_index(0),
+    //     });
+    // let entries = vec![
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "constructor"),
+    //         ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
+    //             IntrinsicObjectIndexes::ErrorConstructor,
+    //         ))),
+    //     ),
+    //     ObjectEntry::new(
+    //         NAME_KEY.into(),
+    //         ObjectEntryPropertyDescriptor::rwx(EMPTY_STRING.into()),
+    //     ),
+    //     ObjectEntry::new(
+    //         NAME_KEY.into(),
+    //         ObjectEntryPropertyDescriptor::rwx(ERROR_CLASS_NAME.into()),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::ErrorPrototype,
+    //     true,
+    //     Some(Object::Object(
+    //         IntrinsicObjectIndexes::ObjectPrototype.into(),
+    //     )),
+    //     entries,
+    // );
 }
 
 fn constructor_binding(

--- a/nova_vm/src/heap/function.rs
+++ b/nova_vm/src/heap/function.rs
@@ -1,68 +1,65 @@
-use super::{
-    heap_constants::WellKnownSymbolIndexes, indexes::BuiltinFunctionIndex, object::ObjectEntry,
-};
+use super::indexes::BuiltinFunctionIndex;
 use crate::{
     ecmascript::{
-        builtins::{ArgumentsList, Behaviour},
-        execution::{Agent, JsResult, RealmIdentifier},
-        types::{BuiltinFunctionHeapData, Object, PropertyKey, Value},
+        builtins::ArgumentsList,
+        execution::{Agent, JsResult},
+        types::{Object, Value},
     },
-    heap::{
-        heap_constants::{get_constructor_index, BuiltinObjectIndexes},
-        Heap, ObjectEntryPropertyDescriptor,
-    },
+    heap::Heap,
 };
 
-pub fn initialize_function_heap(heap: &mut Heap) {
-    let entries = vec![ObjectEntry::new_constructor_prototype_entry(
-        heap,
-        BuiltinObjectIndexes::FunctionPrototype.into(),
-    )];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::FunctionConstructor,
-        true,
-        Some(Object::BuiltinFunction(
-            BuiltinObjectIndexes::FunctionPrototype.into(),
-        )),
-        entries,
-    );
-    heap.builtin_functions
-        [get_constructor_index(BuiltinObjectIndexes::FunctionConstructor).into_index()] =
-        Some(BuiltinFunctionHeapData {
-            object_index: Some(BuiltinObjectIndexes::FunctionConstructor.into()),
-            length: 1,
-            initial_name: None,
-            behaviour: Behaviour::Constructor(function_constructor_binding),
-            realm: RealmIdentifier::from_index(0),
-        });
-    let entries = vec![
-        ObjectEntry::new_prototype_function_entry(heap, "apply", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "bind", 1, true),
-        ObjectEntry::new_prototype_function_entry(heap, "call", 1, true),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "constructor"),
-            ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
-                BuiltinObjectIndexes::FunctionConstructor,
-            ))),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
-        ObjectEntry::new_prototype_symbol_function_entry(
-            heap,
-            "hasInstance",
-            WellKnownSymbolIndexes::HasInstance.into(),
-            1,
-            false,
-        ),
-    ];
-    // NOTE: According to ECMAScript spec https://tc39.es/ecma262/#sec-properties-of-the-function-prototype-object
-    // the %Function.prototype% object should itself be a function that always returns undefined. This is not
-    // upheld here and we probably do not care. It's seemingly the only prototype that is a function.
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::FunctionPrototype,
-        true,
-        Some(Object::Object(BuiltinObjectIndexes::ObjectPrototype.into())),
-        entries,
-    );
+pub fn initialize_function_heap(_heap: &mut Heap) {
+    // let entries = vec![ObjectEntry::new_constructor_prototype_entry(
+    //     heap,
+    //     IntrinsicObjectIndexes::FunctionPrototype.into(),
+    // )];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::FunctionConstructor,
+    //     true,
+    //     Some(Object::BuiltinFunction(
+    //         IntrinsicObjectIndexes::FunctionPrototype.into(),
+    //     )),
+    //     entries,
+    // );
+    // heap.builtin_functions
+    //     [get_constructor_index(IntrinsicObjectIndexes::FunctionConstructor).into_index()] =
+    //     Some(BuiltinFunctionHeapData {
+    //         object_index: Some(IntrinsicObjectIndexes::FunctionConstructor.into()),
+    //         length: 1,
+    //         initial_name: None,
+    //         behaviour: Behaviour::Constructor(function_constructor_binding),
+    //         realm: RealmIdentifier::from_index(0),
+    //     });
+    // let entries = vec![
+    //     ObjectEntry::new_prototype_function_entry(heap, "apply", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "bind", 1, true),
+    //     ObjectEntry::new_prototype_function_entry(heap, "call", 1, true),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "constructor"),
+    //         ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
+    //             IntrinsicObjectIndexes::FunctionConstructor,
+    //         ))),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
+    //     ObjectEntry::new_prototype_symbol_function_entry(
+    //         heap,
+    //         "hasInstance",
+    //         WellKnownSymbolIndexes::HasInstance.into(),
+    //         1,
+    //         false,
+    //     ),
+    // ];
+    // // NOTE: According to ECMAScript spec https://tc39.es/ecma262/#sec-properties-of-the-function-prototype-object
+    // // the %Function.prototype% object should itself be a function that always returns undefined. This is not
+    // // upheld here and we probably do not care. It's seemingly the only prototype that is a function.
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::FunctionPrototype,
+    //     true,
+    //     Some(Object::Object(
+    //         IntrinsicObjectIndexes::ObjectPrototype.into(),
+    //     )),
+    //     entries,
+    // );
 }
 
 fn function_constructor_binding(

--- a/nova_vm/src/heap/heap_bits.rs
+++ b/nova_vm/src/heap/heap_bits.rs
@@ -13,7 +13,7 @@ use super::{
     ArrayHeapData, Heap, NumberHeapData, ObjectHeapData, StringHeapData, SymbolHeapData,
 };
 use crate::ecmascript::{
-    builtins::{ArrayBufferHeapData, SealableElementsVector},
+    builtins::{ArrayBufferHeapData, BuiltinFunction, SealableElementsVector},
     execution::{
         DeclarativeEnvironment, DeclarativeEnvironmentIndex, EnvironmentIndex, FunctionEnvironment,
         FunctionEnvironmentIndex, GlobalEnvironment, GlobalEnvironmentIndex, Intrinsics,
@@ -27,7 +27,7 @@ use crate::ecmascript::{
     },
     types::{
         BigIntHeapData, BoundFunctionHeapData, BuiltinFunctionHeapData, ECMAScriptFunctionHeapData,
-        Function, Number, Object, String, Value,
+        Function, Number, Object, OrdinaryObject, String, Value,
     },
 };
 
@@ -853,6 +853,16 @@ impl HeapMarkAndSweep<()> for Function {
     }
 }
 
+impl HeapMarkAndSweep<()> for BuiltinFunction {
+    fn mark_values(&self, queues: &mut WorkQueues, data: impl BorrowMut<()>) {
+        self.0.mark_values(queues, data)
+    }
+
+    fn sweep_values(&mut self, compactions: &CompactionLists, data: impl Borrow<()>) {
+        self.0.sweep_values(compactions, data)
+    }
+}
+
 impl HeapMarkAndSweep<()> for Number {
     fn mark_values(&self, queues: &mut WorkQueues, data: impl BorrowMut<()>) {
         if let Self::Number(idx) = self {
@@ -885,6 +895,16 @@ impl HeapMarkAndSweep<()> for Object {
             Self::Array(idx) => idx.sweep_values(compactions, ()),
             _ => todo!(),
         }
+    }
+}
+
+impl HeapMarkAndSweep<()> for OrdinaryObject {
+    fn mark_values(&self, queues: &mut WorkQueues, data: impl BorrowMut<()>) {
+        self.0.mark_values(queues, data)
+    }
+
+    fn sweep_values(&mut self, compactions: &CompactionLists, data: impl Borrow<()>) {
+        self.0.sweep_values(compactions, data)
     }
 }
 
@@ -1134,88 +1154,276 @@ impl HeapMarkAndSweep<()> for Realm {
 
 impl HeapMarkAndSweep<()> for Intrinsics {
     fn mark_values(&self, queues: &mut WorkQueues, _data: impl BorrowMut<()>) {
-        self.array().mark_values(queues, ());
+        self.aggregate_error_prototype().mark_values(queues, ());
+        self.aggregate_error().mark_values(queues, ());
+        self.array_prototype_sort().mark_values(queues, ());
+        self.array_prototype_to_string().mark_values(queues, ());
+        self.array_prototype_values().mark_values(queues, ());
         self.array_prototype().mark_values(queues, ());
-        self.array_buffer().mark_values(queues, ());
+        self.array().mark_values(queues, ());
         self.array_buffer_prototype().mark_values(queues, ());
-        self.big_int().mark_values(queues, ());
+        self.array_buffer().mark_values(queues, ());
+        self.array_iterator_prototype().mark_values(queues, ());
+        self.async_from_sync_iterator_prototype()
+            .mark_values(queues, ());
+        self.async_function_prototype().mark_values(queues, ());
+        self.async_function().mark_values(queues, ());
+        self.async_generator_function_prototype_prototype()
+            .mark_values(queues, ());
+        self.async_generator_function_prototype()
+            .mark_values(queues, ());
+        self.async_generator_function().mark_values(queues, ());
+        self.async_generator_prototype().mark_values(queues, ());
+        self.async_iterator_prototype().mark_values(queues, ());
+        self.atomics().mark_values(queues, ());
         self.big_int_prototype().mark_values(queues, ());
-        self.boolean().mark_values(queues, ());
+        self.big_int().mark_values(queues, ());
+        self.big_int64_array().mark_values(queues, ());
+        self.big_uint64_array().mark_values(queues, ());
         self.boolean_prototype().mark_values(queues, ());
-        self.error().mark_values(queues, ());
+        self.boolean().mark_values(queues, ());
+        self.data_view_prototype().mark_values(queues, ());
+        self.data_view().mark_values(queues, ());
+        self.date_prototype_to_utcstring().mark_values(queues, ());
+        self.date_prototype().mark_values(queues, ());
+        self.date().mark_values(queues, ());
+        self.decode_uri().mark_values(queues, ());
+        self.decode_uricomponent().mark_values(queues, ());
+        self.encode_uri().mark_values(queues, ());
+        self.encode_uri_component().mark_values(queues, ());
         self.error_prototype().mark_values(queues, ());
+        self.error().mark_values(queues, ());
+        self.escape().mark_values(queues, ());
         self.eval().mark_values(queues, ());
-        self.eval_error().mark_values(queues, ());
         self.eval_error_prototype().mark_values(queues, ());
-        self.function().mark_values(queues, ());
+        self.eval_error().mark_values(queues, ());
+        self.finalization_registry_prototype()
+            .mark_values(queues, ());
+        self.finalization_registry().mark_values(queues, ());
+        self.float32_array().mark_values(queues, ());
+        self.float64_array().mark_values(queues, ());
+        self.for_in_iterator_prototype().mark_values(queues, ());
         self.function_prototype().mark_values(queues, ());
+        self.function().mark_values(queues, ());
+        self.generator_function_prototype_prototype_next()
+            .mark_values(queues, ());
+        self.generator_function_prototype_prototype()
+            .mark_values(queues, ());
+        self.generator_function_prototype().mark_values(queues, ());
+        self.generator_function().mark_values(queues, ());
+        self.generator_prototype().mark_values(queues, ());
+        self.int16_array().mark_values(queues, ());
+        self.int32_array().mark_values(queues, ());
+        self.int8_array().mark_values(queues, ());
         self.is_finite().mark_values(queues, ());
         self.is_nan().mark_values(queues, ());
+        self.iterator_prototype().mark_values(queues, ());
+        self.json().mark_values(queues, ());
+        self.map_prototype_entries().mark_values(queues, ());
+        self.map_prototype().mark_values(queues, ());
+        self.map().mark_values(queues, ());
+        self.map_iterator_prototype().mark_values(queues, ());
         self.math().mark_values(queues, ());
-        self.number().mark_values(queues, ());
+        self.native_error_prototype().mark_values(queues, ());
         self.number_prototype().mark_values(queues, ());
-        self.object().mark_values(queues, ());
-        self.object_prototype().mark_values(queues, ());
+        self.number().mark_values(queues, ());
         self.object_prototype_to_string().mark_values(queues, ());
-        self.range_error().mark_values(queues, ());
+        self.object_prototype().mark_values(queues, ());
+        self.object().mark_values(queues, ());
+        self.parse_float().mark_values(queues, ());
+        self.parse_int().mark_values(queues, ());
+        self.promise_prototype().mark_values(queues, ());
+        self.promise().mark_values(queues, ());
+        self.proxy().mark_values(queues, ());
         self.range_error_prototype().mark_values(queues, ());
-        self.reference_error().mark_values(queues, ());
+        self.range_error().mark_values(queues, ());
         self.reference_error_prototype().mark_values(queues, ());
+        self.reference_error().mark_values(queues, ());
         self.reflect().mark_values(queues, ());
-        self.string().mark_values(queues, ());
+        self.reg_exp_prototype_exec().mark_values(queues, ());
+        self.reg_exp_prototype().mark_values(queues, ());
+        self.reg_exp().mark_values(queues, ());
+        self.reg_exp_string_iterator_prototype()
+            .mark_values(queues, ());
+        self.set_prototype_values().mark_values(queues, ());
+        self.set_prototype().mark_values(queues, ());
+        self.set().mark_values(queues, ());
+        self.set_iterator_prototype().mark_values(queues, ());
+        self.shared_array_buffer_prototype().mark_values(queues, ());
+        self.shared_array_buffer().mark_values(queues, ());
+        self.string_prototype_trim_end().mark_values(queues, ());
+        self.string_prototype_trim_start().mark_values(queues, ());
         self.string_prototype().mark_values(queues, ());
-        self.symbol().mark_values(queues, ());
+        self.string().mark_values(queues, ());
+        self.string_iterator_prototype().mark_values(queues, ());
         self.symbol_prototype().mark_values(queues, ());
-        self.syntax_error().mark_values(queues, ());
+        self.symbol().mark_values(queues, ());
         self.syntax_error_prototype().mark_values(queues, ());
+        self.syntax_error().mark_values(queues, ());
         self.throw_type_error().mark_values(queues, ());
-        self.type_error().mark_values(queues, ());
+        self.typed_array_prototype_values().mark_values(queues, ());
+        self.typed_array_prototype().mark_values(queues, ());
+        self.typed_array().mark_values(queues, ());
         self.type_error_prototype().mark_values(queues, ());
-        self.uri_error().mark_values(queues, ());
+        self.type_error().mark_values(queues, ());
+        self.uint16_array().mark_values(queues, ());
+        self.uint32_array().mark_values(queues, ());
+        self.uint8_array().mark_values(queues, ());
+        self.uint8_clamped_array().mark_values(queues, ());
+        self.unescape().mark_values(queues, ());
         self.uri_error_prototype().mark_values(queues, ());
+        self.uri_error().mark_values(queues, ());
+        self.weak_map_prototype().mark_values(queues, ());
+        self.weak_map().mark_values(queues, ());
+        self.weak_ref_prototype().mark_values(queues, ());
+        self.weak_ref().mark_values(queues, ());
+        self.weak_set_prototype().mark_values(queues, ());
+        self.weak_set().mark_values(queues, ());
     }
 
     fn sweep_values(&mut self, compactions: &CompactionLists, _data: impl Borrow<()>) {
-        self.array.sweep_values(compactions, ());
-        self.array_prototype.sweep_values(compactions, ());
-        self.array_buffer.sweep_values(compactions, ());
-        self.array_buffer_prototype.sweep_values(compactions, ());
-        self.big_int.sweep_values(compactions, ());
-        self.big_int_prototype.sweep_values(compactions, ());
-        self.boolean.sweep_values(compactions, ());
-        self.boolean_prototype.sweep_values(compactions, ());
-        self.error.sweep_values(compactions, ());
-        self.error_prototype.sweep_values(compactions, ());
-        self.eval.sweep_values(compactions, ());
-        self.eval_error.sweep_values(compactions, ());
-        self.eval_error_prototype.sweep_values(compactions, ());
-        self.function.sweep_values(compactions, ());
-        self.function_prototype.sweep_values(compactions, ());
-        self.is_finite.sweep_values(compactions, ());
-        self.is_nan.sweep_values(compactions, ());
-        self.math.sweep_values(compactions, ());
-        self.number.sweep_values(compactions, ());
-        self.number_prototype.sweep_values(compactions, ());
-        self.object.sweep_values(compactions, ());
-        self.object_prototype.sweep_values(compactions, ());
-        self.object_prototype_to_string
+        self.aggregate_error_prototype()
             .sweep_values(compactions, ());
-        self.range_error.sweep_values(compactions, ());
-        self.range_error_prototype.sweep_values(compactions, ());
-        self.reference_error.sweep_values(compactions, ());
-        self.reference_error_prototype.sweep_values(compactions, ());
-        self.reflect.sweep_values(compactions, ());
-        self.string.sweep_values(compactions, ());
-        self.string_prototype.sweep_values(compactions, ());
-        self.symbol.sweep_values(compactions, ());
-        self.symbol_prototype.sweep_values(compactions, ());
-        self.syntax_error.sweep_values(compactions, ());
-        self.syntax_error_prototype.sweep_values(compactions, ());
-        self.throw_type_error.sweep_values(compactions, ());
-        self.type_error.sweep_values(compactions, ());
-        self.type_error_prototype.sweep_values(compactions, ());
-        self.uri_error.sweep_values(compactions, ());
-        self.uri_error_prototype.sweep_values(compactions, ());
+        self.aggregate_error().sweep_values(compactions, ());
+        self.array_prototype_sort().sweep_values(compactions, ());
+        self.array_prototype_to_string()
+            .sweep_values(compactions, ());
+        self.array_prototype_values().sweep_values(compactions, ());
+        self.array_prototype().sweep_values(compactions, ());
+        self.array().sweep_values(compactions, ());
+        self.array_buffer_prototype().sweep_values(compactions, ());
+        self.array_buffer().sweep_values(compactions, ());
+        self.array_iterator_prototype()
+            .sweep_values(compactions, ());
+        self.async_from_sync_iterator_prototype()
+            .sweep_values(compactions, ());
+        self.async_function_prototype()
+            .sweep_values(compactions, ());
+        self.async_function().sweep_values(compactions, ());
+        self.async_generator_function_prototype_prototype()
+            .sweep_values(compactions, ());
+        self.async_generator_function_prototype()
+            .sweep_values(compactions, ());
+        self.async_generator_function()
+            .sweep_values(compactions, ());
+        self.async_generator_prototype()
+            .sweep_values(compactions, ());
+        self.async_iterator_prototype()
+            .sweep_values(compactions, ());
+        self.atomics().sweep_values(compactions, ());
+        self.big_int_prototype().sweep_values(compactions, ());
+        self.big_int().sweep_values(compactions, ());
+        self.big_int64_array().sweep_values(compactions, ());
+        self.big_uint64_array().sweep_values(compactions, ());
+        self.boolean_prototype().sweep_values(compactions, ());
+        self.boolean().sweep_values(compactions, ());
+        self.data_view_prototype().sweep_values(compactions, ());
+        self.data_view().sweep_values(compactions, ());
+        self.date_prototype_to_utcstring()
+            .sweep_values(compactions, ());
+        self.date_prototype().sweep_values(compactions, ());
+        self.date().sweep_values(compactions, ());
+        self.decode_uri().sweep_values(compactions, ());
+        self.decode_uricomponent().sweep_values(compactions, ());
+        self.encode_uri().sweep_values(compactions, ());
+        self.encode_uri_component().sweep_values(compactions, ());
+        self.error_prototype().sweep_values(compactions, ());
+        self.error().sweep_values(compactions, ());
+        self.escape().sweep_values(compactions, ());
+        self.eval().sweep_values(compactions, ());
+        self.eval_error_prototype().sweep_values(compactions, ());
+        self.eval_error().sweep_values(compactions, ());
+        self.finalization_registry_prototype()
+            .sweep_values(compactions, ());
+        self.finalization_registry().sweep_values(compactions, ());
+        self.float32_array().sweep_values(compactions, ());
+        self.float64_array().sweep_values(compactions, ());
+        self.for_in_iterator_prototype()
+            .sweep_values(compactions, ());
+        self.function_prototype().sweep_values(compactions, ());
+        self.function().sweep_values(compactions, ());
+        self.generator_function_prototype_prototype_next()
+            .sweep_values(compactions, ());
+        self.generator_function_prototype_prototype()
+            .sweep_values(compactions, ());
+        self.generator_function_prototype()
+            .sweep_values(compactions, ());
+        self.generator_function().sweep_values(compactions, ());
+        self.generator_prototype().sweep_values(compactions, ());
+        self.int16_array().sweep_values(compactions, ());
+        self.int32_array().sweep_values(compactions, ());
+        self.int8_array().sweep_values(compactions, ());
+        self.is_finite().sweep_values(compactions, ());
+        self.is_nan().sweep_values(compactions, ());
+        self.iterator_prototype().sweep_values(compactions, ());
+        self.json().sweep_values(compactions, ());
+        self.map_prototype_entries().sweep_values(compactions, ());
+        self.map_prototype().sweep_values(compactions, ());
+        self.map().sweep_values(compactions, ());
+        self.map_iterator_prototype().sweep_values(compactions, ());
+        self.math().sweep_values(compactions, ());
+        self.native_error_prototype().sweep_values(compactions, ());
+        self.number_prototype().sweep_values(compactions, ());
+        self.number().sweep_values(compactions, ());
+        self.object_prototype_to_string()
+            .sweep_values(compactions, ());
+        self.object_prototype().sweep_values(compactions, ());
+        self.object().sweep_values(compactions, ());
+        self.parse_float().sweep_values(compactions, ());
+        self.parse_int().sweep_values(compactions, ());
+        self.promise_prototype().sweep_values(compactions, ());
+        self.promise().sweep_values(compactions, ());
+        self.proxy().sweep_values(compactions, ());
+        self.range_error_prototype().sweep_values(compactions, ());
+        self.range_error().sweep_values(compactions, ());
+        self.reference_error_prototype()
+            .sweep_values(compactions, ());
+        self.reference_error().sweep_values(compactions, ());
+        self.reflect().sweep_values(compactions, ());
+        self.reg_exp_prototype_exec().sweep_values(compactions, ());
+        self.reg_exp_prototype().sweep_values(compactions, ());
+        self.reg_exp().sweep_values(compactions, ());
+        self.reg_exp_string_iterator_prototype()
+            .sweep_values(compactions, ());
+        self.set_prototype_values().sweep_values(compactions, ());
+        self.set_prototype().sweep_values(compactions, ());
+        self.set().sweep_values(compactions, ());
+        self.set_iterator_prototype().sweep_values(compactions, ());
+        self.shared_array_buffer_prototype()
+            .sweep_values(compactions, ());
+        self.shared_array_buffer().sweep_values(compactions, ());
+        self.string_prototype_trim_end()
+            .sweep_values(compactions, ());
+        self.string_prototype_trim_start()
+            .sweep_values(compactions, ());
+        self.string_prototype().sweep_values(compactions, ());
+        self.string().sweep_values(compactions, ());
+        self.string_iterator_prototype()
+            .sweep_values(compactions, ());
+        self.symbol_prototype().sweep_values(compactions, ());
+        self.symbol().sweep_values(compactions, ());
+        self.syntax_error_prototype().sweep_values(compactions, ());
+        self.syntax_error().sweep_values(compactions, ());
+        self.throw_type_error().sweep_values(compactions, ());
+        self.typed_array_prototype_values()
+            .sweep_values(compactions, ());
+        self.typed_array_prototype().sweep_values(compactions, ());
+        self.typed_array().sweep_values(compactions, ());
+        self.type_error_prototype().sweep_values(compactions, ());
+        self.type_error().sweep_values(compactions, ());
+        self.uint16_array().sweep_values(compactions, ());
+        self.uint32_array().sweep_values(compactions, ());
+        self.uint8_array().sweep_values(compactions, ());
+        self.uint8_clamped_array().sweep_values(compactions, ());
+        self.unescape().sweep_values(compactions, ());
+        self.uri_error_prototype().sweep_values(compactions, ());
+        self.uri_error().sweep_values(compactions, ());
+        self.weak_map_prototype().sweep_values(compactions, ());
+        self.weak_map().sweep_values(compactions, ());
+        self.weak_ref_prototype().sweep_values(compactions, ());
+        self.weak_ref().sweep_values(compactions, ());
+        self.weak_set_prototype().sweep_values(compactions, ());
+        self.weak_set().sweep_values(compactions, ());
     }
 }
 

--- a/nova_vm/src/heap/heap_constants.rs
+++ b/nova_vm/src/heap/heap_constants.rs
@@ -4,15 +4,15 @@
 //! are placed into the heap vectors. The order is based on the ECMAScript
 //! definition found in https://tc39.es/ecma262/
 
-// +==================================================================+
-// | First the list of built-in prototypes and non-prototypal objects |
-// +==================================================================+
-
 use super::indexes::{BuiltinFunctionIndex, ObjectIndex, SymbolIndex};
 
 #[repr(u32)]
 #[derive(Debug, Clone, Copy)]
-pub enum BuiltinObjectIndexes {
+pub(crate) enum IntrinsicObjectIndexes {
+    // +==================================================================+
+    // | First the list of built-in prototypes and non-prototypal objects |
+    // +==================================================================+
+
     // Fundamental objects
     ObjectPrototype,
     FunctionPrototype,
@@ -22,7 +22,7 @@ pub enum BuiltinObjectIndexes {
 
     // Numbers and dates
     NumberPrototype,
-    BigintPrototype,
+    BigIntPrototype,
     MathObject,
     DatePrototype,
 
@@ -32,6 +32,7 @@ pub enum BuiltinObjectIndexes {
 
     // Indexed collections
     ArrayPrototype,
+    TypedArrayPrototype,
     Int8ArrayPrototype,
     Uint8ArrayPrototype,
     Uint8ClampedArrayPrototype,
@@ -55,7 +56,7 @@ pub enum BuiltinObjectIndexes {
     SharedArrayBufferPrototype,
     DataViewPrototype,
     AtomicsObject,
-    JsonObject,
+    JSONObject,
 
     // Managing memory
     WeakRefPrototype,
@@ -63,9 +64,17 @@ pub enum BuiltinObjectIndexes {
 
     // Control abstraction objects
     IteratorPrototype,
+    ArrayIteratorPrototype,
+    ForInIteratorPrototype,
     AsyncIteratorPrototype,
+    AsyncFromSyncIteratorPrototype,
+    AsyncGeneratorFunctionPrototypePrototype,
+    MapIteratorPrototype,
+    SetIteratorPrototype,
     PromisePrototype,
+    StringIteratorPrototype,
     GeneratorFunctionPrototype,
+    GeneratorFunctionPrototypePrototype,
     AsyncGeneratorFunctionPrototype,
     GeneratorPrototype,
     AsyncGeneratorPrototype,
@@ -75,90 +84,180 @@ pub enum BuiltinObjectIndexes {
     ReflectObject,
     ModulePrototype,
 
+    // Errors subtypes
+    AggregateErrorPrototype,
+    EvalErrorPrototype,
+    NativeErrorPrototype,
+    RangeErrorPrototype,
+    ReferenceErrorPrototype,
+    SyntaxErrorPrototype,
+    TypeErrorPrototype,
+
+    // Others
+    URIErrorPrototype,
+    RegExpStringIteratorPrototype,
+}
+const LAST_INTRINSIC_OBJECT_INDEX: IntrinsicObjectIndexes =
+    IntrinsicObjectIndexes::RegExpStringIteratorPrototype;
+
+#[repr(u32)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum IntrinsicConstructorIndexes {
     // +===============================================+
     // | Then the list of constructor function objects |
     // +===============================================+
 
     // Fundamental objects
-    ObjectConstructor,
-    FunctionConstructor,
-    BooleanConstructor,
-    SymbolConstructor,
-    ErrorConstructor,
+    Object,
+    Function,
+    Boolean,
+    Symbol,
+    Error,
 
     // Numbers and dates
-    NumberConstructor,
-    BigintConstructor,
-    DateConstructor,
+    Number,
+    BigInt,
+    Date,
 
     // Text processing
-    StringConstructor,
-    RegExpConstructor,
+    String,
+    RegExp,
 
     // Indexed collections
-    ArrayConstructor,
-    Int8ArrayConstructor,
-    Uint8ArrayConstructor,
-    Uint8ClampedArrayConstructor,
-    Int16ArrayConstructor,
-    Uint16ArrayConstructor,
-    Int32ArrayConstructor,
-    Uint32ArrayConstructor,
-    BigInt64ArrayConstructor,
-    BigUint64ArrayConstructor,
-    Float32ArrayConstructor,
-    Float64ArrayConstructor,
+    Array,
+    TypedArray,
+    Int8Array,
+    Uint8Array,
+    Uint8ClampedArray,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    BigInt64Array,
+    BigUint64Array,
+    Float32Array,
+    Float64Array,
 
     // Keyed collections
-    MapConstructor,
-    SetConstructor,
-    WeakMapConstructor,
-    WeakSetConstructor,
+    Map,
+    Set,
+    WeakMap,
+    WeakSet,
 
     // Structured data
-    ArrayBufferConstructor,
-    SharedArrayBufferConstructor,
-    DataViewConstructor,
+    ArrayBuffer,
+    SharedArrayBuffer,
+    DataView,
 
     // Managing memory
-    WeakRefConstructor,
-    FinalizationRegistryConstructor,
+    WeakRef,
+    FinalizationRegistry,
 
     // Control abstraction objects
-    PromiseConstructor,
-    GeneratorFunctionConstructor,
-    AsyncGeneratorFunctionConstructor,
-    AsyncFunctionConstructor,
+    Promise,
+    GeneratorFunction,
+    AsyncGeneratorFunction,
+    AsyncFunction,
 
     // Reflection
-    ProxyConstructor,
-}
+    Proxy,
 
-impl From<BuiltinObjectIndexes> for ObjectIndex {
-    fn from(value: BuiltinObjectIndexes) -> ObjectIndex {
-        ObjectIndex::from_u32_index(value as u32)
+    // Errors subtypes
+    AggregateError,
+    EvalError,
+    RangeError,
+    ReferenceError,
+    SyntaxError,
+    TypeError,
+
+    // Others
+    URIError,
+}
+const LAST_INTRINSIC_CONSTRUCTOR_INDEX: IntrinsicConstructorIndexes =
+    IntrinsicConstructorIndexes::URIError;
+
+#[repr(u32)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum IntrinsicFunctionIndexes {
+    // +===================================================================================+
+    // | Plain functions: These do not have a corresponding object index reserved for them |
+    // +===================================================================================+
+    ArrayPrototypeSort,
+    ArrayPrototypeToString,
+    ArrayPrototypeValues,
+    DatePrototypeToUTCString,
+    DecodeURI,
+    DecodeURIComponent,
+    EncodeURI,
+    EncodeURIComponent,
+    Escape,
+    Eval,
+    GeneratorFunctionPrototypePrototypeNext,
+    IsFinite,
+    IsNaN,
+    MapPrototypeEntries,
+    ObjectPrototypeToString,
+    ParseFloat,
+    ParseInt,
+    RegExpPrototypeExec,
+    SetPrototypeValues,
+    StringPrototypeTrimEnd,
+    StringPrototypeTrimStart,
+    ThrowTypeError,
+    TypedArrayPrototypeValues,
+    Unescape,
+}
+const LAST_INTRINSIC_FUNCTION_INDEX: IntrinsicFunctionIndexes = IntrinsicFunctionIndexes::Unescape;
+
+impl IntrinsicObjectIndexes {
+    const OBJECT_INDEX_OFFSET: u32 = 0;
+
+    pub(crate) const fn get_object_index(self, base: ObjectIndex) -> ObjectIndex {
+        ObjectIndex::from_u32_index(self as u32 + base.into_u32_index() + Self::OBJECT_INDEX_OFFSET)
     }
 }
 
-impl From<BuiltinObjectIndexes> for BuiltinFunctionIndex {
-    fn from(value: BuiltinObjectIndexes) -> BuiltinFunctionIndex {
-        // We do not allow more than 16 777 216 functions to exist.
-        assert!(value as u32 <= u32::pow(2, 24));
-        BuiltinFunctionIndex::from_u32_index(value as u32)
+impl IntrinsicConstructorIndexes {
+    const OBJECT_INDEX_OFFSET: u32 =
+        IntrinsicObjectIndexes::OBJECT_INDEX_OFFSET + LAST_INTRINSIC_OBJECT_INDEX as u32 + 1;
+    const BUILTIN_FUNCTION_INDEX_OFFSET: u32 = 0;
+
+    pub(crate) const fn get_object_index(self, base: ObjectIndex) -> ObjectIndex {
+        ObjectIndex::from_u32_index(self as u32 + base.into_u32_index() + Self::OBJECT_INDEX_OFFSET)
+    }
+
+    pub(crate) const fn get_builtin_function_index(
+        self,
+        base: BuiltinFunctionIndex,
+    ) -> BuiltinFunctionIndex {
+        BuiltinFunctionIndex::from_u32_index(
+            self as u32 + base.into_u32_index() + Self::BUILTIN_FUNCTION_INDEX_OFFSET,
+        )
     }
 }
 
-impl Default for BuiltinObjectIndexes {
-    fn default() -> Self {
-        Self::ObjectPrototype
+impl IntrinsicFunctionIndexes {
+    const BUILTIN_FUNCTION_INDEX_OFFSET: u32 =
+        IntrinsicConstructorIndexes::BUILTIN_FUNCTION_INDEX_OFFSET
+            + LAST_INTRINSIC_CONSTRUCTOR_INDEX as u32
+            + 1;
+
+    pub(crate) const fn get_builtin_function_index(
+        self,
+        base: BuiltinFunctionIndex,
+    ) -> BuiltinFunctionIndex {
+        BuiltinFunctionIndex::from_u32_index(
+            self as u32 + base.into_u32_index() + Self::BUILTIN_FUNCTION_INDEX_OFFSET,
+        )
     }
 }
 
-pub const LAST_BUILTIN_OBJECT_INDEX: u32 = BuiltinObjectIndexes::ProxyConstructor as u32;
-pub const FIRST_CONSTRUCTOR_INDEX: u32 = BuiltinObjectIndexes::ObjectConstructor as u32;
+pub(crate) const fn intrinsic_object_count() -> usize {
+    LAST_INTRINSIC_OBJECT_INDEX as usize + 1 + LAST_INTRINSIC_CONSTRUCTOR_INDEX as usize + 1
+}
 
-pub const fn get_constructor_index(object_index: BuiltinObjectIndexes) -> BuiltinFunctionIndex {
-    BuiltinFunctionIndex::from_u32_index(object_index as u32 - FIRST_CONSTRUCTOR_INDEX)
+pub(crate) const fn intrinsic_function_count() -> usize {
+    LAST_INTRINSIC_CONSTRUCTOR_INDEX as usize + 1 + LAST_INTRINSIC_FUNCTION_INDEX as usize + 1
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/nova_vm/src/heap/heap_gc.rs
+++ b/nova_vm/src/heap/heap_gc.rs
@@ -625,7 +625,7 @@ fn sweep(heap: &mut Heap, bits: &HeapBits) {
 #[test]
 fn test_heap_gc() {
     let mut heap: Heap = Default::default();
-    assert!(!heap.objects.is_empty());
+    assert!(heap.objects.is_empty());
     let obj = Value::Object(heap.create_null_object(vec![]));
     println!("Object: {:#?}", obj);
     heap.globals.push(obj);

--- a/nova_vm/src/heap/math.rs
+++ b/nova_vm/src/heap/math.rs
@@ -1,107 +1,100 @@
-use super::{
-    heap_constants::WellKnownSymbolIndexes,
-    object::{ObjectEntry, ObjectEntryPropertyDescriptor},
-    CreateHeapData, Heap,
-};
-use crate::ecmascript::{
-    execution::JsResult,
-    types::{PropertyKey, Value},
-};
+use super::Heap;
+use crate::ecmascript::{execution::JsResult, types::Value};
 
-pub(super) fn initialize_math_object(heap: &mut Heap) {
-    let e = heap.create(std::f64::consts::E);
-    let ln10 = heap.create(std::f64::consts::LN_10);
-    let ln2 = heap.create(std::f64::consts::LN_2);
-    let log10e = heap.create(std::f64::consts::LOG10_E);
-    let log2e = heap.create(std::f64::consts::LOG2_E);
-    let pi = heap.create(std::f64::consts::PI);
-    let sqrt1_2 = heap.create(std::f64::consts::FRAC_1_SQRT_2);
-    let sqrt2 = heap.create(std::f64::consts::SQRT_2);
-    let abs = ObjectEntry::new_prototype_function_entry(heap, "abs", 1, false);
-    let acos = ObjectEntry::new_prototype_function_entry(heap, "acos", 1, false);
-    let acosh = ObjectEntry::new_prototype_function_entry(heap, "acosh", 1, false);
-    let asin = ObjectEntry::new_prototype_function_entry(heap, "asin", 1, false);
-    let asinh = ObjectEntry::new_prototype_function_entry(heap, "asinh", 1, false);
-    let atan = ObjectEntry::new_prototype_function_entry(heap, "atan", 1, false);
-    let atanh = ObjectEntry::new_prototype_function_entry(heap, "atanh", 1, false);
-    let atan2 = ObjectEntry::new_prototype_function_entry(heap, "atan2", 2, false);
-    let cbrt = ObjectEntry::new_prototype_function_entry(heap, "cbrt", 1, false);
-    let ceil = ObjectEntry::new_prototype_function_entry(heap, "ceil", 1, false);
-    let clz32 = ObjectEntry::new_prototype_function_entry(heap, "clz32", 1, false);
-    let cos = ObjectEntry::new_prototype_function_entry(heap, "cos", 1, false);
-    let cosh = ObjectEntry::new_prototype_function_entry(heap, "cosh", 1, false);
-    let exp = ObjectEntry::new_prototype_function_entry(heap, "exp", 1, false);
-    let expm1 = ObjectEntry::new_prototype_function_entry(heap, "expm1", 1, false);
-    let floor = ObjectEntry::new_prototype_function_entry(heap, "floor", 1, false);
-    let fround = ObjectEntry::new_prototype_function_entry(heap, "fround", 1, false);
-    let hypot = ObjectEntry::new_prototype_function_entry(heap, "hypot", 2, true);
-    let imul = ObjectEntry::new_prototype_function_entry(heap, "imul", 2, false);
-    let log = ObjectEntry::new_prototype_function_entry(heap, "log", 1, false);
-    let log1p = ObjectEntry::new_prototype_function_entry(heap, "log1p", 1, false);
-    let log10 = ObjectEntry::new_prototype_function_entry(heap, "log10", 1, false);
-    let log2 = ObjectEntry::new_prototype_function_entry(heap, "log2", 1, false);
-    let max = ObjectEntry::new_prototype_function_entry(heap, "max", 2, true);
-    let min = ObjectEntry::new_prototype_function_entry(heap, "min", 2, true);
-    let pow = ObjectEntry::new_prototype_function_entry(heap, "pow", 2, false);
-    let random = ObjectEntry::new_prototype_function_entry(heap, "random", 0, false);
-    let round = ObjectEntry::new_prototype_function_entry(heap, "round", 1, false);
-    let sign = ObjectEntry::new_prototype_function_entry(heap, "sign", 1, false);
-    let sin = ObjectEntry::new_prototype_function_entry(heap, "sin", 1, false);
-    let sinh = ObjectEntry::new_prototype_function_entry(heap, "sinh", 1, false);
-    let sqrt = ObjectEntry::new_prototype_function_entry(heap, "sqrt", 1, false);
-    let tan = ObjectEntry::new_prototype_function_entry(heap, "tan", 1, false);
-    let tanh = ObjectEntry::new_prototype_function_entry(heap, "tanh", 1, false);
-    let trunc = ObjectEntry::new_prototype_function_entry(heap, "trunc", 1, false);
-    let entries = vec![
-        ObjectEntry::new_frozen_entry(heap, "E", e.into()),
-        ObjectEntry::new_frozen_entry(heap, "LN10", ln10.into()),
-        ObjectEntry::new_frozen_entry(heap, "LN2", ln2.into()),
-        ObjectEntry::new_frozen_entry(heap, "LOG10E", log10e.into()),
-        ObjectEntry::new_frozen_entry(heap, "LOG2E", log2e.into()),
-        ObjectEntry::new_frozen_entry(heap, "PI", pi.into()),
-        ObjectEntry::new_frozen_entry(heap, "SQRT1_2", sqrt1_2.into()),
-        ObjectEntry::new_frozen_entry(heap, "SQRT2", sqrt2.into()),
-        ObjectEntry::new(
-            PropertyKey::Symbol(WellKnownSymbolIndexes::ToStringTag.into()),
-            ObjectEntryPropertyDescriptor::roxh(Value::from_str(heap, "Math")),
-        ),
-        abs,
-        acos,
-        acosh,
-        asin,
-        asinh,
-        atan,
-        atanh,
-        atan2,
-        cbrt,
-        ceil,
-        clz32,
-        cos,
-        cosh,
-        exp,
-        expm1,
-        floor,
-        fround,
-        hypot,
-        imul,
-        log,
-        log1p,
-        log10,
-        log2,
-        max,
-        min,
-        pow,
-        random,
-        round,
-        sign,
-        sin,
-        sinh,
-        sqrt,
-        tan,
-        tanh,
-        trunc,
-    ];
-    let _ = heap.create_object(entries);
+pub(super) fn initialize_math_object(_heap: &mut Heap) {
+    // let e = heap.create(std::f64::consts::E);
+    // let ln10 = heap.create(std::f64::consts::LN_10);
+    // let ln2 = heap.create(std::f64::consts::LN_2);
+    // let log10e = heap.create(std::f64::consts::LOG10_E);
+    // let log2e = heap.create(std::f64::consts::LOG2_E);
+    // let pi = heap.create(std::f64::consts::PI);
+    // let sqrt1_2 = heap.create(std::f64::consts::FRAC_1_SQRT_2);
+    // let sqrt2 = heap.create(std::f64::consts::SQRT_2);
+    // let abs = ObjectEntry::new_prototype_function_entry(heap, "abs", 1, false);
+    // let acos = ObjectEntry::new_prototype_function_entry(heap, "acos", 1, false);
+    // let acosh = ObjectEntry::new_prototype_function_entry(heap, "acosh", 1, false);
+    // let asin = ObjectEntry::new_prototype_function_entry(heap, "asin", 1, false);
+    // let asinh = ObjectEntry::new_prototype_function_entry(heap, "asinh", 1, false);
+    // let atan = ObjectEntry::new_prototype_function_entry(heap, "atan", 1, false);
+    // let atanh = ObjectEntry::new_prototype_function_entry(heap, "atanh", 1, false);
+    // let atan2 = ObjectEntry::new_prototype_function_entry(heap, "atan2", 2, false);
+    // let cbrt = ObjectEntry::new_prototype_function_entry(heap, "cbrt", 1, false);
+    // let ceil = ObjectEntry::new_prototype_function_entry(heap, "ceil", 1, false);
+    // let clz32 = ObjectEntry::new_prototype_function_entry(heap, "clz32", 1, false);
+    // let cos = ObjectEntry::new_prototype_function_entry(heap, "cos", 1, false);
+    // let cosh = ObjectEntry::new_prototype_function_entry(heap, "cosh", 1, false);
+    // let exp = ObjectEntry::new_prototype_function_entry(heap, "exp", 1, false);
+    // let expm1 = ObjectEntry::new_prototype_function_entry(heap, "expm1", 1, false);
+    // let floor = ObjectEntry::new_prototype_function_entry(heap, "floor", 1, false);
+    // let fround = ObjectEntry::new_prototype_function_entry(heap, "fround", 1, false);
+    // let hypot = ObjectEntry::new_prototype_function_entry(heap, "hypot", 2, true);
+    // let imul = ObjectEntry::new_prototype_function_entry(heap, "imul", 2, false);
+    // let log = ObjectEntry::new_prototype_function_entry(heap, "log", 1, false);
+    // let log1p = ObjectEntry::new_prototype_function_entry(heap, "log1p", 1, false);
+    // let log10 = ObjectEntry::new_prototype_function_entry(heap, "log10", 1, false);
+    // let log2 = ObjectEntry::new_prototype_function_entry(heap, "log2", 1, false);
+    // let max = ObjectEntry::new_prototype_function_entry(heap, "max", 2, true);
+    // let min = ObjectEntry::new_prototype_function_entry(heap, "min", 2, true);
+    // let pow = ObjectEntry::new_prototype_function_entry(heap, "pow", 2, false);
+    // let random = ObjectEntry::new_prototype_function_entry(heap, "random", 0, false);
+    // let round = ObjectEntry::new_prototype_function_entry(heap, "round", 1, false);
+    // let sign = ObjectEntry::new_prototype_function_entry(heap, "sign", 1, false);
+    // let sin = ObjectEntry::new_prototype_function_entry(heap, "sin", 1, false);
+    // let sinh = ObjectEntry::new_prototype_function_entry(heap, "sinh", 1, false);
+    // let sqrt = ObjectEntry::new_prototype_function_entry(heap, "sqrt", 1, false);
+    // let tan = ObjectEntry::new_prototype_function_entry(heap, "tan", 1, false);
+    // let tanh = ObjectEntry::new_prototype_function_entry(heap, "tanh", 1, false);
+    // let trunc = ObjectEntry::new_prototype_function_entry(heap, "trunc", 1, false);
+    // let entries = vec![
+    //     ObjectEntry::new_frozen_entry(heap, "E", e.into()),
+    //     ObjectEntry::new_frozen_entry(heap, "LN10", ln10.into()),
+    //     ObjectEntry::new_frozen_entry(heap, "LN2", ln2.into()),
+    //     ObjectEntry::new_frozen_entry(heap, "LOG10E", log10e.into()),
+    //     ObjectEntry::new_frozen_entry(heap, "LOG2E", log2e.into()),
+    //     ObjectEntry::new_frozen_entry(heap, "PI", pi.into()),
+    //     ObjectEntry::new_frozen_entry(heap, "SQRT1_2", sqrt1_2.into()),
+    //     ObjectEntry::new_frozen_entry(heap, "SQRT2", sqrt2.into()),
+    //     ObjectEntry::new(
+    //         PropertyKey::Symbol(WellKnownSymbolIndexes::ToStringTag.into()),
+    //         ObjectEntryPropertyDescriptor::roxh(Value::from_str(heap, "Math")),
+    //     ),
+    //     abs,
+    //     acos,
+    //     acosh,
+    //     asin,
+    //     asinh,
+    //     atan,
+    //     atanh,
+    //     atan2,
+    //     cbrt,
+    //     ceil,
+    //     clz32,
+    //     cos,
+    //     cosh,
+    //     exp,
+    //     expm1,
+    //     floor,
+    //     fround,
+    //     hypot,
+    //     imul,
+    //     log,
+    //     log1p,
+    //     log10,
+    //     log2,
+    //     max,
+    //     min,
+    //     pow,
+    //     random,
+    //     round,
+    //     sign,
+    //     sin,
+    //     sinh,
+    //     sqrt,
+    //     tan,
+    //     tanh,
+    //     trunc,
+    // ];
+    // let _ = heap.create_object(entries);
 }
 
 fn math_todo(_heap: &mut Heap, _this: Value, _args: &[Value]) -> JsResult<Value> {

--- a/nova_vm/src/heap/number.rs
+++ b/nova_vm/src/heap/number.rs
@@ -1,99 +1,94 @@
-use super::{object::ObjectEntry, CreateHeapData, Heap};
-use crate::{
-    ecmascript::{
-        builtins::{ArgumentsList, Behaviour},
-        execution::{Agent, JsResult, RealmIdentifier},
-        types::{Number, Object, PropertyKey, Value},
-    },
-    heap::{
-        heap_constants::{get_constructor_index, BuiltinObjectIndexes},
-        BuiltinFunctionHeapData, ObjectEntryPropertyDescriptor,
-    },
-    SmallInteger,
+use super::Heap;
+use crate::ecmascript::{
+    builtins::ArgumentsList,
+    execution::{Agent, JsResult},
+    types::{Object, Value},
 };
 
-pub fn initialize_number_heap(heap: &mut Heap) {
-    let entries = vec![
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "EPSILON"),
-            ObjectEntryPropertyDescriptor::roh(heap.create(f64::EPSILON).into()),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "isFinite", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "isInteger", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "isNan", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "isSafeInteger", 1, false),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "MAX_SAFE_INTEGER"),
-            ObjectEntryPropertyDescriptor::roh(Number::from(SmallInteger::MAX_NUMBER).into()),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "MAX_VALUE"),
-            ObjectEntryPropertyDescriptor::roh(heap.create(f64::MAX).into()),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "MIN_SAFE_INTEGER"),
-            ObjectEntryPropertyDescriptor::roh(Number::from(SmallInteger::MIN_NUMBER).into()),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "MIN_VALUE"),
-            ObjectEntryPropertyDescriptor::roh(heap.create(f64::MIN).into()),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "NaN"),
-            ObjectEntryPropertyDescriptor::roh(Value::from(f32::NAN)),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "NEGATIVE_INFINITY"),
-            ObjectEntryPropertyDescriptor::roh(Value::from(f32::NEG_INFINITY)),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "parseFloat", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "parseInt", 2, false),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "POSITIVE_INFINITY"),
-            ObjectEntryPropertyDescriptor::roh(Value::from(f32::INFINITY)),
-        ),
-        ObjectEntry::new_constructor_prototype_entry(
-            heap,
-            BuiltinObjectIndexes::NumberPrototype.into(),
-        ),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::NumberConstructor,
-        true,
-        Some(Object::BuiltinFunction(
-            BuiltinObjectIndexes::FunctionPrototype.into(),
-        )),
-        entries,
-    );
-    heap.builtin_functions
-        [get_constructor_index(BuiltinObjectIndexes::NumberConstructor).into_index()] =
-        Some(BuiltinFunctionHeapData {
-            object_index: Some(BuiltinObjectIndexes::NumberConstructor.into()),
-            length: 1,
-            initial_name: None,
-            behaviour: Behaviour::Constructor(constructor_binding),
-            realm: RealmIdentifier::from_index(0),
-        });
-    let entries = vec![
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "constructor"),
-            ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
-                BuiltinObjectIndexes::NumberConstructor,
-            ))),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "toExponential", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toExponential", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toLocaleString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toPrecision", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "valueOf", 0, false),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::NumberPrototype,
-        true,
-        Some(Object::Object(BuiltinObjectIndexes::ObjectPrototype.into())),
-        entries,
-    );
+pub fn initialize_number_heap(_heap: &mut Heap) {
+    // let entries = vec![
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "EPSILON"),
+    //         ObjectEntryPropertyDescriptor::roh(heap.create(f64::EPSILON).into()),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "isFinite", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "isInteger", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "isNan", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "isSafeInteger", 1, false),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "MAX_SAFE_INTEGER"),
+    //         ObjectEntryPropertyDescriptor::roh(Number::from(SmallInteger::MAX_NUMBER).into()),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "MAX_VALUE"),
+    //         ObjectEntryPropertyDescriptor::roh(heap.create(f64::MAX).into()),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "MIN_SAFE_INTEGER"),
+    //         ObjectEntryPropertyDescriptor::roh(Number::from(SmallInteger::MIN_NUMBER).into()),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "MIN_VALUE"),
+    //         ObjectEntryPropertyDescriptor::roh(heap.create(f64::MIN).into()),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "NaN"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::from(f32::NAN)),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "NEGATIVE_INFINITY"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::from(f32::NEG_INFINITY)),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "parseFloat", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "parseInt", 2, false),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "POSITIVE_INFINITY"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::from(f32::INFINITY)),
+    //     ),
+    //     ObjectEntry::new_constructor_prototype_entry(
+    //         heap,
+    //         IntrinsicObjectIndexes::NumberPrototype.into(),
+    //     ),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::NumberConstructor,
+    //     true,
+    //     Some(Object::BuiltinFunction(
+    //         IntrinsicObjectIndexes::FunctionPrototype.into(),
+    //     )),
+    //     entries,
+    // );
+    // heap.builtin_functions
+    //     [get_constructor_index(IntrinsicObjectIndexes::NumberConstructor).into_index()] =
+    //     Some(BuiltinFunctionHeapData {
+    //         object_index: Some(IntrinsicObjectIndexes::NumberConstructor.into()),
+    //         length: 1,
+    //         initial_name: None,
+    //         behaviour: Behaviour::Constructor(constructor_binding),
+    //         realm: RealmIdentifier::from_index(0),
+    //     });
+    // let entries = vec![
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "constructor"),
+    //         ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
+    //             IntrinsicObjectIndexes::NumberConstructor,
+    //         ))),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toExponential", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toExponential", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toLocaleString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toPrecision", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "valueOf", 0, false),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::NumberPrototype,
+    //     true,
+    //     Some(Object::Object(
+    //         IntrinsicObjectIndexes::ObjectPrototype.into(),
+    //     )),
+    //     entries,
+    // );
 }
 
 fn constructor_binding(

--- a/nova_vm/src/heap/object.rs
+++ b/nova_vm/src/heap/object.rs
@@ -1,75 +1,18 @@
-use super::indexes::{ObjectIndex, SymbolIndex};
+use super::indexes::ObjectIndex;
 use crate::{
     ecmascript::{
-        builtins::{ArgumentsList, Behaviour},
-        execution::{Agent, JsResult, RealmIdentifier},
+        builtins::ArgumentsList,
+        execution::{Agent, JsResult},
         types::{Function, Object, PropertyDescriptor, PropertyKey, Value},
     },
-    heap::{
-        heap_constants::{get_constructor_index, BuiltinObjectIndexes},
-        BuiltinFunctionHeapData, Heap,
-    },
+    heap::Heap,
 };
-use std::{fmt::Debug, vec};
+use std::fmt::Debug;
 
 #[derive(Debug)]
 pub(crate) struct ObjectEntry {
     pub key: PropertyKey,
     pub value: ObjectEntryPropertyDescriptor,
-}
-
-impl ObjectEntry {
-    pub fn new(key: PropertyKey, value: ObjectEntryPropertyDescriptor) -> Self {
-        ObjectEntry { key, value }
-    }
-
-    pub fn new_prototype_function_entry(
-        heap: &mut Heap,
-        name: &str,
-        length: u8,
-        uses_arguments: bool,
-        // behaviour: Behaviour,
-    ) -> Self {
-        let key = PropertyKey::from_str(heap, name);
-        let name = key.into_value();
-        let func_index = heap.create_function(name, length, uses_arguments);
-        let value = ObjectEntryPropertyDescriptor::rwxh(Value::BuiltinFunction(func_index));
-        ObjectEntry { key, value }
-    }
-
-    pub fn new_prototype_symbol_function_entry(
-        heap: &mut Heap,
-        name: &str,
-        symbol_index: SymbolIndex,
-        length: u8,
-        uses_arguments: bool,
-        // behaviour: Behaviour,
-    ) -> Self {
-        let name = Value::from_str(heap, name);
-        let key = PropertyKey::Symbol(symbol_index);
-        let func_index = heap.create_function(name, length, uses_arguments);
-        let value = ObjectEntryPropertyDescriptor::roxh(Value::BuiltinFunction(func_index));
-        ObjectEntry { key, value }
-    }
-
-    pub fn new_constructor_prototype_entry(heap: &mut Heap, idx: ObjectIndex) -> Self {
-        ObjectEntry {
-            key: PropertyKey::from_str(heap, "prototype"),
-            value: ObjectEntryPropertyDescriptor::Data {
-                value: Value::Object(idx),
-                writable: false,
-                enumerable: false,
-                configurable: false,
-            },
-        }
-    }
-
-    pub fn new_frozen_entry(heap: &mut Heap, key: &str, value: Value) -> Self {
-        ObjectEntry {
-            key: PropertyKey::from_str(heap, key),
-            value: ObjectEntryPropertyDescriptor::roh(value),
-        }
-    }
 }
 
 impl From<PropertyDescriptor> for ObjectEntryPropertyDescriptor {
@@ -239,67 +182,72 @@ impl ObjectEntryPropertyDescriptor {
     }
 }
 
-pub fn initialize_object_heap(heap: &mut Heap) {
-    let entries = vec![
-        ObjectEntry::new_prototype_function_entry(heap, "assign", 1, true),
-        ObjectEntry::new_prototype_function_entry(heap, "create", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "defineProperties", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "defineProperty", 3, false),
-        ObjectEntry::new_prototype_function_entry(heap, "entries", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "freeze", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "fromEntries", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getOwnPropertyDescriptor", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getOwnPropertyDescriptors", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getOwnPropertyNames", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getOwnPropertySymbols", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "getPrototypeOf", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "hasOwn", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "is", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "isExtensible", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "isFrozen", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "isSealed", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "keys", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "preventExtensions", 1, false),
-        ObjectEntry::new_constructor_prototype_entry(
-            heap,
-            BuiltinObjectIndexes::ObjectPrototype.into(),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "seal", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "setPrototypeOf", 2, false),
-        ObjectEntry::new_prototype_function_entry(heap, "values", 1, false),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::ObjectConstructor,
-        true,
-        Some(Object::BuiltinFunction(
-            BuiltinObjectIndexes::FunctionPrototype.into(),
-        )),
-        entries,
-    );
-    heap.builtin_functions
-        [get_constructor_index(BuiltinObjectIndexes::ObjectConstructor).into_index()] =
-        Some(BuiltinFunctionHeapData {
-            object_index: Some(BuiltinObjectIndexes::ObjectConstructor.into()),
-            length: 1,
-            initial_name: None,
-            behaviour: Behaviour::Constructor(object_constructor_binding),
-            realm: RealmIdentifier::from_index(0),
-        });
-    let entries = vec![
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "constructor"),
-            ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
-                BuiltinObjectIndexes::ObjectConstructor,
-            ))),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "hasOwnProperty", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "isPrototypeOf", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "propertyIsEnumerable", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toLocaleString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "valueOf", 0, false),
-    ];
-    heap.insert_builtin_object(BuiltinObjectIndexes::ObjectConstructor, true, None, entries);
+pub fn initialize_object_heap(_heap: &mut Heap) {
+    // let entries = vec![
+    //     ObjectEntry::new_prototype_function_entry(heap, "assign", 1, true),
+    //     ObjectEntry::new_prototype_function_entry(heap, "create", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "defineProperties", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "defineProperty", 3, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "entries", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "freeze", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "fromEntries", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getOwnPropertyDescriptor", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getOwnPropertyDescriptors", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getOwnPropertyNames", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getOwnPropertySymbols", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "getPrototypeOf", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "hasOwn", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "is", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "isExtensible", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "isFrozen", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "isSealed", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "keys", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "preventExtensions", 1, false),
+    //     ObjectEntry::new_constructor_prototype_entry(
+    //         heap,
+    //         IntrinsicObjectIndexes::ObjectPrototype.into(),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "seal", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "setPrototypeOf", 2, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "values", 1, false),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::ObjectConstructor,
+    //     true,
+    //     Some(Object::BuiltinFunction(
+    //         IntrinsicObjectIndexes::FunctionPrototype.into(),
+    //     )),
+    //     entries,
+    // );
+    // heap.builtin_functions
+    //     [get_constructor_index(IntrinsicObjectIndexes::ObjectConstructor).into_index()] =
+    //     Some(BuiltinFunctionHeapData {
+    //         object_index: Some(IntrinsicObjectIndexes::ObjectConstructor.into()),
+    //         length: 1,
+    //         initial_name: None,
+    //         behaviour: Behaviour::Constructor(object_constructor_binding),
+    //         realm: RealmIdentifier::from_index(0),
+    //     });
+    // let entries = vec![
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "constructor"),
+    //         ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
+    //             IntrinsicObjectIndexes::ObjectConstructor,
+    //         ))),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "hasOwnProperty", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "isPrototypeOf", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "propertyIsEnumerable", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toLocaleString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "valueOf", 0, false),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::ObjectConstructor,
+    //     true,
+    //     None,
+    //     entries,
+    // );
 }
 
 fn object_constructor_binding(

--- a/nova_vm/src/heap/regexp.rs
+++ b/nova_vm/src/heap/regexp.rs
@@ -1,14 +1,11 @@
-use super::{heap_constants::WellKnownSymbolIndexes, indexes::ObjectIndex, object::ObjectEntry};
+use super::indexes::ObjectIndex;
 use crate::{
     ecmascript::{
-        builtins::{ArgumentsList, Behaviour},
-        execution::{Agent, JsResult, RealmIdentifier},
-        types::{BuiltinFunctionHeapData, Function, Object, PropertyKey, Value},
+        builtins::ArgumentsList,
+        execution::{Agent, JsResult},
+        types::{Object, Value},
     },
-    heap::{
-        heap_constants::{get_constructor_index, BuiltinObjectIndexes},
-        Heap, ObjectEntryPropertyDescriptor,
-    },
+    heap::Heap,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -17,97 +14,99 @@ pub struct RegExpHeapData {
     // pub(super) _regex: RegExp,
 }
 
-pub fn initialize_regexp_heap(heap: &mut Heap) {
-    let species_function_name = Value::from_str(heap, "get [Symbol.species]");
-    let entries = vec![
-        ObjectEntry::new_constructor_prototype_entry(
-            heap,
-            BuiltinObjectIndexes::RegExpPrototype.into(),
-        ),
-        ObjectEntry::new(
-            PropertyKey::Symbol(WellKnownSymbolIndexes::Species.into()),
-            ObjectEntryPropertyDescriptor::ReadOnly {
-                get: Function::BuiltinFunction(heap.create_function(
-                    species_function_name,
-                    0,
-                    false,
-                )),
-                enumerable: false,
-                configurable: true,
-            },
-        ),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::RegExpConstructor,
-        true,
-        Some(Object::BuiltinFunction(
-            BuiltinObjectIndexes::FunctionPrototype.into(),
-        )),
-        entries,
-    );
-    heap.builtin_functions
-        [get_constructor_index(BuiltinObjectIndexes::RegExpConstructor).into_index()] =
-        Some(BuiltinFunctionHeapData {
-            object_index: Some(BuiltinObjectIndexes::RegExpConstructor.into()),
-            length: 1,
-            initial_name: None,
-            behaviour: Behaviour::Constructor(constructor_binding),
-            realm: RealmIdentifier::from_index(0),
-        });
-    let entries = vec![
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "constructor"),
-            ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
-                BuiltinObjectIndexes::RegExpConstructor,
-            ))),
-        ),
-        // TODO: Write out all the getters
-        ObjectEntry::new_prototype_function_entry(heap, "exec", 1, false),
-        // TODO: These symbol function properties are actually rwxh, this helper generates roxh instead.
-        ObjectEntry::new_prototype_symbol_function_entry(
-            heap,
-            "[Symbol.match]",
-            WellKnownSymbolIndexes::Match.into(),
-            1,
-            false,
-        ),
-        ObjectEntry::new_prototype_symbol_function_entry(
-            heap,
-            "[Symbol.matchAll]",
-            WellKnownSymbolIndexes::MatchAll.into(),
-            1,
-            false,
-        ),
-        ObjectEntry::new_prototype_symbol_function_entry(
-            heap,
-            "[Symbol.replace]",
-            WellKnownSymbolIndexes::Replace.into(),
-            2,
-            false,
-        ),
-        ObjectEntry::new_prototype_symbol_function_entry(
-            heap,
-            "[Symbol.search]",
-            WellKnownSymbolIndexes::Search.into(),
-            1,
-            false,
-        ),
-        ObjectEntry::new_prototype_symbol_function_entry(
-            heap,
-            "[Symbol.split]",
-            WellKnownSymbolIndexes::Split.into(),
-            2,
-            false,
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "test", 1, false),
-        ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::RegExpPrototype,
-        true,
-        Some(Object::Object(BuiltinObjectIndexes::ObjectPrototype.into())),
-        entries,
-    );
+pub fn initialize_regexp_heap(_heap: &mut Heap) {
+    // let species_function_name = Value::from_str(heap, "get [Symbol.species]");
+    // let entries = vec![
+    //     ObjectEntry::new_constructor_prototype_entry(
+    //         heap,
+    //         IntrinsicObjectIndexes::RegExpPrototype.into(),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::Symbol(WellKnownSymbolIndexes::Species.into()),
+    //         ObjectEntryPropertyDescriptor::ReadOnly {
+    //             get: Function::BuiltinFunction(heap.create_function(
+    //                 species_function_name,
+    //                 0,
+    //                 false,
+    //             )),
+    //             enumerable: false,
+    //             configurable: true,
+    //         },
+    //     ),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::RegExpConstructor,
+    //     true,
+    //     Some(Object::BuiltinFunction(
+    //         IntrinsicObjectIndexes::FunctionPrototype.into(),
+    //     )),
+    //     entries,
+    // );
+    // heap.builtin_functions
+    //     [get_constructor_index(IntrinsicObjectIndexes::RegExpConstructor).into_index()] =
+    //     Some(BuiltinFunctionHeapData {
+    //         object_index: Some(IntrinsicObjectIndexes::RegExpConstructor.into()),
+    //         length: 1,
+    //         initial_name: None,
+    //         behaviour: Behaviour::Constructor(constructor_binding),
+    //         realm: RealmIdentifier::from_index(0),
+    //     });
+    // let entries = vec![
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "constructor"),
+    //         ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
+    //             IntrinsicObjectIndexes::RegExpConstructor,
+    //         ))),
+    //     ),
+    //     // TODO: Write out all the getters
+    //     ObjectEntry::new_prototype_function_entry(heap, "exec", 1, false),
+    //     // TODO: These symbol function properties are actually rwxh, this helper generates roxh instead.
+    //     ObjectEntry::new_prototype_symbol_function_entry(
+    //         heap,
+    //         "[Symbol.match]",
+    //         WellKnownSymbolIndexes::Match.into(),
+    //         1,
+    //         false,
+    //     ),
+    //     ObjectEntry::new_prototype_symbol_function_entry(
+    //         heap,
+    //         "[Symbol.matchAll]",
+    //         WellKnownSymbolIndexes::MatchAll.into(),
+    //         1,
+    //         false,
+    //     ),
+    //     ObjectEntry::new_prototype_symbol_function_entry(
+    //         heap,
+    //         "[Symbol.replace]",
+    //         WellKnownSymbolIndexes::Replace.into(),
+    //         2,
+    //         false,
+    //     ),
+    //     ObjectEntry::new_prototype_symbol_function_entry(
+    //         heap,
+    //         "[Symbol.search]",
+    //         WellKnownSymbolIndexes::Search.into(),
+    //         1,
+    //         false,
+    //     ),
+    //     ObjectEntry::new_prototype_symbol_function_entry(
+    //         heap,
+    //         "[Symbol.split]",
+    //         WellKnownSymbolIndexes::Split.into(),
+    //         2,
+    //         false,
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "test", 1, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::RegExpPrototype,
+    //     true,
+    //     Some(Object::Object(
+    //         IntrinsicObjectIndexes::ObjectPrototype.into(),
+    //     )),
+    //     entries,
+    // );
 }
 
 fn constructor_binding(

--- a/nova_vm/src/heap/string.rs
+++ b/nova_vm/src/heap/string.rs
@@ -1,41 +1,40 @@
 use crate::{
     ecmascript::{
-        builtins::{ArgumentsList, Behaviour},
-        execution::{Agent, JsResult, RealmIdentifier},
+        builtins::ArgumentsList,
+        execution::{Agent, JsResult},
         types::{Object, Value},
     },
-    heap::{
-        heap_constants::{get_constructor_index, BuiltinObjectIndexes},
-        BuiltinFunctionHeapData, Heap,
-    },
+    heap::Heap,
 };
 
-pub fn initialize_string_heap(heap: &mut Heap) {
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::StringConstructor,
-        true,
-        Some(Object::BuiltinFunction(
-            BuiltinObjectIndexes::FunctionPrototype.into(),
-        )),
-        // TODO: Methods and properties
-        Vec::with_capacity(0),
-    );
-    heap.builtin_functions
-        [get_constructor_index(BuiltinObjectIndexes::StringConstructor).into_index()] =
-        Some(BuiltinFunctionHeapData {
-            object_index: Some(BuiltinObjectIndexes::StringConstructor.into()),
-            length: 1,
-            initial_name: None,
-            behaviour: Behaviour::Constructor(constructor_binding),
-            realm: RealmIdentifier::from_index(0),
-        });
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::StringPrototype,
-        true,
-        Some(Object::Object(BuiltinObjectIndexes::ObjectPrototype.into())),
-        // TODO: Methods and properties
-        Vec::with_capacity(0),
-    );
+pub fn initialize_string_heap(_heap: &mut Heap) {
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::StringConstructor,
+    //     true,
+    //     Some(Object::BuiltinFunction(
+    //         IntrinsicObjectIndexes::FunctionPrototype.into(),
+    //     )),
+    //     // TODO: Methods and properties
+    //     Vec::with_capacity(0),
+    // );
+    // heap.builtin_functions
+    //     [get_constructor_index(IntrinsicObjectIndexes::StringConstructor).into_index()] =
+    //     Some(BuiltinFunctionHeapData {
+    //         object_index: Some(IntrinsicObjectIndexes::StringConstructor.into()),
+    //         length: 1,
+    //         initial_name: None,
+    //         behaviour: Behaviour::Constructor(constructor_binding),
+    //         realm: RealmIdentifier::from_index(0),
+    //     });
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::StringPrototype,
+    //     true,
+    //     Some(Object::Object(
+    //         IntrinsicObjectIndexes::ObjectPrototype.into(),
+    //     )),
+    //     // TODO: Methods and properties
+    //     Vec::with_capacity(0),
+    // );
 }
 
 fn constructor_binding(

--- a/nova_vm/src/heap/symbol.rs
+++ b/nova_vm/src/heap/symbol.rs
@@ -1,14 +1,10 @@
-use super::{indexes::BuiltinFunctionIndex, object::ObjectEntry, CreateHeapData};
 use crate::{
     ecmascript::{
-        builtins::{ArgumentsList, Behaviour},
-        execution::{Agent, JsResult, RealmIdentifier},
-        types::{Function, Object, PropertyKey, String, Value},
+        builtins::ArgumentsList,
+        execution::{Agent, JsResult},
+        types::{Object, String, Value},
     },
-    heap::{
-        heap_constants::{get_constructor_index, BuiltinObjectIndexes, WellKnownSymbolIndexes},
-        BuiltinFunctionHeapData, Heap, ObjectEntryPropertyDescriptor,
-    },
+    heap::Heap,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -16,195 +12,197 @@ pub struct SymbolHeapData {
     pub(crate) descriptor: Option<String>,
 }
 
-pub fn initialize_symbol_heap(heap: &mut Heap) {
-    // AsyncIterator
-    heap.symbols[WellKnownSymbolIndexes::AsyncIterator as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.asyncIterator")),
-    });
-    // HasInstance
-    heap.symbols[WellKnownSymbolIndexes::HasInstance as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.hasInstance")),
-    });
-    // IsConcatSpreadable
-    heap.symbols[WellKnownSymbolIndexes::IsConcatSpreadable as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.isConcatSpreadable")),
-    });
-    // Iterator
-    heap.symbols[WellKnownSymbolIndexes::Iterator as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.iterator")),
-    });
-    // Match
-    heap.symbols[WellKnownSymbolIndexes::Match as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.match")),
-    });
-    // MatchAll
-    heap.symbols[WellKnownSymbolIndexes::MatchAll as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.matchAll")),
-    });
-    // Replace
-    heap.symbols[WellKnownSymbolIndexes::Replace as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.replace")),
-    });
-    // Search
-    heap.symbols[WellKnownSymbolIndexes::Search as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.search")),
-    });
-    // Species
-    heap.symbols[WellKnownSymbolIndexes::Species as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.species")),
-    });
-    // Split
-    heap.symbols[WellKnownSymbolIndexes::Split as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.split")),
-    });
-    // ToPrimitive
-    heap.symbols[WellKnownSymbolIndexes::ToPrimitive as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.toPrimitive")),
-    });
-    // ToStringTag
-    heap.symbols[WellKnownSymbolIndexes::ToStringTag as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.toStringTag")),
-    });
-    // Unscopables
-    heap.symbols[WellKnownSymbolIndexes::Unscopables as usize] = Some(SymbolHeapData {
-        descriptor: Some(heap.create("Symbol.unscopables")),
-    });
+pub fn initialize_symbol_heap(_heap: &mut Heap) {
+    // // AsyncIterator
+    // heap.symbols[WellKnownSymbolIndexes::AsyncIterator as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.asyncIterator")),
+    // });
+    // // HasInstance
+    // heap.symbols[WellKnownSymbolIndexes::HasInstance as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.hasInstance")),
+    // });
+    // // IsConcatSpreadable
+    // heap.symbols[WellKnownSymbolIndexes::IsConcatSpreadable as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.isConcatSpreadable")),
+    // });
+    // // Iterator
+    // heap.symbols[WellKnownSymbolIndexes::Iterator as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.iterator")),
+    // });
+    // // Match
+    // heap.symbols[WellKnownSymbolIndexes::Match as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.match")),
+    // });
+    // // MatchAll
+    // heap.symbols[WellKnownSymbolIndexes::MatchAll as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.matchAll")),
+    // });
+    // // Replace
+    // heap.symbols[WellKnownSymbolIndexes::Replace as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.replace")),
+    // });
+    // // Search
+    // heap.symbols[WellKnownSymbolIndexes::Search as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.search")),
+    // });
+    // // Species
+    // heap.symbols[WellKnownSymbolIndexes::Species as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.species")),
+    // });
+    // // Split
+    // heap.symbols[WellKnownSymbolIndexes::Split as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.split")),
+    // });
+    // // ToPrimitive
+    // heap.symbols[WellKnownSymbolIndexes::ToPrimitive as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.toPrimitive")),
+    // });
+    // // ToStringTag
+    // heap.symbols[WellKnownSymbolIndexes::ToStringTag as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.toStringTag")),
+    // });
+    // // Unscopables
+    // heap.symbols[WellKnownSymbolIndexes::Unscopables as usize] = Some(SymbolHeapData {
+    //     descriptor: Some(heap.create("Symbol.unscopables")),
+    // });
 
-    let entries = vec![
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "asyncIterator"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(
-                WellKnownSymbolIndexes::AsyncIterator.into(),
-            )),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "for", 1, false),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "hasInstance"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(
-                WellKnownSymbolIndexes::HasInstance.into(),
-            )),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "isConcatSpreadable"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(
-                WellKnownSymbolIndexes::IsConcatSpreadable.into(),
-            )),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "iterator"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(
-                WellKnownSymbolIndexes::Iterator.into(),
-            )),
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "keyFor", 1, false),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "Match"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(WellKnownSymbolIndexes::Match.into())),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "MatchAll"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(
-                WellKnownSymbolIndexes::MatchAll.into(),
-            )),
-        ),
-        ObjectEntry::new_constructor_prototype_entry(
-            heap,
-            BuiltinObjectIndexes::SymbolPrototype.into(),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "Replace"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(
-                WellKnownSymbolIndexes::Replace.into(),
-            )),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "Search"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(
-                WellKnownSymbolIndexes::Search.into(),
-            )),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "Species"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(
-                WellKnownSymbolIndexes::Species.into(),
-            )),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "Split"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(WellKnownSymbolIndexes::Split.into())),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "ToPrimitive"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(
-                WellKnownSymbolIndexes::ToPrimitive.into(),
-            )),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "ToStringTag"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(
-                WellKnownSymbolIndexes::ToStringTag.into(),
-            )),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "Unscopables"),
-            ObjectEntryPropertyDescriptor::roh(Value::Symbol(
-                WellKnownSymbolIndexes::Unscopables.into(),
-            )),
-        ),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::SymbolConstructor,
-        true,
-        Some(Object::BuiltinFunction(
-            BuiltinObjectIndexes::FunctionPrototype.into(),
-        )),
-        entries,
-    );
-    heap.builtin_functions
-        [get_constructor_index(BuiltinObjectIndexes::SymbolConstructor).into_index()] =
-        Some(BuiltinFunctionHeapData {
-            object_index: Some(BuiltinObjectIndexes::SymbolConstructor.into()),
-            length: 1,
-            initial_name: None,
-            behaviour: Behaviour::Constructor(constructor_binding),
-            realm: RealmIdentifier::from_index(0),
-        });
-    let entries = vec![
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "constructor"),
-            ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
-                BuiltinObjectIndexes::SymbolConstructor,
-            ))),
-        ),
-        ObjectEntry::new(
-            PropertyKey::from_str(heap, "description"),
-            // TODO: create description getter function
-            ObjectEntryPropertyDescriptor::ReadOnly {
-                get: Function::BuiltinFunction(BuiltinFunctionIndex::from_index(0)),
-                enumerable: false,
-                configurable: true,
-            },
-        ),
-        ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
-        ObjectEntry::new_prototype_function_entry(heap, "valueOf", 0, false),
-        ObjectEntry::new_prototype_symbol_function_entry(
-            heap,
-            "[Symbol.toPrimitive]",
-            WellKnownSymbolIndexes::ToPrimitive.into(),
-            1,
-            false,
-        ),
-        ObjectEntry::new(
-            PropertyKey::Symbol(WellKnownSymbolIndexes::ToStringTag.into()),
-            ObjectEntryPropertyDescriptor::roxh(Value::from_str(heap, "Symbol")),
-        ),
-    ];
-    heap.insert_builtin_object(
-        BuiltinObjectIndexes::SymbolPrototype,
-        true,
-        Some(Object::Object(BuiltinObjectIndexes::ObjectPrototype.into())),
-        entries,
-    );
+    // let entries = vec![
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "asyncIterator"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(
+    //             WellKnownSymbolIndexes::AsyncIterator.into(),
+    //         )),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "for", 1, false),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "hasInstance"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(
+    //             WellKnownSymbolIndexes::HasInstance.into(),
+    //         )),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "isConcatSpreadable"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(
+    //             WellKnownSymbolIndexes::IsConcatSpreadable.into(),
+    //         )),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "iterator"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(
+    //             WellKnownSymbolIndexes::Iterator.into(),
+    //         )),
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "keyFor", 1, false),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "Match"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(WellKnownSymbolIndexes::Match.into())),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "MatchAll"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(
+    //             WellKnownSymbolIndexes::MatchAll.into(),
+    //         )),
+    //     ),
+    //     ObjectEntry::new_constructor_prototype_entry(
+    //         heap,
+    //         IntrinsicObjectIndexes::SymbolPrototype.into(),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "Replace"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(
+    //             WellKnownSymbolIndexes::Replace.into(),
+    //         )),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "Search"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(
+    //             WellKnownSymbolIndexes::Search.into(),
+    //         )),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "Species"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(
+    //             WellKnownSymbolIndexes::Species.into(),
+    //         )),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "Split"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(WellKnownSymbolIndexes::Split.into())),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "ToPrimitive"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(
+    //             WellKnownSymbolIndexes::ToPrimitive.into(),
+    //         )),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "ToStringTag"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(
+    //             WellKnownSymbolIndexes::ToStringTag.into(),
+    //         )),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "Unscopables"),
+    //         ObjectEntryPropertyDescriptor::roh(Value::Symbol(
+    //             WellKnownSymbolIndexes::Unscopables.into(),
+    //         )),
+    //     ),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::SymbolConstructor,
+    //     true,
+    //     Some(Object::BuiltinFunction(
+    //         IntrinsicObjectIndexes::FunctionPrototype.into(),
+    //     )),
+    //     entries,
+    // );
+    // heap.builtin_functions
+    //     [get_constructor_index(IntrinsicObjectIndexes::SymbolConstructor).into_index()] =
+    //     Some(BuiltinFunctionHeapData {
+    //         object_index: Some(IntrinsicObjectIndexes::SymbolConstructor.into()),
+    //         length: 1,
+    //         initial_name: None,
+    //         behaviour: Behaviour::Constructor(constructor_binding),
+    //         realm: RealmIdentifier::from_index(0),
+    //     });
+    // let entries = vec![
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "constructor"),
+    //         ObjectEntryPropertyDescriptor::rwx(Value::BuiltinFunction(get_constructor_index(
+    //             IntrinsicObjectIndexes::SymbolConstructor,
+    //         ))),
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::from_str(heap, "description"),
+    //         // TODO: create description getter function
+    //         ObjectEntryPropertyDescriptor::ReadOnly {
+    //             get: Function::BuiltinFunction(BuiltinFunctionIndex::from_index(0)),
+    //             enumerable: false,
+    //             configurable: true,
+    //         },
+    //     ),
+    //     ObjectEntry::new_prototype_function_entry(heap, "toString", 0, false),
+    //     ObjectEntry::new_prototype_function_entry(heap, "valueOf", 0, false),
+    //     ObjectEntry::new_prototype_symbol_function_entry(
+    //         heap,
+    //         "[Symbol.toPrimitive]",
+    //         WellKnownSymbolIndexes::ToPrimitive.into(),
+    //         1,
+    //         false,
+    //     ),
+    //     ObjectEntry::new(
+    //         PropertyKey::Symbol(WellKnownSymbolIndexes::ToStringTag.into()),
+    //         ObjectEntryPropertyDescriptor::roxh(Value::from_str(heap, "Symbol")),
+    //     ),
+    // ];
+    // heap.insert_builtin_object(
+    //     IntrinsicObjectIndexes::SymbolPrototype,
+    //     true,
+    //     Some(Object::Object(
+    //         IntrinsicObjectIndexes::ObjectPrototype.into(),
+    //     )),
+    //     entries,
+    // );
 }
 
 fn constructor_binding(


### PR DESCRIPTION
Building on top of #102 this PR refactors the `Intrinsics` struct to be a lot smaller (only 8 bytes now) and fills it in to fully define the all the intrinsic objects, constructors and functions mentioned in the spec.