### PR TITLE
chore(ecmasript): Rename internal method and slot APIs with `internal_` prefix

### DIFF
--- a/nova_vm/src/ecmascript/abstract_operations/testing_and_comparison.rs
+++ b/nova_vm/src/ecmascript/abstract_operations/testing_and_comparison.rs
@@ -91,7 +91,7 @@ pub(crate) fn is_constructor(agent: &mut Agent, constructor: Value) -> bool {
 /// added to O.
 pub(crate) fn is_extensible(agent: &mut Agent, o: Object) -> JsResult<bool> {
     // 1. Return ? O.[[IsExtensible]]().
-    o.is_extensible(agent)
+    o.internal_is_extensible(agent)
 }
 
 pub(crate) fn is_same_type<V1: Copy + Into<Value>, V2: Copy + Into<Value>>(x: V1, y: V2) -> bool {

--- a/nova_vm/src/ecmascript/builtins/array/abstract_operations.rs
+++ b/nova_vm/src/ecmascript/builtins/array/abstract_operations.rs
@@ -120,7 +120,9 @@ pub fn array_set_length(agent: &mut Agent, a: Array, desc: PropertyDescriptor) -
     debug_assert!(old_len > new_len);
     for i in old_len..new_len {
         // a. Let deleteSucceeded be ! A.[[Delete]](P).
-        let delete_succeeded = a.delete(agent, PropertyKey::Integer(i.into())).unwrap();
+        let delete_succeeded = a
+            .internal_delete(agent, PropertyKey::Integer(i.into()))
+            .unwrap();
         // b. If deleteSucceeded is false, then
         if !delete_succeeded {
             let array_heap_data = agent.heap.get_mut(a.0);

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -162,26 +162,26 @@ impl From<BuiltinFunction> for Function {
 }
 
 impl OrdinaryObjectInternalSlots for BuiltinFunction {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).extensible(agent)
+            OrdinaryObject::from(object_index).internal_extensible(agent)
         } else {
             true
         }
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_extensible(agent, value)
+            OrdinaryObject::from(object_index).internal_set_extensible(agent, value)
         } else {
             // Create function base object and set inextensible
             todo!()
         }
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).prototype(agent)
+            OrdinaryObject::from(object_index).internal_prototype(agent)
         } else {
             Some(
                 agent
@@ -193,9 +193,9 @@ impl OrdinaryObjectInternalSlots for BuiltinFunction {
         }
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype(agent, prototype)
         } else {
             // Create function base object and set inextensible
             todo!()
@@ -204,13 +204,17 @@ impl OrdinaryObjectInternalSlots for BuiltinFunction {
 }
 
 impl InternalMethods for BuiltinFunction {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype_of(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype_of(agent, prototype)
         } else {
             // If we're setting %ArrayBuffer.prototype% then we can still avoid creating the ObjectHeapData.
             let current = agent.current_realm().intrinsics().function_prototype();
@@ -221,27 +225,27 @@ impl InternalMethods for BuiltinFunction {
                 // OrdinarySetPrototypeOf 7.b.i: Setting prototype would cause a loop to occur.
                 return Ok(false);
             }
-            self.set_prototype(agent, prototype);
+            self.internal_set_prototype(agent, prototype);
             Ok(true)
         }
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get_own_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_get_own_property(agent, property_key)
         } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
             Ok(Some(PropertyDescriptor {
                 value: Some(agent.heap.get(self.0).length.into()),
@@ -263,14 +267,14 @@ impl InternalMethods for BuiltinFunction {
         }
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
             let prototype = agent.current_realm().intrinsics().array_prototype();
             let length_entry = ObjectEntry {
@@ -346,35 +350,42 @@ impl InternalMethods for BuiltinFunction {
         }
     }
 
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length)
             || property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name)
         {
             Ok(true)
         } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(false), |parent| parent.has_property(agent, property_key))
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(false), |parent| {
+                parent.internal_has_property(agent, property_key)
+            })
         }
     }
 
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get(agent, property_key, receiver)
+            OrdinaryObject::from(object_index).internal_get(agent, property_key, receiver)
         } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
             Ok(agent.heap.get(self.0).length.into())
         } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name) {
             Ok(agent.heap.get(self.0).initial_name.into())
         } else {
-            let parent = self.get_prototype_of(agent)?;
+            let parent = self.internal_get_prototype_of(agent)?;
             parent.map_or(Ok(Value::Undefined), |parent| {
-                parent.get(agent, property_key, receiver)
+                parent.internal_get(agent, property_key, receiver)
             })
         }
     }
 
-    fn set(
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -382,7 +393,7 @@ impl InternalMethods for BuiltinFunction {
         receiver: Value,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set(agent, property_key, value, receiver)
+            OrdinaryObject::from(object_index).internal_set(agent, property_key, value, receiver)
         } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length)
             || property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name)
         {
@@ -390,13 +401,13 @@ impl InternalMethods for BuiltinFunction {
             Ok(false)
         } else {
             let prototype = agent.current_realm().intrinsics().array_prototype();
-            prototype.set(agent, property_key, value, receiver)
+            prototype.internal_set(agent, property_key, value, receiver)
         }
     }
 
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).delete(agent, property_key)
+            OrdinaryObject::from(object_index).internal_delete(agent, property_key)
         } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length)
             || property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name)
         {
@@ -433,9 +444,9 @@ impl InternalMethods for BuiltinFunction {
         }
     }
 
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).own_property_keys(agent)
+            OrdinaryObject::from(object_index).internal_own_property_keys(agent)
         } else {
             Ok(vec![
                 PropertyKey::from(BUILTIN_STRING_MEMORY.length),
@@ -451,7 +462,7 @@ impl InternalMethods for BuiltinFunction {
     /// (a List of ECMAScript language values) and returns either a normal
     /// completion containing an ECMAScript language value or a throw
     /// completion.
-    fn call(
+    fn internal_call(
         self,
         agent: &mut Agent,
         this_argument: Value,
@@ -467,7 +478,7 @@ impl InternalMethods for BuiltinFunction {
     /// the method is present) takes arguments argumentsList (a List of
     /// ECMAScript language values) and newTarget (a constructor) and returns
     /// either a normal completion containing an Object or a throw completion.
-    fn construct(
+    fn internal_construct(
         self,
         agent: &mut Agent,
         arguments_list: ArgumentsList,

--- a/nova_vm/src/ecmascript/builtins/data_view.rs
+++ b/nova_vm/src/ecmascript/builtins/data_view.rs
@@ -53,26 +53,26 @@ impl From<DataView> for Object {
 }
 
 impl OrdinaryObjectInternalSlots for DataView {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).extensible(agent)
+            OrdinaryObject::from(object_index).internal_extensible(agent)
         } else {
             true
         }
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_extensible(agent, value)
+            OrdinaryObject::from(object_index).internal_set_extensible(agent, value)
         } else {
             // Create base object and set inextensible
             todo!()
         }
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).prototype(agent)
+            OrdinaryObject::from(object_index).internal_prototype(agent)
         } else {
             Some(
                 agent
@@ -84,9 +84,9 @@ impl OrdinaryObjectInternalSlots for DataView {
         }
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype(agent, prototype)
         } else {
             // Create base object and set inextensible
             todo!()
@@ -95,13 +95,17 @@ impl OrdinaryObjectInternalSlots for DataView {
 }
 
 impl InternalMethods for DataView {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype_of(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype_of(agent, prototype)
         } else {
             // If we're setting %DataView.prototype% then we can still avoid creating the ObjectHeapData.
             let current = agent.current_realm().intrinsics().data_view_prototype();
@@ -112,40 +116,40 @@ impl InternalMethods for DataView {
                 // OrdinarySetPrototypeOf 7.b.i: Setting prototype would cause a loop to occur.
                 return Ok(false);
             }
-            self.set_prototype(agent, prototype);
+            self.internal_set_prototype(agent, prototype);
             Ok(true)
         }
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get_own_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_get_own_property(agent, property_key)
         } else {
             Ok(None)
         }
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
             let prototype = agent.current_realm().intrinsics().data_view_prototype();
             let new_entry = ObjectEntry {
@@ -160,27 +164,34 @@ impl InternalMethods for DataView {
         }
     }
 
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(false), |parent| parent.has_property(agent, property_key))
-        }
-    }
-
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
-        if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get(agent, property_key, receiver)
-        } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(Value::Undefined), |parent| {
-                parent.get(agent, property_key, receiver)
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(false), |parent| {
+                parent.internal_has_property(agent, property_key)
             })
         }
     }
 
-    fn set(
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
+        if let Some(object_index) = agent.heap.get(self.0).object_index {
+            OrdinaryObject::from(object_index).internal_get(agent, property_key, receiver)
+        } else {
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(Value::Undefined), |parent| {
+                parent.internal_get(agent, property_key, receiver)
+            })
+        }
+    }
+
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -188,25 +199,25 @@ impl InternalMethods for DataView {
         receiver: Value,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set(agent, property_key, value, receiver)
+            OrdinaryObject::from(object_index).internal_set(agent, property_key, value, receiver)
         } else {
             let prototype = agent.current_realm().intrinsics().data_view_prototype();
-            prototype.set(agent, property_key, value, receiver)
+            prototype.internal_set(agent, property_key, value, receiver)
         }
     }
 
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).delete(agent, property_key)
+            OrdinaryObject::from(object_index).internal_delete(agent, property_key)
         } else {
             // Non-existing property
             Ok(true)
         }
     }
 
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).own_property_keys(agent)
+            OrdinaryObject::from(object_index).internal_own_property_keys(agent)
         } else {
             Ok(vec![])
         }

--- a/nova_vm/src/ecmascript/builtins/date.rs
+++ b/nova_vm/src/ecmascript/builtins/date.rs
@@ -83,41 +83,45 @@ impl TryFrom<Object> for Date {
 }
 
 impl OrdinaryObjectInternalSlots for Date {
-    fn extensible(self, _agent: &Agent) -> bool {
+    fn internal_extensible(self, _agent: &Agent) -> bool {
         false
     }
 
-    fn set_extensible(self, _agent: &mut Agent, _value: bool) {
+    fn internal_set_extensible(self, _agent: &mut Agent, _value: bool) {
         todo!()
     }
 
-    fn prototype(self, _agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, _agent: &Agent) -> Option<Object> {
         todo!()
     }
 
-    fn set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {
+    fn internal_set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {
         todo!()
     }
 }
 
 impl InternalMethods for Date {
-    fn get_prototype_of(self, _agent: &mut Agent) -> JsResult<Option<Object>> {
+    fn internal_get_prototype_of(self, _agent: &mut Agent) -> JsResult<Option<Object>> {
         todo!()
     }
 
-    fn set_prototype_of(self, _agent: &mut Agent, _prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        _agent: &mut Agent,
+        _prototype: Option<Object>,
+    ) -> JsResult<bool> {
         todo!()
     }
 
-    fn is_extensible(self, _agent: &mut Agent) -> JsResult<bool> {
+    fn internal_is_extensible(self, _agent: &mut Agent) -> JsResult<bool> {
         todo!()
     }
 
-    fn prevent_extensions(self, _agent: &mut Agent) -> JsResult<bool> {
+    fn internal_prevent_extensions(self, _agent: &mut Agent) -> JsResult<bool> {
         todo!()
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -125,7 +129,7 @@ impl InternalMethods for Date {
         todo!()
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -134,23 +138,32 @@ impl InternalMethods for Date {
         todo!()
     }
 
-    fn has_property(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(
+        self,
+        _agent: &mut Agent,
+        _property_key: PropertyKey,
+    ) -> JsResult<bool> {
         todo!()
     }
 
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
         if let Some(object_index) = agent.heap.get(*self).object_index {
-            OrdinaryObject::from(object_index).get(agent, property_key, receiver)
+            OrdinaryObject::from(object_index).internal_get(agent, property_key, receiver)
         } else {
             agent
                 .current_realm()
                 .intrinsics()
                 .date_prototype()
-                .get(agent, property_key, receiver)
+                .internal_get(agent, property_key, receiver)
         }
     }
 
-    fn set(
+    fn internal_set(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -160,11 +173,11 @@ impl InternalMethods for Date {
         todo!()
     }
 
-    fn delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
         todo!()
     }
 
-    fn own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         todo!()
     }
 }

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -164,23 +164,27 @@ pub(crate) struct OrdinaryFunctionCreateParams<'agent, 'program> {
 }
 
 impl InternalMethods for ECMAScriptFunction {
-    fn get_prototype_of(self, _agent: &mut Agent) -> JsResult<Option<Object>> {
+    fn internal_get_prototype_of(self, _agent: &mut Agent) -> JsResult<Option<Object>> {
         todo!()
     }
 
-    fn set_prototype_of(self, _agent: &mut Agent, _prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        _agent: &mut Agent,
+        _prototype: Option<Object>,
+    ) -> JsResult<bool> {
         todo!()
     }
 
-    fn is_extensible(self, _agent: &mut Agent) -> JsResult<bool> {
+    fn internal_is_extensible(self, _agent: &mut Agent) -> JsResult<bool> {
         todo!()
     }
 
-    fn prevent_extensions(self, _agent: &mut Agent) -> JsResult<bool> {
+    fn internal_prevent_extensions(self, _agent: &mut Agent) -> JsResult<bool> {
         todo!()
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -188,7 +192,7 @@ impl InternalMethods for ECMAScriptFunction {
         todo!()
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -197,11 +201,15 @@ impl InternalMethods for ECMAScriptFunction {
         todo!()
     }
 
-    fn has_property(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(
+        self,
+        _agent: &mut Agent,
+        _property_key: PropertyKey,
+    ) -> JsResult<bool> {
         todo!()
     }
 
-    fn get(
+    fn internal_get(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -210,7 +218,7 @@ impl InternalMethods for ECMAScriptFunction {
         todo!()
     }
 
-    fn set(
+    fn internal_set(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -220,11 +228,11 @@ impl InternalMethods for ECMAScriptFunction {
         todo!()
     }
 
-    fn delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
         todo!()
     }
 
-    fn own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         todo!()
     }
 
@@ -235,7 +243,7 @@ impl InternalMethods for ECMAScriptFunction {
     /// `argumentsList` (a List of ECMAScript language values) and returns
     /// either a normal completion containing an ECMAScript language value or a
     /// throw completion.
-    fn call(
+    fn internal_call(
         self,
         agent: &mut Agent,
         this_argument: Value,
@@ -278,7 +286,7 @@ impl InternalMethods for ECMAScriptFunction {
         result
     }
 
-    fn construct(
+    fn internal_construct(
         self,
         _agent: &mut Agent,
         _arguments_list: ArgumentsList,

--- a/nova_vm/src/ecmascript/builtins/embedder_object.rs
+++ b/nova_vm/src/ecmascript/builtins/embedder_object.rs
@@ -51,42 +51,46 @@ impl From<EmbedderObject> for Object {
 }
 
 impl OrdinaryObjectInternalSlots for EmbedderObject {
-    fn extensible(self, _agent: &Agent) -> bool {
+    fn internal_extensible(self, _agent: &Agent) -> bool {
         todo!();
     }
 
-    fn set_extensible(self, _agent: &mut Agent, _value: bool) {
+    fn internal_set_extensible(self, _agent: &mut Agent, _value: bool) {
         todo!();
     }
 
-    fn prototype(self, _agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, _agent: &Agent) -> Option<Object> {
         todo!();
     }
 
-    fn set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {
+    fn internal_set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {
         todo!();
     }
 }
 
 impl InternalMethods for EmbedderObject {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, _agent: &mut Agent, _prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        _agent: &mut Agent,
+        _prototype: Option<Object>,
+    ) -> JsResult<bool> {
         todo!();
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -94,7 +98,7 @@ impl InternalMethods for EmbedderObject {
         todo!();
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -103,11 +107,15 @@ impl InternalMethods for EmbedderObject {
         todo!();
     }
 
-    fn has_property(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(
+        self,
+        _agent: &mut Agent,
+        _property_key: PropertyKey,
+    ) -> JsResult<bool> {
         todo!();
     }
 
-    fn get(
+    fn internal_get(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -116,7 +124,7 @@ impl InternalMethods for EmbedderObject {
         todo!();
     }
 
-    fn set(
+    fn internal_set(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -126,11 +134,11 @@ impl InternalMethods for EmbedderObject {
         todo!();
     }
 
-    fn delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
         todo!();
     }
 
-    fn own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         todo!();
     }
 }

--- a/nova_vm/src/ecmascript/builtins/error.rs
+++ b/nova_vm/src/ecmascript/builtins/error.rs
@@ -75,41 +75,45 @@ impl TryFrom<Object> for Error {
 }
 
 impl OrdinaryObjectInternalSlots for Error {
-    fn extensible(self, _agent: &Agent) -> bool {
+    fn internal_extensible(self, _agent: &Agent) -> bool {
         false
     }
 
-    fn set_extensible(self, _agent: &mut Agent, _value: bool) {
+    fn internal_set_extensible(self, _agent: &mut Agent, _value: bool) {
         todo!()
     }
 
-    fn prototype(self, _agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, _agent: &Agent) -> Option<Object> {
         todo!()
     }
 
-    fn set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {
+    fn internal_set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {
         todo!()
     }
 }
 
 impl InternalMethods for Error {
-    fn get_prototype_of(self, _agent: &mut Agent) -> JsResult<Option<Object>> {
+    fn internal_get_prototype_of(self, _agent: &mut Agent) -> JsResult<Option<Object>> {
         todo!()
     }
 
-    fn set_prototype_of(self, _agent: &mut Agent, _prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        _agent: &mut Agent,
+        _prototype: Option<Object>,
+    ) -> JsResult<bool> {
         todo!()
     }
 
-    fn is_extensible(self, _agent: &mut Agent) -> JsResult<bool> {
+    fn internal_is_extensible(self, _agent: &mut Agent) -> JsResult<bool> {
         todo!()
     }
 
-    fn prevent_extensions(self, _agent: &mut Agent) -> JsResult<bool> {
+    fn internal_prevent_extensions(self, _agent: &mut Agent) -> JsResult<bool> {
         todo!()
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -117,7 +121,7 @@ impl InternalMethods for Error {
         todo!()
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -126,17 +130,26 @@ impl InternalMethods for Error {
         todo!()
     }
 
-    fn has_property(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(
+        self,
+        _agent: &mut Agent,
+        _property_key: PropertyKey,
+    ) -> JsResult<bool> {
         todo!()
     }
 
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
         if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.toString) {
             agent
                 .current_realm()
                 .intrinsics()
                 .error_prototype()
-                .get(agent, property_key, receiver)
+                .internal_get(agent, property_key, receiver)
         } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name) {
             match agent.heap.get(self.0).kind {
                 ExceptionType::AggregateError => {
@@ -165,7 +178,7 @@ impl InternalMethods for Error {
         }
     }
 
-    fn set(
+    fn internal_set(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -175,11 +188,11 @@ impl InternalMethods for Error {
         todo!()
     }
 
-    fn delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
         todo!()
     }
 
-    fn own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         todo!()
     }
 }

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/object_objects/object_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/object_objects/object_constructor.rs
@@ -375,7 +375,7 @@ impl ObjectConstructor {
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
         let obj = to_object(agent, arguments.get(0))?;
-        obj.get_prototype_of(agent)
+        obj.internal_get_prototype_of(agent)
             .map(|proto| proto.map_or(Value::Null, |proto| proto.into_value()))
     }
 

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/object_objects/object_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/object_objects/object_prototype.rs
@@ -97,7 +97,7 @@ impl ObjectPrototype {
         };
         let o = to_object(agent, this_value)?;
         loop {
-            let proto = v.get_prototype_of(agent)?;
+            let proto = v.internal_get_prototype_of(agent)?;
             if let Some(proto) = proto {
                 v = proto;
                 if same_value(agent, o, v) {
@@ -116,7 +116,7 @@ impl ObjectPrototype {
     ) -> JsResult<Value> {
         let p = to_property_key(agent, arguments.get(0))?;
         let o = to_object(agent, this_value)?;
-        let desc = o.get_own_property(agent, p)?;
+        let desc = o.internal_get_own_property(agent, p)?;
         if let Some(desc) = desc {
             Ok(desc.enumerable.unwrap_or(false).into())
         } else {

--- a/nova_vm/src/ecmascript/builtins/map.rs
+++ b/nova_vm/src/ecmascript/builtins/map.rs
@@ -53,26 +53,26 @@ impl From<Map> for Object {
 }
 
 impl OrdinaryObjectInternalSlots for Map {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).extensible(agent)
+            OrdinaryObject::from(object_index).internal_extensible(agent)
         } else {
             true
         }
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_extensible(agent, value)
+            OrdinaryObject::from(object_index).internal_set_extensible(agent, value)
         } else {
             // Create base object and set inextensible
             todo!()
         }
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).prototype(agent)
+            OrdinaryObject::from(object_index).internal_prototype(agent)
         } else {
             Some(
                 agent
@@ -84,9 +84,9 @@ impl OrdinaryObjectInternalSlots for Map {
         }
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype(agent, prototype)
         } else {
             // Create base object and set inextensible
             todo!()
@@ -95,13 +95,17 @@ impl OrdinaryObjectInternalSlots for Map {
 }
 
 impl InternalMethods for Map {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype_of(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype_of(agent, prototype)
         } else {
             // If we're setting %Map.prototype% then we can still avoid creating the ObjectHeapData.
             let current = agent.current_realm().intrinsics().map_prototype();
@@ -112,40 +116,40 @@ impl InternalMethods for Map {
                 // OrdinarySetPrototypeOf 7.b.i: Setting prototype would cause a loop to occur.
                 return Ok(false);
             }
-            self.set_prototype(agent, prototype);
+            self.internal_set_prototype(agent, prototype);
             Ok(true)
         }
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get_own_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_get_own_property(agent, property_key)
         } else {
             Ok(None)
         }
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
             let prototype = agent.current_realm().intrinsics().map_prototype();
             let new_entry = ObjectEntry {
@@ -160,27 +164,34 @@ impl InternalMethods for Map {
         }
     }
 
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(false), |parent| parent.has_property(agent, property_key))
-        }
-    }
-
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
-        if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get(agent, property_key, receiver)
-        } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(Value::Undefined), |parent| {
-                parent.get(agent, property_key, receiver)
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(false), |parent| {
+                parent.internal_has_property(agent, property_key)
             })
         }
     }
 
-    fn set(
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
+        if let Some(object_index) = agent.heap.get(self.0).object_index {
+            OrdinaryObject::from(object_index).internal_get(agent, property_key, receiver)
+        } else {
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(Value::Undefined), |parent| {
+                parent.internal_get(agent, property_key, receiver)
+            })
+        }
+    }
+
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -188,25 +199,25 @@ impl InternalMethods for Map {
         receiver: Value,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set(agent, property_key, value, receiver)
+            OrdinaryObject::from(object_index).internal_set(agent, property_key, value, receiver)
         } else {
             let prototype = agent.current_realm().intrinsics().map_prototype();
-            prototype.set(agent, property_key, value, receiver)
+            prototype.internal_set(agent, property_key, value, receiver)
         }
     }
 
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).delete(agent, property_key)
+            OrdinaryObject::from(object_index).internal_delete(agent, property_key)
         } else {
             // Non-existing property
             Ok(true)
         }
     }
 
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).own_property_keys(agent)
+            OrdinaryObject::from(object_index).internal_own_property_keys(agent)
         } else {
             Ok(vec![])
         }

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -49,42 +49,46 @@ impl From<Module> for Object {
 }
 
 impl OrdinaryObjectInternalSlots for Module {
-    fn extensible(self, _agent: &Agent) -> bool {
+    fn internal_extensible(self, _agent: &Agent) -> bool {
         todo!();
     }
 
-    fn set_extensible(self, _agent: &mut Agent, _value: bool) {
+    fn internal_set_extensible(self, _agent: &mut Agent, _value: bool) {
         todo!();
     }
 
-    fn prototype(self, _agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, _agent: &Agent) -> Option<Object> {
         todo!();
     }
 
-    fn set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {
+    fn internal_set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {
         todo!();
     }
 }
 
 impl InternalMethods for Module {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, _agent: &mut Agent, _prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        _agent: &mut Agent,
+        _prototype: Option<Object>,
+    ) -> JsResult<bool> {
         todo!();
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -92,7 +96,7 @@ impl InternalMethods for Module {
         todo!();
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -101,11 +105,15 @@ impl InternalMethods for Module {
         todo!();
     }
 
-    fn has_property(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(
+        self,
+        _agent: &mut Agent,
+        _property_key: PropertyKey,
+    ) -> JsResult<bool> {
         todo!();
     }
 
-    fn get(
+    fn internal_get(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -114,7 +122,7 @@ impl InternalMethods for Module {
         todo!();
     }
 
-    fn set(
+    fn internal_set(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -124,11 +132,11 @@ impl InternalMethods for Module {
         todo!();
     }
 
-    fn delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
         todo!();
     }
 
-    fn own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         todo!();
     }
 }

--- a/nova_vm/src/ecmascript/builtins/ordinary.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary.rs
@@ -28,29 +28,33 @@ use super::{
 /// ### [10.1 Ordinary Object Internal Methods and Internal Slots](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots)
 impl InternalMethods for OrdinaryObject {
     /// ### [10.1.1 \[\[GetPrototypeOf\]\] ( )](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof)
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
         Ok(ordinary_get_prototype_of(agent, self.into()))
     }
 
     /// ### [10.1.2 \[\[SetPrototypeOf\]\] ( V )](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-setprototypeof-v)
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool> {
         Ok(ordinary_set_prototype_of(agent, self.into(), prototype))
     }
 
     /// ### [10.1.3 \[\[IsExtensible\]\] ( )](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible)
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
         // 1. Return OrdinaryIsExtensible(O).
         Ok(ordinary_is_extensible(agent, self.into()))
     }
 
     /// ### [10.1.4 \[\[PreventExtensions\]\] ( )](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions)
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
         // 1. Return OrdinaryPreventExtensions(O).
         Ok(ordinary_prevent_extensions(agent, self.into()))
     }
 
     /// ### [10.1.5 \[\[GetOwnProperty\]\] ( P )](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p)
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -60,7 +64,7 @@ impl InternalMethods for OrdinaryObject {
     }
 
     /// ### [10.1.6 \[\[DefineOwnProperty\]\] ( P, Desc )](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc)
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -70,19 +74,24 @@ impl InternalMethods for OrdinaryObject {
     }
 
     /// ### [10.1.7 \[\[HasProperty\]\] ( P )](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p)
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         // 1. Return ? OrdinaryHasProperty(O, P).
         ordinary_has_property(agent, self.into(), property_key)
     }
 
     /// ### [10.1.8 \[\[Get\]\] ( P, Receiver )](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver)
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
         // 1. Return ? OrdinaryGet(O, P, Receiver).
         ordinary_get(agent, self.into(), property_key, receiver)
     }
 
     /// ### [10.1.9 \[\[Set\]\] ( P, V, Receiver )](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver)
-    fn set(
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -94,13 +103,13 @@ impl InternalMethods for OrdinaryObject {
     }
 
     /// ### [10.1.10 \[\[Delete\]\] ( P )](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-delete-p)
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         // 1. Return ? OrdinaryDelete(O, P).
         ordinary_delete(agent, self.into(), property_key)
     }
 
     /// ### [10.1.11 \[\[OwnPropertyKeys\]\] ( )](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys)
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         // 1. Return OrdinaryOwnPropertyKeys(O).
         ordinary_own_property_keys(agent, self.into())
     }
@@ -109,7 +118,7 @@ impl InternalMethods for OrdinaryObject {
 /// ### [10.1.1.1 OrdinaryGetPrototypeOf ( O )](https://tc39.es/ecma262/#sec-ordinarygetprototypeof)
 pub(crate) fn ordinary_get_prototype_of(agent: &mut Agent, object: Object) -> Option<Object> {
     // 1. Return O.[[Prototype]].
-    object.prototype(agent)
+    object.internal_prototype(agent)
 }
 
 /// Implements steps 5 through 7 of OrdinarySetPrototypeOf
@@ -146,7 +155,7 @@ pub(crate) fn ordinary_set_prototype_of_check_loop(
         // }
 
         // ii. Else, set p to p.[[Prototype]].
-        p = p_inner.prototype(agent);
+        p = p_inner.internal_prototype(agent);
     }
     true
 }
@@ -158,7 +167,7 @@ pub(crate) fn ordinary_set_prototype_of(
     prototype: Option<Object>,
 ) -> bool {
     // 1. Let current be O.[[Prototype]].
-    let current = object.prototype(agent);
+    let current = object.internal_prototype(agent);
 
     // 2. If SameValue(V, current) is true, return true.
     match (prototype, current) {
@@ -168,7 +177,7 @@ pub(crate) fn ordinary_set_prototype_of(
     }
 
     // 3. Let extensible be O.[[Extensible]].
-    let extensible = object.extensible(agent);
+    let extensible = object.internal_extensible(agent);
 
     // 4. If extensible is false, return false.
     if !extensible {
@@ -181,7 +190,7 @@ pub(crate) fn ordinary_set_prototype_of(
     }
 
     // 8. Set O.[[Prototype]] to V.
-    object.set_prototype(agent, prototype);
+    object.internal_set_prototype(agent, prototype);
 
     // 9. Return true.
     true
@@ -190,13 +199,13 @@ pub(crate) fn ordinary_set_prototype_of(
 /// ### [10.1.3.1 OrdinaryIsExtensible ( O )](https://tc39.es/ecma262/#sec-ordinaryisextensible)
 pub(crate) fn ordinary_is_extensible(agent: &mut Agent, object: Object) -> bool {
     // 1. Return O.[[Extensible]].
-    object.extensible(agent)
+    object.internal_extensible(agent)
 }
 
 /// ### [10.1.4.1 OrdinaryPreventExtensions ( O )](https://tc39.es/ecma262/#sec-ordinarypreventextensions)
 pub(crate) fn ordinary_prevent_extensions(agent: &mut Agent, object: Object) -> bool {
     // 1. Set O.[[Extensible]] to false.
-    object.set_extensible(agent, false);
+    object.internal_set_extensible(agent, false);
 
     // 2. Return true.
     true
@@ -252,10 +261,10 @@ pub(crate) fn ordinary_define_own_property(
     descriptor: PropertyDescriptor,
 ) -> JsResult<bool> {
     // 1. Let current be ? O.[[GetOwnProperty]](P).
-    let current = object.get_own_property(agent, property_key)?;
+    let current = object.internal_get_own_property(agent, property_key)?;
 
     // 2. Let extensible be ? IsExtensible(O).
-    let extensible = object.extensible(agent);
+    let extensible = object.internal_extensible(agent);
 
     // 3. Return ValidateAndApplyPropertyDescriptor(O, P, extensible, Desc, current).
     validate_and_apply_property_descriptor(
@@ -515,7 +524,7 @@ pub(crate) fn ordinary_has_property(
     property_key: PropertyKey,
 ) -> JsResult<bool> {
     // 1. Let hasOwn be ? O.[[GetOwnProperty]](P).
-    let has_own = object.get_own_property(agent, property_key)?;
+    let has_own = object.internal_get_own_property(agent, property_key)?;
 
     // 2. If hasOwn is not undefined, return true.
     if has_own.is_some() {
@@ -523,12 +532,12 @@ pub(crate) fn ordinary_has_property(
     }
 
     // 3. Let parent be ? O.[[GetPrototypeOf]]().
-    let parent = object.get_prototype_of(agent)?;
+    let parent = object.internal_get_prototype_of(agent)?;
 
     // 4. If parent is not null, then
     if let Some(parent) = parent {
         // a. Return ? parent.[[HasProperty]](P).
-        return parent.has_property(agent, property_key);
+        return parent.internal_has_property(agent, property_key);
     }
 
     // 5. Return false.
@@ -543,16 +552,16 @@ pub(crate) fn ordinary_get(
     receiver: Value,
 ) -> JsResult<Value> {
     // 1. Let desc be ? O.[[GetOwnProperty]](P).
-    let Some(descriptor) = object.get_own_property(agent, property_key)? else {
+    let Some(descriptor) = object.internal_get_own_property(agent, property_key)? else {
         // 2. If desc is undefined, then
 
         // a. Let parent be ? O.[[GetPrototypeOf]]().
-        let Some(parent) = object.get_prototype_of(agent)? else {
+        let Some(parent) = object.internal_get_prototype_of(agent)? else {
             return Ok(Value::Undefined);
         };
 
         // c. Return ? parent.[[Get]](P, Receiver).
-        return parent.get(agent, property_key, receiver);
+        return parent.internal_get(agent, property_key, receiver);
     };
 
     // 3. If IsDataDescriptor(desc) is true, return desc.[[Value]].
@@ -583,7 +592,7 @@ pub(crate) fn ordinary_set(
     receiver: Value,
 ) -> JsResult<bool> {
     // 1. Let ownDesc be ? O.[[GetOwnProperty]](P).
-    let own_descriptor = object.get_own_property(agent, property_key)?;
+    let own_descriptor = object.internal_get_own_property(agent, property_key)?;
 
     // 2. Return ? OrdinarySetWithOwnDescriptor(O, P, V, Receiver, ownDesc).
     ordinary_set_with_own_descriptor(agent, object, property_key, value, receiver, own_descriptor)
@@ -603,12 +612,12 @@ pub(crate) fn ordinary_set_with_own_descriptor(
     } else {
         // 1. If ownDesc is undefined, then
         // a. Let parent be ? O.[[GetPrototypeOf]]().
-        let parent = object.get_prototype_of(agent)?;
+        let parent = object.internal_get_prototype_of(agent)?;
 
         // b. If parent is not null, then
         if let Some(parent) = parent {
             // i. Return ? parent.[[Set]](P, V, Receiver).
-            return parent.set(agent, property_key, value, receiver);
+            return parent.internal_set(agent, property_key, value, receiver);
         }
         // c. Else,
         else {
@@ -638,7 +647,7 @@ pub(crate) fn ordinary_set_with_own_descriptor(
         };
 
         // c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
-        let existing_descriptor = receiver.get_own_property(agent, property_key)?;
+        let existing_descriptor = receiver.internal_get_own_property(agent, property_key)?;
 
         // d. If existingDescriptor is not undefined, then
         if let Some(existing_descriptor) = existing_descriptor {
@@ -659,7 +668,7 @@ pub(crate) fn ordinary_set_with_own_descriptor(
             };
 
             // iv. Return ? Receiver.[[DefineOwnProperty]](P, valueDesc).
-            return receiver.define_own_property(agent, property_key, value_descriptor);
+            return receiver.internal_define_own_property(agent, property_key, value_descriptor);
         }
         // e. Else,
         else {
@@ -694,7 +703,7 @@ pub(crate) fn ordinary_delete(
     property_key: PropertyKey,
 ) -> JsResult<bool> {
     // 1. Let desc be ? O.[[GetOwnProperty]](P).
-    let descriptor = object.get_own_property(agent, property_key)?;
+    let descriptor = object.internal_get_own_property(agent, property_key)?;
 
     // 2. If desc is undefined, return true.
     let Some(descriptor) = descriptor else {

--- a/nova_vm/src/ecmascript/builtins/promise.rs
+++ b/nova_vm/src/ecmascript/builtins/promise.rs
@@ -53,26 +53,26 @@ impl From<Promise> for Object {
 }
 
 impl OrdinaryObjectInternalSlots for Promise {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).extensible(agent)
+            OrdinaryObject::from(object_index).internal_extensible(agent)
         } else {
             true
         }
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_extensible(agent, value)
+            OrdinaryObject::from(object_index).internal_set_extensible(agent, value)
         } else {
             // Create base object and set inextensible
             todo!()
         }
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).prototype(agent)
+            OrdinaryObject::from(object_index).internal_prototype(agent)
         } else {
             Some(
                 agent
@@ -84,9 +84,9 @@ impl OrdinaryObjectInternalSlots for Promise {
         }
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype(agent, prototype)
         } else {
             // Create base object and set inextensible
             todo!()
@@ -95,13 +95,17 @@ impl OrdinaryObjectInternalSlots for Promise {
 }
 
 impl InternalMethods for Promise {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype_of(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype_of(agent, prototype)
         } else {
             // If we're setting %Promise.prototype% then we can still avoid creating the ObjectHeapData.
             let current = agent.current_realm().intrinsics().promise_prototype();
@@ -112,40 +116,40 @@ impl InternalMethods for Promise {
                 // OrdinarySetPrototypeOf 7.b.i: Setting prototype would cause a loop to occur.
                 return Ok(false);
             }
-            self.set_prototype(agent, prototype);
+            self.internal_set_prototype(agent, prototype);
             Ok(true)
         }
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get_own_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_get_own_property(agent, property_key)
         } else {
             Ok(None)
         }
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
             let prototype = agent.current_realm().intrinsics().promise_prototype();
             let new_entry = ObjectEntry {
@@ -160,27 +164,34 @@ impl InternalMethods for Promise {
         }
     }
 
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(false), |parent| parent.has_property(agent, property_key))
-        }
-    }
-
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
-        if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get(agent, property_key, receiver)
-        } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(Value::Undefined), |parent| {
-                parent.get(agent, property_key, receiver)
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(false), |parent| {
+                parent.internal_has_property(agent, property_key)
             })
         }
     }
 
-    fn set(
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
+        if let Some(object_index) = agent.heap.get(self.0).object_index {
+            OrdinaryObject::from(object_index).internal_get(agent, property_key, receiver)
+        } else {
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(Value::Undefined), |parent| {
+                parent.internal_get(agent, property_key, receiver)
+            })
+        }
+    }
+
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -188,25 +199,25 @@ impl InternalMethods for Promise {
         receiver: Value,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set(agent, property_key, value, receiver)
+            OrdinaryObject::from(object_index).internal_set(agent, property_key, value, receiver)
         } else {
             let prototype = agent.current_realm().intrinsics().promise_prototype();
-            prototype.set(agent, property_key, value, receiver)
+            prototype.internal_set(agent, property_key, value, receiver)
         }
     }
 
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).delete(agent, property_key)
+            OrdinaryObject::from(object_index).internal_delete(agent, property_key)
         } else {
             // Non-existing property
             Ok(true)
         }
     }
 
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).own_property_keys(agent)
+            OrdinaryObject::from(object_index).internal_own_property_keys(agent)
         } else {
             Ok(vec![])
         }

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -51,42 +51,46 @@ impl From<Proxy> for Object {
 }
 
 impl OrdinaryObjectInternalSlots for Proxy {
-    fn extensible(self, _agent: &Agent) -> bool {
+    fn internal_extensible(self, _agent: &Agent) -> bool {
         todo!();
     }
 
-    fn set_extensible(self, _agent: &mut Agent, _value: bool) {
+    fn internal_set_extensible(self, _agent: &mut Agent, _value: bool) {
         todo!();
     }
 
-    fn prototype(self, _agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, _agent: &Agent) -> Option<Object> {
         todo!();
     }
 
-    fn set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {
+    fn internal_set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {
         todo!();
     }
 }
 
 impl InternalMethods for Proxy {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, _agent: &mut Agent, _prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        _agent: &mut Agent,
+        _prototype: Option<Object>,
+    ) -> JsResult<bool> {
         todo!();
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -94,7 +98,7 @@ impl InternalMethods for Proxy {
         todo!();
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -103,11 +107,15 @@ impl InternalMethods for Proxy {
         todo!();
     }
 
-    fn has_property(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(
+        self,
+        _agent: &mut Agent,
+        _property_key: PropertyKey,
+    ) -> JsResult<bool> {
         todo!();
     }
 
-    fn get(
+    fn internal_get(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -116,7 +124,7 @@ impl InternalMethods for Proxy {
         todo!();
     }
 
-    fn set(
+    fn internal_set(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -126,11 +134,11 @@ impl InternalMethods for Proxy {
         todo!();
     }
 
-    fn delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
         todo!();
     }
 
-    fn own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         todo!();
     }
 }

--- a/nova_vm/src/ecmascript/builtins/set.rs
+++ b/nova_vm/src/ecmascript/builtins/set.rs
@@ -53,26 +53,26 @@ impl From<Set> for Object {
 }
 
 impl OrdinaryObjectInternalSlots for Set {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).extensible(agent)
+            OrdinaryObject::from(object_index).internal_extensible(agent)
         } else {
             true
         }
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_extensible(agent, value)
+            OrdinaryObject::from(object_index).internal_set_extensible(agent, value)
         } else {
             // Create base object and set inextensible
             todo!()
         }
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).prototype(agent)
+            OrdinaryObject::from(object_index).internal_prototype(agent)
         } else {
             Some(
                 agent
@@ -84,9 +84,9 @@ impl OrdinaryObjectInternalSlots for Set {
         }
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype(agent, prototype)
         } else {
             // Create base object and set inextensible
             todo!()
@@ -95,13 +95,17 @@ impl OrdinaryObjectInternalSlots for Set {
 }
 
 impl InternalMethods for Set {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype_of(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype_of(agent, prototype)
         } else {
             // If we're setting %Set.prototype% then we can still avoid creating the ObjectHeapData.
             let current = agent.current_realm().intrinsics().set_prototype();
@@ -112,40 +116,40 @@ impl InternalMethods for Set {
                 // OrdinarySetPrototypeOf 7.b.i: Setting prototype would cause a loop to occur.
                 return Ok(false);
             }
-            self.set_prototype(agent, prototype);
+            self.internal_set_prototype(agent, prototype);
             Ok(true)
         }
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get_own_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_get_own_property(agent, property_key)
         } else {
             Ok(None)
         }
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
             let prototype = agent.current_realm().intrinsics().set_prototype();
             let new_entry = ObjectEntry {
@@ -160,27 +164,34 @@ impl InternalMethods for Set {
         }
     }
 
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(false), |parent| parent.has_property(agent, property_key))
-        }
-    }
-
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
-        if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get(agent, property_key, receiver)
-        } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(Value::Undefined), |parent| {
-                parent.get(agent, property_key, receiver)
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(false), |parent| {
+                parent.internal_has_property(agent, property_key)
             })
         }
     }
 
-    fn set(
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
+        if let Some(object_index) = agent.heap.get(self.0).object_index {
+            OrdinaryObject::from(object_index).internal_get(agent, property_key, receiver)
+        } else {
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(Value::Undefined), |parent| {
+                parent.internal_get(agent, property_key, receiver)
+            })
+        }
+    }
+
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -188,25 +199,25 @@ impl InternalMethods for Set {
         receiver: Value,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set(agent, property_key, value, receiver)
+            OrdinaryObject::from(object_index).internal_set(agent, property_key, value, receiver)
         } else {
             let prototype = agent.current_realm().intrinsics().set_prototype();
-            prototype.set(agent, property_key, value, receiver)
+            prototype.internal_set(agent, property_key, value, receiver)
         }
     }
 
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).delete(agent, property_key)
+            OrdinaryObject::from(object_index).internal_delete(agent, property_key)
         } else {
             // Non-existing property
             Ok(true)
         }
     }
 
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).own_property_keys(agent)
+            OrdinaryObject::from(object_index).internal_own_property_keys(agent)
         } else {
             Ok(vec![])
         }

--- a/nova_vm/src/ecmascript/builtins/shared_array_buffer.rs
+++ b/nova_vm/src/ecmascript/builtins/shared_array_buffer.rs
@@ -55,26 +55,26 @@ impl From<SharedArrayBuffer> for Object {
 }
 
 impl OrdinaryObjectInternalSlots for SharedArrayBuffer {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).extensible(agent)
+            OrdinaryObject::from(object_index).internal_extensible(agent)
         } else {
             true
         }
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_extensible(agent, value)
+            OrdinaryObject::from(object_index).internal_set_extensible(agent, value)
         } else {
             // Create base object and set inextensible
             todo!()
         }
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).prototype(agent)
+            OrdinaryObject::from(object_index).internal_prototype(agent)
         } else {
             Some(
                 agent
@@ -86,9 +86,9 @@ impl OrdinaryObjectInternalSlots for SharedArrayBuffer {
         }
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype(agent, prototype)
         } else {
             // Create base object and set inextensible
             todo!()
@@ -97,13 +97,17 @@ impl OrdinaryObjectInternalSlots for SharedArrayBuffer {
 }
 
 impl InternalMethods for SharedArrayBuffer {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype_of(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype_of(agent, prototype)
         } else {
             // If we're setting %SharedArrayBuffer.prototype% then we can still avoid creating the ObjectHeapData.
             let current = agent
@@ -117,40 +121,40 @@ impl InternalMethods for SharedArrayBuffer {
                 // OrdinarySetPrototypeOf 7.b.i: Setting prototype would cause a loop to occur.
                 return Ok(false);
             }
-            self.set_prototype(agent, prototype);
+            self.internal_set_prototype(agent, prototype);
             Ok(true)
         }
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get_own_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_get_own_property(agent, property_key)
         } else {
             Ok(None)
         }
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
             let prototype = agent
                 .current_realm()
@@ -168,27 +172,34 @@ impl InternalMethods for SharedArrayBuffer {
         }
     }
 
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(false), |parent| parent.has_property(agent, property_key))
-        }
-    }
-
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
-        if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get(agent, property_key, receiver)
-        } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(Value::Undefined), |parent| {
-                parent.get(agent, property_key, receiver)
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(false), |parent| {
+                parent.internal_has_property(agent, property_key)
             })
         }
     }
 
-    fn set(
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
+        if let Some(object_index) = agent.heap.get(self.0).object_index {
+            OrdinaryObject::from(object_index).internal_get(agent, property_key, receiver)
+        } else {
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(Value::Undefined), |parent| {
+                parent.internal_get(agent, property_key, receiver)
+            })
+        }
+    }
+
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -196,28 +207,28 @@ impl InternalMethods for SharedArrayBuffer {
         receiver: Value,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set(agent, property_key, value, receiver)
+            OrdinaryObject::from(object_index).internal_set(agent, property_key, value, receiver)
         } else {
             let prototype = agent
                 .current_realm()
                 .intrinsics()
                 .shared_array_buffer_prototype();
-            prototype.set(agent, property_key, value, receiver)
+            prototype.internal_set(agent, property_key, value, receiver)
         }
     }
 
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).delete(agent, property_key)
+            OrdinaryObject::from(object_index).internal_delete(agent, property_key)
         } else {
             // Non-existing property
             Ok(true)
         }
     }
 
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).own_property_keys(agent)
+            OrdinaryObject::from(object_index).internal_own_property_keys(agent)
         } else {
             Ok(vec![])
         }

--- a/nova_vm/src/ecmascript/builtins/typed_array.rs
+++ b/nova_vm/src/ecmascript/builtins/typed_array.rs
@@ -102,29 +102,29 @@ impl From<TypedArray> for Object {
 }
 
 impl OrdinaryObjectInternalSlots for TypedArray {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         let idx: TypedArrayIndex = self.into();
         if let Some(object_index) = agent.heap.get(idx).object_index {
-            OrdinaryObject::from(object_index).extensible(agent)
+            OrdinaryObject::from(object_index).internal_extensible(agent)
         } else {
             true
         }
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         let idx: TypedArrayIndex = self.into();
         if let Some(object_index) = agent.heap.get(idx).object_index {
-            OrdinaryObject::from(object_index).set_extensible(agent, value)
+            OrdinaryObject::from(object_index).internal_set_extensible(agent, value)
         } else {
             // Create base object and set inextensible
             todo!()
         }
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         let idx: TypedArrayIndex = self.into();
         if let Some(object_index) = agent.heap.get(idx).object_index {
-            OrdinaryObject::from(object_index).prototype(agent)
+            OrdinaryObject::from(object_index).internal_prototype(agent)
         } else {
             Some(
                 agent
@@ -136,10 +136,10 @@ impl OrdinaryObjectInternalSlots for TypedArray {
         }
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         let idx: TypedArrayIndex = self.into();
         if let Some(object_index) = agent.heap.get(idx).object_index {
-            OrdinaryObject::from(object_index).set_prototype(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype(agent, prototype)
         } else {
             // Create base object and set inextensible
             todo!()
@@ -148,14 +148,18 @@ impl OrdinaryObjectInternalSlots for TypedArray {
 }
 
 impl InternalMethods for TypedArray {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool> {
         let idx: TypedArrayIndex = self.into();
         if let Some(object_index) = agent.heap.get(idx).object_index {
-            OrdinaryObject::from(object_index).set_prototype_of(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype_of(agent, prototype)
         } else {
             // If we're setting %TypedArray.prototype% then we can still avoid creating the ObjectHeapData.
             let current = agent.current_realm().intrinsics().typed_array_prototype();
@@ -166,34 +170,34 @@ impl InternalMethods for TypedArray {
                 // OrdinarySetPrototypeOf 7.b.i: Setting prototype would cause a loop to occur.
                 return Ok(false);
             }
-            self.set_prototype(agent, prototype);
+            self.internal_set_prototype(agent, prototype);
             Ok(true)
         }
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         let idx: TypedArrayIndex = self.into();
         if let Some(object_index) = agent.heap.get(idx).object_index {
-            OrdinaryObject::from(object_index).get_own_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_get_own_property(agent, property_key)
         } else {
             Ok(None)
         }
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -201,7 +205,7 @@ impl InternalMethods for TypedArray {
     ) -> JsResult<bool> {
         let idx: TypedArrayIndex = self.into();
         if let Some(object_index) = agent.heap.get(idx).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
             let prototype = agent.current_realm().intrinsics().typed_array_prototype();
             let new_entry = ObjectEntry {
@@ -216,29 +220,36 @@ impl InternalMethods for TypedArray {
         }
     }
 
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         let idx: TypedArrayIndex = self.into();
         if let Some(object_index) = agent.heap.get(idx).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(false), |parent| parent.has_property(agent, property_key))
-        }
-    }
-
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
-        let idx: TypedArrayIndex = self.into();
-        if let Some(object_index) = agent.heap.get(idx).object_index {
-            OrdinaryObject::from(object_index).get(agent, property_key, receiver)
-        } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(Value::Undefined), |parent| {
-                parent.get(agent, property_key, receiver)
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(false), |parent| {
+                parent.internal_has_property(agent, property_key)
             })
         }
     }
 
-    fn set(
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
+        let idx: TypedArrayIndex = self.into();
+        if let Some(object_index) = agent.heap.get(idx).object_index {
+            OrdinaryObject::from(object_index).internal_get(agent, property_key, receiver)
+        } else {
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(Value::Undefined), |parent| {
+                parent.internal_get(agent, property_key, receiver)
+            })
+        }
+    }
+
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -247,27 +258,27 @@ impl InternalMethods for TypedArray {
     ) -> JsResult<bool> {
         let idx: TypedArrayIndex = self.into();
         if let Some(object_index) = agent.heap.get(idx).object_index {
-            OrdinaryObject::from(object_index).set(agent, property_key, value, receiver)
+            OrdinaryObject::from(object_index).internal_set(agent, property_key, value, receiver)
         } else {
             let prototype = agent.current_realm().intrinsics().typed_array_prototype();
-            prototype.set(agent, property_key, value, receiver)
+            prototype.internal_set(agent, property_key, value, receiver)
         }
     }
 
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         let idx: TypedArrayIndex = self.into();
         if let Some(object_index) = agent.heap.get(idx).object_index {
-            OrdinaryObject::from(object_index).delete(agent, property_key)
+            OrdinaryObject::from(object_index).internal_delete(agent, property_key)
         } else {
             // Non-existing property
             Ok(true)
         }
     }
 
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         let idx: TypedArrayIndex = self.into();
         if let Some(object_index) = agent.heap.get(idx).object_index {
-            OrdinaryObject::from(object_index).own_property_keys(agent)
+            OrdinaryObject::from(object_index).internal_own_property_keys(agent)
         } else {
             Ok(vec![])
         }

--- a/nova_vm/src/ecmascript/builtins/weak_map.rs
+++ b/nova_vm/src/ecmascript/builtins/weak_map.rs
@@ -53,26 +53,26 @@ impl From<WeakMap> for Object {
 }
 
 impl OrdinaryObjectInternalSlots for WeakMap {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).extensible(agent)
+            OrdinaryObject::from(object_index).internal_extensible(agent)
         } else {
             true
         }
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_extensible(agent, value)
+            OrdinaryObject::from(object_index).internal_set_extensible(agent, value)
         } else {
             // Create base object and set inextensible
             todo!()
         }
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).prototype(agent)
+            OrdinaryObject::from(object_index).internal_prototype(agent)
         } else {
             Some(
                 agent
@@ -84,9 +84,9 @@ impl OrdinaryObjectInternalSlots for WeakMap {
         }
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype(agent, prototype)
         } else {
             // Create base object and set inextensible
             todo!()
@@ -95,13 +95,17 @@ impl OrdinaryObjectInternalSlots for WeakMap {
 }
 
 impl InternalMethods for WeakMap {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype_of(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype_of(agent, prototype)
         } else {
             // If we're setting %WeakMap.prototype% then we can still avoid creating the ObjectHeapData.
             let current = agent.current_realm().intrinsics().weak_map_prototype();
@@ -112,40 +116,40 @@ impl InternalMethods for WeakMap {
                 // OrdinarySetPrototypeOf 7.b.i: Setting prototype would cause a loop to occur.
                 return Ok(false);
             }
-            self.set_prototype(agent, prototype);
+            self.internal_set_prototype(agent, prototype);
             Ok(true)
         }
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get_own_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_get_own_property(agent, property_key)
         } else {
             Ok(None)
         }
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
             let prototype = agent.current_realm().intrinsics().weak_map_prototype();
             let new_entry = ObjectEntry {
@@ -160,27 +164,34 @@ impl InternalMethods for WeakMap {
         }
     }
 
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(false), |parent| parent.has_property(agent, property_key))
-        }
-    }
-
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
-        if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get(agent, property_key, receiver)
-        } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(Value::Undefined), |parent| {
-                parent.get(agent, property_key, receiver)
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(false), |parent| {
+                parent.internal_has_property(agent, property_key)
             })
         }
     }
 
-    fn set(
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
+        if let Some(object_index) = agent.heap.get(self.0).object_index {
+            OrdinaryObject::from(object_index).internal_get(agent, property_key, receiver)
+        } else {
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(Value::Undefined), |parent| {
+                parent.internal_get(agent, property_key, receiver)
+            })
+        }
+    }
+
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -188,25 +199,25 @@ impl InternalMethods for WeakMap {
         receiver: Value,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set(agent, property_key, value, receiver)
+            OrdinaryObject::from(object_index).internal_set(agent, property_key, value, receiver)
         } else {
             let prototype = agent.current_realm().intrinsics().weak_map_prototype();
-            prototype.set(agent, property_key, value, receiver)
+            prototype.internal_set(agent, property_key, value, receiver)
         }
     }
 
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).delete(agent, property_key)
+            OrdinaryObject::from(object_index).internal_delete(agent, property_key)
         } else {
             // Non-existing property
             Ok(true)
         }
     }
 
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).own_property_keys(agent)
+            OrdinaryObject::from(object_index).internal_own_property_keys(agent)
         } else {
             Ok(vec![])
         }

--- a/nova_vm/src/ecmascript/builtins/weak_ref.rs
+++ b/nova_vm/src/ecmascript/builtins/weak_ref.rs
@@ -53,26 +53,26 @@ impl From<WeakRef> for Object {
 }
 
 impl OrdinaryObjectInternalSlots for WeakRef {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).extensible(agent)
+            OrdinaryObject::from(object_index).internal_extensible(agent)
         } else {
             true
         }
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_extensible(agent, value)
+            OrdinaryObject::from(object_index).internal_set_extensible(agent, value)
         } else {
             // Create base object and set inextensible
             todo!()
         }
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).prototype(agent)
+            OrdinaryObject::from(object_index).internal_prototype(agent)
         } else {
             Some(
                 agent
@@ -84,9 +84,9 @@ impl OrdinaryObjectInternalSlots for WeakRef {
         }
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype(agent, prototype)
         } else {
             // Create base object and set inextensible
             todo!()
@@ -95,13 +95,17 @@ impl OrdinaryObjectInternalSlots for WeakRef {
 }
 
 impl InternalMethods for WeakRef {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype_of(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype_of(agent, prototype)
         } else {
             // If we're setting %WeakRef.prototype% then we can still avoid creating the ObjectHeapData.
             let current = agent.current_realm().intrinsics().weak_ref_prototype();
@@ -112,40 +116,40 @@ impl InternalMethods for WeakRef {
                 // OrdinarySetPrototypeOf 7.b.i: Setting prototype would cause a loop to occur.
                 return Ok(false);
             }
-            self.set_prototype(agent, prototype);
+            self.internal_set_prototype(agent, prototype);
             Ok(true)
         }
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get_own_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_get_own_property(agent, property_key)
         } else {
             Ok(None)
         }
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
             let prototype = agent.current_realm().intrinsics().weak_ref_prototype();
             let new_entry = ObjectEntry {
@@ -160,27 +164,34 @@ impl InternalMethods for WeakRef {
         }
     }
 
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(false), |parent| parent.has_property(agent, property_key))
-        }
-    }
-
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
-        if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get(agent, property_key, receiver)
-        } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(Value::Undefined), |parent| {
-                parent.get(agent, property_key, receiver)
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(false), |parent| {
+                parent.internal_has_property(agent, property_key)
             })
         }
     }
 
-    fn set(
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
+        if let Some(object_index) = agent.heap.get(self.0).object_index {
+            OrdinaryObject::from(object_index).internal_get(agent, property_key, receiver)
+        } else {
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(Value::Undefined), |parent| {
+                parent.internal_get(agent, property_key, receiver)
+            })
+        }
+    }
+
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -188,25 +199,25 @@ impl InternalMethods for WeakRef {
         receiver: Value,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set(agent, property_key, value, receiver)
+            OrdinaryObject::from(object_index).internal_set(agent, property_key, value, receiver)
         } else {
             let prototype = agent.current_realm().intrinsics().weak_ref_prototype();
-            prototype.set(agent, property_key, value, receiver)
+            prototype.internal_set(agent, property_key, value, receiver)
         }
     }
 
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).delete(agent, property_key)
+            OrdinaryObject::from(object_index).internal_delete(agent, property_key)
         } else {
             // Non-existing property
             Ok(true)
         }
     }
 
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).own_property_keys(agent)
+            OrdinaryObject::from(object_index).internal_own_property_keys(agent)
         } else {
             Ok(vec![])
         }

--- a/nova_vm/src/ecmascript/builtins/weak_set.rs
+++ b/nova_vm/src/ecmascript/builtins/weak_set.rs
@@ -53,26 +53,26 @@ impl From<WeakSet> for Object {
 }
 
 impl OrdinaryObjectInternalSlots for WeakSet {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).extensible(agent)
+            OrdinaryObject::from(object_index).internal_extensible(agent)
         } else {
             true
         }
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_extensible(agent, value)
+            OrdinaryObject::from(object_index).internal_set_extensible(agent, value)
         } else {
             // Create base object and set inextensible
             todo!()
         }
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).prototype(agent)
+            OrdinaryObject::from(object_index).internal_prototype(agent)
         } else {
             Some(
                 agent
@@ -84,9 +84,9 @@ impl OrdinaryObjectInternalSlots for WeakSet {
         }
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype(agent, prototype)
         } else {
             // Create base object and set inextensible
             todo!()
@@ -95,13 +95,17 @@ impl OrdinaryObjectInternalSlots for WeakSet {
 }
 
 impl InternalMethods for WeakSet {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.prototype(agent))
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(self.internal_prototype(agent))
     }
 
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set_prototype_of(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype_of(agent, prototype)
         } else {
             // If we're setting %WeakSet.prototype% then we can still avoid creating the ObjectHeapData.
             let current = agent.current_realm().intrinsics().weak_set_prototype();
@@ -112,40 +116,40 @@ impl InternalMethods for WeakSet {
                 // OrdinarySetPrototypeOf 7.b.i: Setting prototype would cause a loop to occur.
                 return Ok(false);
             }
-            self.set_prototype(agent, prototype);
+            self.internal_set_prototype(agent, prototype);
             Ok(true)
         }
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.extensible(agent))
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+        Ok(self.internal_extensible(agent))
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.set_extensible(agent, false);
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+        self.internal_set_extensible(agent, false);
         Ok(true)
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get_own_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_get_own_property(agent, property_key)
         } else {
             Ok(None)
         }
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
             let prototype = agent.current_realm().intrinsics().weak_set_prototype();
             let new_entry = ObjectEntry {
@@ -160,27 +164,34 @@ impl InternalMethods for WeakSet {
         }
     }
 
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).has_property(agent, property_key)
+            OrdinaryObject::from(object_index).internal_has_property(agent, property_key)
         } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(false), |parent| parent.has_property(agent, property_key))
-        }
-    }
-
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
-        if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).get(agent, property_key, receiver)
-        } else {
-            let parent = self.get_prototype_of(agent)?;
-            parent.map_or(Ok(Value::Undefined), |parent| {
-                parent.get(agent, property_key, receiver)
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(false), |parent| {
+                parent.internal_has_property(agent, property_key)
             })
         }
     }
 
-    fn set(
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
+        if let Some(object_index) = agent.heap.get(self.0).object_index {
+            OrdinaryObject::from(object_index).internal_get(agent, property_key, receiver)
+        } else {
+            let parent = self.internal_get_prototype_of(agent)?;
+            parent.map_or(Ok(Value::Undefined), |parent| {
+                parent.internal_get(agent, property_key, receiver)
+            })
+        }
+    }
+
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -188,25 +199,25 @@ impl InternalMethods for WeakSet {
         receiver: Value,
     ) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).set(agent, property_key, value, receiver)
+            OrdinaryObject::from(object_index).internal_set(agent, property_key, value, receiver)
         } else {
             let prototype = agent.current_realm().intrinsics().weak_set_prototype();
-            prototype.set(agent, property_key, value, receiver)
+            prototype.internal_set(agent, property_key, value, receiver)
         }
     }
 
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).delete(agent, property_key)
+            OrdinaryObject::from(object_index).internal_delete(agent, property_key)
         } else {
             // Non-existing property
             Ok(true)
         }
     }
 
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         if let Some(object_index) = agent.heap.get(self.0).object_index {
-            OrdinaryObject::from(object_index).own_property_keys(agent)
+            OrdinaryObject::from(object_index).internal_own_property_keys(agent)
         } else {
             Ok(vec![])
         }

--- a/nova_vm/src/ecmascript/execution/environments/function_environment.rs
+++ b/nova_vm/src/ecmascript/execution/environments/function_environment.rs
@@ -362,7 +362,7 @@ impl FunctionEnvironmentIndex {
         // 3. Assert: home is an Object.
         // Type guarantees Objectness.
         // 4. Return ? home.[[GetPrototypeOf]]().
-        home.get_prototype_of(agent)
+        home.internal_get_prototype_of(agent)
             .map(|proto| proto.map_or_else(|| Value::Null, |proto| proto.into_value()))
     }
 }

--- a/nova_vm/src/ecmascript/execution/environments/global_environment.rs
+++ b/nova_vm/src/ecmascript/execution/environments/global_environment.rs
@@ -405,7 +405,7 @@ impl GlobalEnvironmentIndex {
         let global_object = obj_rec.heap_data(agent).binding_object;
         // 3. Let existingProp be ? globalObject.[[GetOwnProperty]](N).
         let n = PropertyKey::from(name);
-        let existing_prop = global_object.get_own_property(agent, n)?;
+        let existing_prop = global_object.internal_get_own_property(agent, n)?;
         let Some(existing_prop) = existing_prop else {
             // 4. If existingProp is undefined, return false.
             return Ok(false);
@@ -460,7 +460,7 @@ impl GlobalEnvironmentIndex {
         let global_object = obj_rec.heap_data(agent).binding_object;
         let n = PropertyKey::from(name);
         // 3. Let existingProp be ? globalObject.[[GetOwnProperty]](N).
-        let existing_prop = global_object.get_own_property(agent, n)?;
+        let existing_prop = global_object.internal_get_own_property(agent, n)?;
         // 4. If existingProp is undefined, return ? IsExtensible(globalObject).
         let Some(existing_prop) = existing_prop else {
             return is_extensible(agent, global_object);
@@ -544,7 +544,7 @@ impl GlobalEnvironmentIndex {
         let global_object = obj_rec.heap_data(agent).binding_object;
         let n = PropertyKey::from(name);
         // 3. Let existingProp be ? globalObject.[[GetOwnProperty]](N).
-        let existing_prop = global_object.get_own_property(agent, n)?;
+        let existing_prop = global_object.internal_get_own_property(agent, n)?;
         // 4. If existingProp is undefined or existingProp.[[Configurable]] is true, then
         let desc = if existing_prop.is_none() || existing_prop.unwrap().configurable == Some(true) {
             // a. Let desc be the PropertyDescriptor { [[Value]]: V, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: D }.

--- a/nova_vm/src/ecmascript/execution/environments/object_environment.rs
+++ b/nova_vm/src/ecmascript/execution/environments/object_environment.rs
@@ -260,7 +260,7 @@ impl ObjectEnvironmentIndex {
         let binding_boject = env_rec.binding_object;
         let name = PropertyKey::from(name);
         // 2. Return ? bindingObject.[[Delete]](N).
-        binding_boject.delete(agent, name)
+        binding_boject.internal_delete(agent, name)
     }
 
     /// ### [9.1.1.2.8 HasThisBinding ( )](https://tc39.es/ecma262/#sec-object-environment-records-hasthisbinding)

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -636,14 +636,17 @@ mod test {
         let foo = agent
             .get_realm(realm)
             .global_object
-            .get_own_property(&mut agent, key)
+            .internal_get_own_property(&mut agent, key)
             .unwrap()
             .unwrap()
             .value
             .unwrap();
         assert!(foo.is_object());
         let result = Object::try_from(foo).unwrap();
-        assert!(result.own_property_keys(&mut agent).unwrap().is_empty());
+        assert!(result
+            .internal_own_property_keys(&mut agent)
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -661,7 +664,7 @@ mod test {
         let foo = agent
             .get_realm(realm)
             .global_object
-            .get_own_property(&mut agent, key)
+            .internal_get_own_property(&mut agent, key)
             .unwrap()
             .unwrap()
             .value
@@ -669,10 +672,10 @@ mod test {
         assert!(foo.is_object());
         let result = Object::try_from(foo).unwrap();
         let key = PropertyKey::from_static_str(&mut agent, "a");
-        assert!(result.has_property(&mut agent, key).unwrap());
+        assert!(result.internal_has_property(&mut agent, key).unwrap());
         assert_eq!(
             result
-                .get_own_property(&mut agent, key)
+                .internal_get_own_property(&mut agent, key)
                 .unwrap()
                 .unwrap()
                 .value,
@@ -707,7 +710,10 @@ mod test {
             .unwrap();
         assert!(foo.is_object());
         let result = Object::try_from(foo).unwrap();
-        assert!(result.own_property_keys(&mut agent).unwrap().is_empty());
+        assert!(result
+            .internal_own_property_keys(&mut agent)
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -731,20 +737,20 @@ mod test {
         assert!(foo.is_object());
         let result = Object::try_from(foo).unwrap();
         let key = PropertyKey::Integer(0.into());
-        assert!(result.has_property(&mut agent, key).unwrap());
+        assert!(result.internal_has_property(&mut agent, key).unwrap());
         assert_eq!(
             result
-                .get_own_property(&mut agent, key)
+                .internal_get_own_property(&mut agent, key)
                 .unwrap()
                 .unwrap()
                 .value,
             Some(Value::from_static_str(&mut agent, "a"))
         );
         let key = PropertyKey::Integer(1.into());
-        assert!(result.has_property(&mut agent, key).unwrap());
+        assert!(result.internal_has_property(&mut agent, key).unwrap());
         assert_eq!(
             result
-                .get_own_property(&mut agent, key)
+                .internal_get_own_property(&mut agent, key)
                 .unwrap()
                 .unwrap()
                 .value,
@@ -986,7 +992,7 @@ mod test {
         let i: Value = agent
             .get_realm(realm)
             .global_object
-            .get_own_property(&mut agent, key)
+            .internal_get_own_property(&mut agent, key)
             .unwrap()
             .unwrap()
             .value

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -196,7 +196,7 @@ impl Function {
 }
 
 impl OrdinaryObjectInternalSlots for Function {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         if let Some(object_index) = match self {
             Function::BoundFunction(d) => agent.heap.get(d).object_index,
             Function::BuiltinFunction(d) => agent.heap.get(d).object_index,
@@ -212,13 +212,13 @@ impl OrdinaryObjectInternalSlots for Function {
             Function::ECMAScriptConstructorFunction => todo!(),
             Function::ECMAScriptGeneratorFunction => todo!(),
         } {
-            OrdinaryObject::from(object_index).extensible(agent)
+            OrdinaryObject::from(object_index).internal_extensible(agent)
         } else {
             true
         }
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         if let Some(object_index) = match self {
             Function::BoundFunction(d) => agent.heap.get(d).object_index,
             Function::BuiltinFunction(d) => agent.heap.get(d).object_index,
@@ -234,14 +234,14 @@ impl OrdinaryObjectInternalSlots for Function {
             Function::ECMAScriptConstructorFunction => todo!(),
             Function::ECMAScriptGeneratorFunction => todo!(),
         } {
-            OrdinaryObject::from(object_index).set_extensible(agent, value)
+            OrdinaryObject::from(object_index).internal_set_extensible(agent, value)
         } else if !value {
             // Create function base object and set inextensible
             todo!()
         }
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         if let Some(object_index) = match self {
             Function::BoundFunction(d) => agent.heap.get(d).object_index,
             Function::BuiltinFunction(d) => agent.heap.get(d).object_index,
@@ -257,7 +257,7 @@ impl OrdinaryObjectInternalSlots for Function {
             Function::ECMAScriptConstructorFunction => todo!(),
             Function::ECMAScriptGeneratorFunction => todo!(),
         } {
-            OrdinaryObject::from(object_index).prototype(agent)
+            OrdinaryObject::from(object_index).internal_prototype(agent)
         } else {
             Some(
                 agent
@@ -269,7 +269,7 @@ impl OrdinaryObjectInternalSlots for Function {
         }
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         if let Some(object_index) = match self {
             Function::BoundFunction(d) => agent.heap.get(d).object_index,
             Function::BuiltinFunction(d) => agent.heap.get(d).object_index,
@@ -285,7 +285,7 @@ impl OrdinaryObjectInternalSlots for Function {
             Function::ECMAScriptConstructorFunction => todo!(),
             Function::ECMAScriptGeneratorFunction => todo!(),
         } {
-            OrdinaryObject::from(object_index).set_prototype(agent, prototype)
+            OrdinaryObject::from(object_index).internal_set_prototype(agent, prototype)
         } else if prototype
             != Some(
                 agent
@@ -302,23 +302,27 @@ impl OrdinaryObjectInternalSlots for Function {
 }
 
 impl InternalMethods for Function {
-    fn get_prototype_of(self, _agent: &mut Agent) -> JsResult<Option<Object>> {
+    fn internal_get_prototype_of(self, _agent: &mut Agent) -> JsResult<Option<Object>> {
         todo!()
     }
 
-    fn set_prototype_of(self, _agent: &mut Agent, _prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        _agent: &mut Agent,
+        _prototype: Option<Object>,
+    ) -> JsResult<bool> {
         todo!()
     }
 
-    fn is_extensible(self, _agent: &mut Agent) -> JsResult<bool> {
+    fn internal_is_extensible(self, _agent: &mut Agent) -> JsResult<bool> {
         todo!()
     }
 
-    fn prevent_extensions(self, _agent: &mut Agent) -> JsResult<bool> {
+    fn internal_prevent_extensions(self, _agent: &mut Agent) -> JsResult<bool> {
         todo!()
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -326,7 +330,7 @@ impl InternalMethods for Function {
         todo!()
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -335,18 +339,27 @@ impl InternalMethods for Function {
         todo!()
     }
 
-    fn has_property(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(
+        self,
+        _agent: &mut Agent,
+        _property_key: PropertyKey,
+    ) -> JsResult<bool> {
         todo!()
     }
 
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
         match self {
             Function::BoundFunction(_) => todo!(),
             Function::BuiltinFunction(x) => {
-                BuiltinFunction::from(x).get(agent, property_key, receiver)
+                BuiltinFunction::from(x).internal_get(agent, property_key, receiver)
             }
             Function::ECMAScriptFunction(x) => {
-                ECMAScriptFunction::from(x).get(agent, property_key, receiver)
+                ECMAScriptFunction::from(x).internal_get(agent, property_key, receiver)
             }
             Function::BuiltinGeneratorFunction => todo!(),
             Function::BuiltinConstructorFunction => todo!(),
@@ -361,7 +374,7 @@ impl InternalMethods for Function {
         }
     }
 
-    fn set(
+    fn internal_set(
         self,
         _agent: &mut Agent,
         _property_key: PropertyKey,
@@ -371,15 +384,15 @@ impl InternalMethods for Function {
         todo!()
     }
 
-    fn delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
         todo!()
     }
 
-    fn own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         todo!()
     }
 
-    fn call(
+    fn internal_call(
         self,
         agent: &mut Agent,
         this_argument: Value,
@@ -388,10 +401,10 @@ impl InternalMethods for Function {
         match self {
             Function::BoundFunction(_idx) => todo!(),
             Function::BuiltinFunction(idx) => {
-                BuiltinFunction::from(idx).call(agent, this_argument, arguments_list)
+                BuiltinFunction::from(idx).internal_call(agent, this_argument, arguments_list)
             }
             Function::ECMAScriptFunction(idx) => {
-                ECMAScriptFunction::from(idx).call(agent, this_argument, arguments_list)
+                ECMAScriptFunction::from(idx).internal_call(agent, this_argument, arguments_list)
             }
             Function::BuiltinGeneratorFunction => todo!(),
             Function::BuiltinConstructorFunction => todo!(),
@@ -406,7 +419,7 @@ impl InternalMethods for Function {
         }
     }
 
-    fn construct(
+    fn internal_construct(
         self,
         agent: &mut Agent,
         arguments_list: ArgumentsList,
@@ -415,10 +428,10 @@ impl InternalMethods for Function {
         match self {
             Function::BoundFunction(_) => todo!(),
             Function::BuiltinFunction(idx) => {
-                BuiltinFunction::from(idx).construct(agent, arguments_list, new_target)
+                BuiltinFunction::from(idx).internal_construct(agent, arguments_list, new_target)
             }
             Function::ECMAScriptFunction(idx) => {
-                ECMAScriptFunction::from(idx).construct(agent, arguments_list, new_target)
+                ECMAScriptFunction::from(idx).internal_construct(agent, arguments_list, new_target)
             }
             Function::BuiltinGeneratorFunction => todo!(),
             Function::BuiltinConstructorFunction => todo!(),

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -178,19 +178,19 @@ impl Deref for OrdinaryObject {
 }
 
 impl OrdinaryObjectInternalSlots for OrdinaryObject {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         agent.heap.get(*self).extensible
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         agent.heap.get_mut(*self).extensible = value;
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         agent.heap.get(*self).prototype
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         agent.heap.get_mut(*self).prototype = prototype;
     }
 }
@@ -368,16 +368,16 @@ impl Object {
 }
 
 impl OrdinaryObjectInternalSlots for Object {
-    fn extensible(self, agent: &Agent) -> bool {
+    fn internal_extensible(self, agent: &Agent) -> bool {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).extensible(agent),
-            Object::Array(idx) => Array::from(idx).extensible(agent),
-            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).extensible(agent),
-            Object::Date(idx) => Date::from(idx).extensible(agent),
-            Object::Error(idx) => Error::from(idx).extensible(agent),
-            Object::BoundFunction(idx) => Function::from(idx).extensible(agent),
-            Object::BuiltinFunction(idx) => Function::from(idx).extensible(agent),
-            Object::ECMAScriptFunction(idx) => Function::from(idx).extensible(agent),
+            Object::Object(idx) => OrdinaryObject::from(idx).internal_extensible(agent),
+            Object::Array(idx) => Array::from(idx).internal_extensible(agent),
+            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).internal_extensible(agent),
+            Object::Date(idx) => Date::from(idx).internal_extensible(agent),
+            Object::Error(idx) => Error::from(idx).internal_extensible(agent),
+            Object::BoundFunction(idx) => Function::from(idx).internal_extensible(agent),
+            Object::BuiltinFunction(idx) => Function::from(idx).internal_extensible(agent),
+            Object::ECMAScriptFunction(idx) => Function::from(idx).internal_extensible(agent),
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
             Object::BuiltinPromiseResolveFunction => todo!(),
@@ -392,11 +392,11 @@ impl OrdinaryObjectInternalSlots for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).extensible(agent),
+            Object::Map(data) => Map::from(data).internal_extensible(agent),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).extensible(agent),
+            Object::Set(data) => Set::from(data).internal_extensible(agent),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -420,16 +420,22 @@ impl OrdinaryObjectInternalSlots for Object {
         }
     }
 
-    fn set_extensible(self, agent: &mut Agent, value: bool) {
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool) {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).set_extensible(agent, value),
-            Object::Array(idx) => Array::from(idx).set_extensible(agent, value),
-            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).set_extensible(agent, value),
-            Object::Date(idx) => Date::from(idx).set_extensible(agent, value),
-            Object::Error(idx) => Error::from(idx).set_extensible(agent, value),
-            Object::BoundFunction(idx) => Function::from(idx).set_extensible(agent, value),
-            Object::BuiltinFunction(idx) => Function::from(idx).set_extensible(agent, value),
-            Object::ECMAScriptFunction(idx) => Function::from(idx).set_extensible(agent, value),
+            Object::Object(idx) => OrdinaryObject::from(idx).internal_set_extensible(agent, value),
+            Object::Array(idx) => Array::from(idx).internal_set_extensible(agent, value),
+            Object::ArrayBuffer(idx) => {
+                ArrayBuffer::from(idx).internal_set_extensible(agent, value)
+            }
+            Object::Date(idx) => Date::from(idx).internal_set_extensible(agent, value),
+            Object::Error(idx) => Error::from(idx).internal_set_extensible(agent, value),
+            Object::BoundFunction(idx) => Function::from(idx).internal_set_extensible(agent, value),
+            Object::BuiltinFunction(idx) => {
+                Function::from(idx).internal_set_extensible(agent, value)
+            }
+            Object::ECMAScriptFunction(idx) => {
+                Function::from(idx).internal_set_extensible(agent, value)
+            }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
             Object::BuiltinPromiseResolveFunction => todo!(),
@@ -444,11 +450,11 @@ impl OrdinaryObjectInternalSlots for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).set_extensible(agent, value),
+            Object::Map(data) => Map::from(data).internal_set_extensible(agent, value),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).set_extensible(agent, value),
+            Object::Set(data) => Set::from(data).internal_set_extensible(agent, value),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -472,16 +478,16 @@ impl OrdinaryObjectInternalSlots for Object {
         }
     }
 
-    fn prototype(self, agent: &Agent) -> Option<Object> {
+    fn internal_prototype(self, agent: &Agent) -> Option<Object> {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).prototype(agent),
-            Object::Array(idx) => Array::from(idx).prototype(agent),
-            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).prototype(agent),
-            Object::Date(idx) => Date::from(idx).prototype(agent),
-            Object::Error(idx) => Error::from(idx).prototype(agent),
-            Object::BoundFunction(idx) => Function::from(idx).prototype(agent),
-            Object::BuiltinFunction(idx) => Function::from(idx).prototype(agent),
-            Object::ECMAScriptFunction(idx) => Function::from(idx).prototype(agent),
+            Object::Object(idx) => OrdinaryObject::from(idx).internal_prototype(agent),
+            Object::Array(idx) => Array::from(idx).internal_prototype(agent),
+            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).internal_prototype(agent),
+            Object::Date(idx) => Date::from(idx).internal_prototype(agent),
+            Object::Error(idx) => Error::from(idx).internal_prototype(agent),
+            Object::BoundFunction(idx) => Function::from(idx).internal_prototype(agent),
+            Object::BuiltinFunction(idx) => Function::from(idx).internal_prototype(agent),
+            Object::ECMAScriptFunction(idx) => Function::from(idx).internal_prototype(agent),
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
             Object::BuiltinPromiseResolveFunction => todo!(),
@@ -496,11 +502,11 @@ impl OrdinaryObjectInternalSlots for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).prototype(agent),
+            Object::Map(data) => Map::from(data).internal_prototype(agent),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).prototype(agent),
+            Object::Set(data) => Set::from(data).internal_prototype(agent),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -524,16 +530,26 @@ impl OrdinaryObjectInternalSlots for Object {
         }
     }
 
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>) {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).set_prototype(agent, prototype),
-            Object::Array(idx) => Array::from(idx).set_prototype(agent, prototype),
-            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).set_prototype(agent, prototype),
-            Object::Date(idx) => Date::from(idx).set_prototype(agent, prototype),
-            Object::Error(idx) => Error::from(idx).set_prototype(agent, prototype),
-            Object::BoundFunction(idx) => Function::from(idx).set_prototype(agent, prototype),
-            Object::BuiltinFunction(idx) => Function::from(idx).set_prototype(agent, prototype),
-            Object::ECMAScriptFunction(idx) => Function::from(idx).set_prototype(agent, prototype),
+            Object::Object(idx) => {
+                OrdinaryObject::from(idx).internal_set_prototype(agent, prototype)
+            }
+            Object::Array(idx) => Array::from(idx).internal_set_prototype(agent, prototype),
+            Object::ArrayBuffer(idx) => {
+                ArrayBuffer::from(idx).internal_set_prototype(agent, prototype)
+            }
+            Object::Date(idx) => Date::from(idx).internal_set_prototype(agent, prototype),
+            Object::Error(idx) => Error::from(idx).internal_set_prototype(agent, prototype),
+            Object::BoundFunction(idx) => {
+                Function::from(idx).internal_set_prototype(agent, prototype)
+            }
+            Object::BuiltinFunction(idx) => {
+                Function::from(idx).internal_set_prototype(agent, prototype)
+            }
+            Object::ECMAScriptFunction(idx) => {
+                Function::from(idx).internal_set_prototype(agent, prototype)
+            }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
             Object::BuiltinPromiseResolveFunction => todo!(),
@@ -548,11 +564,11 @@ impl OrdinaryObjectInternalSlots for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).set_prototype(agent, prototype),
+            Object::Map(data) => Map::from(data).internal_set_prototype(agent, prototype),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).set_prototype(agent, prototype),
+            Object::Set(data) => Set::from(data).internal_set_prototype(agent, prototype),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -578,16 +594,16 @@ impl OrdinaryObjectInternalSlots for Object {
 }
 
 impl InternalMethods for Object {
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).get_prototype_of(agent),
-            Object::Array(idx) => Array::from(idx).get_prototype_of(agent),
-            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).get_prototype_of(agent),
-            Object::Date(idx) => Date::from(idx).get_prototype_of(agent),
-            Object::Error(idx) => Error::from(idx).get_prototype_of(agent),
-            Object::BoundFunction(idx) => Function::from(idx).get_prototype_of(agent),
-            Object::BuiltinFunction(idx) => Function::from(idx).get_prototype_of(agent),
-            Object::ECMAScriptFunction(idx) => Function::from(idx).get_prototype_of(agent),
+            Object::Object(idx) => OrdinaryObject::from(idx).internal_get_prototype_of(agent),
+            Object::Array(idx) => Array::from(idx).internal_get_prototype_of(agent),
+            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).internal_get_prototype_of(agent),
+            Object::Date(idx) => Date::from(idx).internal_get_prototype_of(agent),
+            Object::Error(idx) => Error::from(idx).internal_get_prototype_of(agent),
+            Object::BoundFunction(idx) => Function::from(idx).internal_get_prototype_of(agent),
+            Object::BuiltinFunction(idx) => Function::from(idx).internal_get_prototype_of(agent),
+            Object::ECMAScriptFunction(idx) => Function::from(idx).internal_get_prototype_of(agent),
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
             Object::BuiltinPromiseResolveFunction => todo!(),
@@ -602,11 +618,11 @@ impl InternalMethods for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).get_prototype_of(agent),
+            Object::Map(data) => Map::from(data).internal_get_prototype_of(agent),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).get_prototype_of(agent),
+            Object::Set(data) => Set::from(data).internal_get_prototype_of(agent),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -630,17 +646,29 @@ impl InternalMethods for Object {
         }
     }
 
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool> {
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool> {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).set_prototype_of(agent, prototype),
-            Object::Array(idx) => Array::from(idx).set_prototype_of(agent, prototype),
-            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).set_prototype_of(agent, prototype),
-            Object::Date(idx) => Date::from(idx).set_prototype_of(agent, prototype),
-            Object::Error(idx) => Error::from(idx).set_prototype_of(agent, prototype),
-            Object::BoundFunction(idx) => Function::from(idx).set_prototype_of(agent, prototype),
-            Object::BuiltinFunction(idx) => Function::from(idx).set_prototype_of(agent, prototype),
+            Object::Object(idx) => {
+                OrdinaryObject::from(idx).internal_set_prototype_of(agent, prototype)
+            }
+            Object::Array(idx) => Array::from(idx).internal_set_prototype_of(agent, prototype),
+            Object::ArrayBuffer(idx) => {
+                ArrayBuffer::from(idx).internal_set_prototype_of(agent, prototype)
+            }
+            Object::Date(idx) => Date::from(idx).internal_set_prototype_of(agent, prototype),
+            Object::Error(idx) => Error::from(idx).internal_set_prototype_of(agent, prototype),
+            Object::BoundFunction(idx) => {
+                Function::from(idx).internal_set_prototype_of(agent, prototype)
+            }
+            Object::BuiltinFunction(idx) => {
+                Function::from(idx).internal_set_prototype_of(agent, prototype)
+            }
             Object::ECMAScriptFunction(idx) => {
-                Function::from(idx).set_prototype_of(agent, prototype)
+                Function::from(idx).internal_set_prototype_of(agent, prototype)
             }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
@@ -656,11 +684,11 @@ impl InternalMethods for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).set_prototype_of(agent, prototype),
+            Object::Map(data) => Map::from(data).internal_set_prototype_of(agent, prototype),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).set_prototype_of(agent, prototype),
+            Object::Set(data) => Set::from(data).internal_set_prototype_of(agent, prototype),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -684,16 +712,16 @@ impl InternalMethods for Object {
         }
     }
 
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).is_extensible(agent),
-            Object::Array(idx) => Array::from(idx).is_extensible(agent),
-            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).is_extensible(agent),
-            Object::Date(idx) => Date::from(idx).is_extensible(agent),
-            Object::Error(idx) => Error::from(idx).is_extensible(agent),
-            Object::BoundFunction(idx) => Function::from(idx).is_extensible(agent),
-            Object::BuiltinFunction(idx) => Function::from(idx).is_extensible(agent),
-            Object::ECMAScriptFunction(idx) => Function::from(idx).is_extensible(agent),
+            Object::Object(idx) => OrdinaryObject::from(idx).internal_is_extensible(agent),
+            Object::Array(idx) => Array::from(idx).internal_is_extensible(agent),
+            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).internal_is_extensible(agent),
+            Object::Date(idx) => Date::from(idx).internal_is_extensible(agent),
+            Object::Error(idx) => Error::from(idx).internal_is_extensible(agent),
+            Object::BoundFunction(idx) => Function::from(idx).internal_is_extensible(agent),
+            Object::BuiltinFunction(idx) => Function::from(idx).internal_is_extensible(agent),
+            Object::ECMAScriptFunction(idx) => Function::from(idx).internal_is_extensible(agent),
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
             Object::BuiltinPromiseResolveFunction => todo!(),
@@ -708,11 +736,11 @@ impl InternalMethods for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).is_extensible(agent),
+            Object::Map(data) => Map::from(data).internal_is_extensible(agent),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).is_extensible(agent),
+            Object::Set(data) => Set::from(data).internal_is_extensible(agent),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -736,16 +764,18 @@ impl InternalMethods for Object {
         }
     }
 
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).prevent_extensions(agent),
-            Object::Array(idx) => Array::from(idx).prevent_extensions(agent),
-            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).prevent_extensions(agent),
-            Object::Date(idx) => Date::from(idx).prevent_extensions(agent),
-            Object::Error(idx) => Error::from(idx).prevent_extensions(agent),
-            Object::BoundFunction(idx) => Function::from(idx).prevent_extensions(agent),
-            Object::BuiltinFunction(idx) => Function::from(idx).prevent_extensions(agent),
-            Object::ECMAScriptFunction(idx) => Function::from(idx).prevent_extensions(agent),
+            Object::Object(idx) => OrdinaryObject::from(idx).internal_prevent_extensions(agent),
+            Object::Array(idx) => Array::from(idx).internal_prevent_extensions(agent),
+            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).internal_prevent_extensions(agent),
+            Object::Date(idx) => Date::from(idx).internal_prevent_extensions(agent),
+            Object::Error(idx) => Error::from(idx).internal_prevent_extensions(agent),
+            Object::BoundFunction(idx) => Function::from(idx).internal_prevent_extensions(agent),
+            Object::BuiltinFunction(idx) => Function::from(idx).internal_prevent_extensions(agent),
+            Object::ECMAScriptFunction(idx) => {
+                Function::from(idx).internal_prevent_extensions(agent)
+            }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
             Object::BuiltinPromiseResolveFunction => todo!(),
@@ -760,11 +790,11 @@ impl InternalMethods for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).prevent_extensions(agent),
+            Object::Map(data) => Map::from(data).internal_prevent_extensions(agent),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).prevent_extensions(agent),
+            Object::Set(data) => Set::from(data).internal_prevent_extensions(agent),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -788,25 +818,29 @@ impl InternalMethods for Object {
         }
     }
 
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).get_own_property(agent, property_key),
-            Object::Array(idx) => Array::from(idx).get_own_property(agent, property_key),
-            Object::ArrayBuffer(idx) => {
-                ArrayBuffer::from(idx).get_own_property(agent, property_key)
+            Object::Object(idx) => {
+                OrdinaryObject::from(idx).internal_get_own_property(agent, property_key)
             }
-            Object::Date(idx) => Date::from(idx).get_own_property(agent, property_key),
-            Object::Error(idx) => Error::from(idx).get_own_property(agent, property_key),
-            Object::BoundFunction(idx) => Function::from(idx).get_own_property(agent, property_key),
+            Object::Array(idx) => Array::from(idx).internal_get_own_property(agent, property_key),
+            Object::ArrayBuffer(idx) => {
+                ArrayBuffer::from(idx).internal_get_own_property(agent, property_key)
+            }
+            Object::Date(idx) => Date::from(idx).internal_get_own_property(agent, property_key),
+            Object::Error(idx) => Error::from(idx).internal_get_own_property(agent, property_key),
+            Object::BoundFunction(idx) => {
+                Function::from(idx).internal_get_own_property(agent, property_key)
+            }
             Object::BuiltinFunction(idx) => {
-                Function::from(idx).get_own_property(agent, property_key)
+                Function::from(idx).internal_get_own_property(agent, property_key)
             }
             Object::ECMAScriptFunction(idx) => {
-                Function::from(idx).get_own_property(agent, property_key)
+                Function::from(idx).internal_get_own_property(agent, property_key)
             }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
@@ -822,11 +856,11 @@ impl InternalMethods for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).get_own_property(agent, property_key),
+            Object::Map(data) => Map::from(data).internal_get_own_property(agent, property_key),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).get_own_property(agent, property_key),
+            Object::Set(data) => Set::from(data).internal_get_own_property(agent, property_key),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -850,38 +884,122 @@ impl InternalMethods for Object {
         }
     }
 
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).define_own_property(
+            Object::Object(idx) => OrdinaryObject::from(idx).internal_define_own_property(
                 agent,
                 property_key,
                 property_descriptor,
             ),
-            Object::Array(idx) => {
-                Array::from(idx).define_own_property(agent, property_key, property_descriptor)
+            Object::Array(idx) => Array::from(idx).internal_define_own_property(
+                agent,
+                property_key,
+                property_descriptor,
+            ),
+            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).internal_define_own_property(
+                agent,
+                property_key,
+                property_descriptor,
+            ),
+            Object::Date(idx) => Date::from(idx).internal_define_own_property(
+                agent,
+                property_key,
+                property_descriptor,
+            ),
+            Object::Error(idx) => Error::from(idx).internal_define_own_property(
+                agent,
+                property_key,
+                property_descriptor,
+            ),
+            Object::BoundFunction(idx) => Function::from(idx).internal_define_own_property(
+                agent,
+                property_key,
+                property_descriptor,
+            ),
+            Object::BuiltinFunction(idx) => Function::from(idx).internal_define_own_property(
+                agent,
+                property_key,
+                property_descriptor,
+            ),
+            Object::ECMAScriptFunction(idx) => Function::from(idx).internal_define_own_property(
+                agent,
+                property_key,
+                property_descriptor,
+            ),
+            Object::BuiltinGeneratorFunction => todo!(),
+            Object::BuiltinConstructorFunction => todo!(),
+            Object::BuiltinPromiseResolveFunction => todo!(),
+            Object::BuiltinPromiseRejectFunction => todo!(),
+            Object::BuiltinPromiseCollectorFunction => todo!(),
+            Object::BuiltinProxyRevokerFunction => todo!(),
+            Object::ECMAScriptAsyncFunction => todo!(),
+            Object::ECMAScriptAsyncGeneratorFunction => todo!(),
+            Object::ECMAScriptConstructorFunction => todo!(),
+            Object::ECMAScriptGeneratorFunction => todo!(),
+            Object::PrimitiveObject(_data) => todo!(),
+            Object::Arguments => todo!(),
+            Object::DataView(_) => todo!(),
+            Object::FinalizationRegistry(_) => todo!(),
+            Object::Map(data) => Map::from(data).internal_define_own_property(
+                agent,
+                property_key,
+                property_descriptor,
+            ),
+            Object::Promise(_) => todo!(),
+            Object::Proxy(_) => todo!(),
+            Object::RegExp(_) => todo!(),
+            Object::Set(data) => Set::from(data).internal_define_own_property(
+                agent,
+                property_key,
+                property_descriptor,
+            ),
+            Object::SharedArrayBuffer(_) => todo!(),
+            Object::WeakMap(_) => todo!(),
+            Object::WeakRef(_) => todo!(),
+            Object::WeakSet(_) => todo!(),
+            Object::Int8Array(_) => todo!(),
+            Object::Uint8Array(_) => todo!(),
+            Object::Uint8ClampedArray(_) => todo!(),
+            Object::Int16Array(_) => todo!(),
+            Object::Uint16Array(_) => todo!(),
+            Object::Int32Array(_) => todo!(),
+            Object::Uint32Array(_) => todo!(),
+            Object::BigInt64Array(_) => todo!(),
+            Object::BigUint64Array(_) => todo!(),
+            Object::Float32Array(_) => todo!(),
+            Object::Float64Array(_) => todo!(),
+            Object::AsyncFromSyncIterator => todo!(),
+            Object::AsyncIterator => todo!(),
+            Object::Iterator => todo!(),
+            Object::Module(_) => todo!(),
+            Object::EmbedderObject(_) => todo!(),
+        }
+    }
+
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+        match self {
+            Object::Object(idx) => {
+                OrdinaryObject::from(idx).internal_has_property(agent, property_key)
             }
+            Object::Array(idx) => Array::from(idx).internal_has_property(agent, property_key),
             Object::ArrayBuffer(idx) => {
-                ArrayBuffer::from(idx).define_own_property(agent, property_key, property_descriptor)
+                ArrayBuffer::from(idx).internal_has_property(agent, property_key)
             }
-            Object::Date(idx) => {
-                Date::from(idx).define_own_property(agent, property_key, property_descriptor)
-            }
-            Object::Error(idx) => {
-                Error::from(idx).define_own_property(agent, property_key, property_descriptor)
-            }
+            Object::Date(idx) => Date::from(idx).internal_has_property(agent, property_key),
+            Object::Error(idx) => Error::from(idx).internal_has_property(agent, property_key),
             Object::BoundFunction(idx) => {
-                Function::from(idx).define_own_property(agent, property_key, property_descriptor)
+                Function::from(idx).internal_has_property(agent, property_key)
             }
             Object::BuiltinFunction(idx) => {
-                Function::from(idx).define_own_property(agent, property_key, property_descriptor)
+                Function::from(idx).internal_has_property(agent, property_key)
             }
             Object::ECMAScriptFunction(idx) => {
-                Function::from(idx).define_own_property(agent, property_key, property_descriptor)
+                Function::from(idx).internal_has_property(agent, property_key)
             }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
@@ -897,15 +1015,11 @@ impl InternalMethods for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => {
-                Map::from(data).define_own_property(agent, property_key, property_descriptor)
-            }
+            Object::Map(data) => Map::from(data).internal_has_property(agent, property_key),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => {
-                Set::from(data).define_own_property(agent, property_key, property_descriptor)
-            }
+            Object::Set(data) => Set::from(data).internal_has_property(agent, property_key),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -929,73 +1043,30 @@ impl InternalMethods for Object {
         }
     }
 
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value> {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).has_property(agent, property_key),
-            Object::Array(idx) => Array::from(idx).has_property(agent, property_key),
-            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).has_property(agent, property_key),
-            Object::Date(idx) => Date::from(idx).has_property(agent, property_key),
-            Object::Error(idx) => Error::from(idx).has_property(agent, property_key),
-            Object::BoundFunction(idx) => Function::from(idx).has_property(agent, property_key),
-            Object::BuiltinFunction(idx) => Function::from(idx).has_property(agent, property_key),
-            Object::ECMAScriptFunction(idx) => {
-                Function::from(idx).has_property(agent, property_key)
+            Object::Object(idx) => {
+                OrdinaryObject::from(idx).internal_get(agent, property_key, receiver)
             }
-            Object::BuiltinGeneratorFunction => todo!(),
-            Object::BuiltinConstructorFunction => todo!(),
-            Object::BuiltinPromiseResolveFunction => todo!(),
-            Object::BuiltinPromiseRejectFunction => todo!(),
-            Object::BuiltinPromiseCollectorFunction => todo!(),
-            Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::ECMAScriptAsyncFunction => todo!(),
-            Object::ECMAScriptAsyncGeneratorFunction => todo!(),
-            Object::ECMAScriptConstructorFunction => todo!(),
-            Object::ECMAScriptGeneratorFunction => todo!(),
-            Object::PrimitiveObject(_data) => todo!(),
-            Object::Arguments => todo!(),
-            Object::DataView(_) => todo!(),
-            Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).has_property(agent, property_key),
-            Object::Promise(_) => todo!(),
-            Object::Proxy(_) => todo!(),
-            Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).has_property(agent, property_key),
-            Object::SharedArrayBuffer(_) => todo!(),
-            Object::WeakMap(_) => todo!(),
-            Object::WeakRef(_) => todo!(),
-            Object::WeakSet(_) => todo!(),
-            Object::Int8Array(_) => todo!(),
-            Object::Uint8Array(_) => todo!(),
-            Object::Uint8ClampedArray(_) => todo!(),
-            Object::Int16Array(_) => todo!(),
-            Object::Uint16Array(_) => todo!(),
-            Object::Int32Array(_) => todo!(),
-            Object::Uint32Array(_) => todo!(),
-            Object::BigInt64Array(_) => todo!(),
-            Object::BigUint64Array(_) => todo!(),
-            Object::Float32Array(_) => todo!(),
-            Object::Float64Array(_) => todo!(),
-            Object::AsyncFromSyncIterator => todo!(),
-            Object::AsyncIterator => todo!(),
-            Object::Iterator => todo!(),
-            Object::Module(_) => todo!(),
-            Object::EmbedderObject(_) => todo!(),
-        }
-    }
-
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value> {
-        match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).get(agent, property_key, receiver),
-            Object::Array(idx) => Array::from(idx).get(agent, property_key, receiver),
-            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).get(agent, property_key, receiver),
-            Object::Date(idx) => Date::from(idx).get(agent, property_key, receiver),
-            Object::Error(idx) => Error::from(idx).get(agent, property_key, receiver),
-            Object::BoundFunction(idx) => Function::from(idx).get(agent, property_key, receiver),
+            Object::Array(idx) => Array::from(idx).internal_get(agent, property_key, receiver),
+            Object::ArrayBuffer(idx) => {
+                ArrayBuffer::from(idx).internal_get(agent, property_key, receiver)
+            }
+            Object::Date(idx) => Date::from(idx).internal_get(agent, property_key, receiver),
+            Object::Error(idx) => Error::from(idx).internal_get(agent, property_key, receiver),
+            Object::BoundFunction(idx) => {
+                Function::from(idx).internal_get(agent, property_key, receiver)
+            }
             Object::BuiltinFunction(idx) => {
-                BuiltinFunction::from(idx).get(agent, property_key, receiver)
+                BuiltinFunction::from(idx).internal_get(agent, property_key, receiver)
             }
             Object::ECMAScriptFunction(idx) => {
-                ECMAScriptFunction::from(idx).get(agent, property_key, receiver)
+                ECMAScriptFunction::from(idx).internal_get(agent, property_key, receiver)
             }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
@@ -1011,11 +1082,11 @@ impl InternalMethods for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).get(agent, property_key, receiver),
+            Object::Map(data) => Map::from(data).internal_get(agent, property_key, receiver),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).get(agent, property_key, receiver),
+            Object::Set(data) => Set::from(data).internal_get(agent, property_key, receiver),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -1039,7 +1110,7 @@ impl InternalMethods for Object {
         }
     }
 
-    fn set(
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -1048,22 +1119,26 @@ impl InternalMethods for Object {
     ) -> JsResult<bool> {
         match self {
             Object::Object(idx) => {
-                OrdinaryObject::from(idx).set(agent, property_key, value, receiver)
+                OrdinaryObject::from(idx).internal_set(agent, property_key, value, receiver)
             }
-            Object::Array(idx) => Array::from(idx).set(agent, property_key, value, receiver),
+            Object::Array(idx) => {
+                Array::from(idx).internal_set(agent, property_key, value, receiver)
+            }
             Object::ArrayBuffer(idx) => {
-                ArrayBuffer::from(idx).set(agent, property_key, value, receiver)
+                ArrayBuffer::from(idx).internal_set(agent, property_key, value, receiver)
             }
-            Object::Date(idx) => Date::from(idx).set(agent, property_key, value, receiver),
-            Object::Error(idx) => Error::from(idx).set(agent, property_key, value, receiver),
+            Object::Date(idx) => Date::from(idx).internal_set(agent, property_key, value, receiver),
+            Object::Error(idx) => {
+                Error::from(idx).internal_set(agent, property_key, value, receiver)
+            }
             Object::BoundFunction(idx) => {
-                Function::from(idx).set(agent, property_key, value, receiver)
+                Function::from(idx).internal_set(agent, property_key, value, receiver)
             }
             Object::BuiltinFunction(idx) => {
-                Function::from(idx).set(agent, property_key, value, receiver)
+                Function::from(idx).internal_set(agent, property_key, value, receiver)
             }
             Object::ECMAScriptFunction(idx) => {
-                Function::from(idx).set(agent, property_key, value, receiver)
+                Function::from(idx).internal_set(agent, property_key, value, receiver)
             }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
@@ -1079,11 +1154,11 @@ impl InternalMethods for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).set(agent, property_key, value, receiver),
+            Object::Map(data) => Map::from(data).internal_set(agent, property_key, value, receiver),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).set(agent, property_key, value, receiver),
+            Object::Set(data) => Set::from(data).internal_set(agent, property_key, value, receiver),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -1107,16 +1182,20 @@ impl InternalMethods for Object {
         }
     }
 
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).delete(agent, property_key),
-            Object::Array(idx) => Array::from(idx).delete(agent, property_key),
-            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).delete(agent, property_key),
-            Object::Date(idx) => Date::from(idx).delete(agent, property_key),
-            Object::Error(idx) => Error::from(idx).delete(agent, property_key),
-            Object::BoundFunction(idx) => Function::from(idx).delete(agent, property_key),
-            Object::BuiltinFunction(idx) => Function::from(idx).delete(agent, property_key),
-            Object::ECMAScriptFunction(idx) => Function::from(idx).delete(agent, property_key),
+            Object::Object(idx) => OrdinaryObject::from(idx).internal_delete(agent, property_key),
+            Object::Array(idx) => Array::from(idx).internal_delete(agent, property_key),
+            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).internal_delete(agent, property_key),
+            Object::Date(idx) => Date::from(idx).internal_delete(agent, property_key),
+            Object::Error(idx) => Error::from(idx).internal_delete(agent, property_key),
+            Object::BoundFunction(idx) => Function::from(idx).internal_delete(agent, property_key),
+            Object::BuiltinFunction(idx) => {
+                Function::from(idx).internal_delete(agent, property_key)
+            }
+            Object::ECMAScriptFunction(idx) => {
+                Function::from(idx).internal_delete(agent, property_key)
+            }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
             Object::BuiltinPromiseResolveFunction => todo!(),
@@ -1131,11 +1210,11 @@ impl InternalMethods for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).delete(agent, property_key),
+            Object::Map(data) => Map::from(data).internal_delete(agent, property_key),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).delete(agent, property_key),
+            Object::Set(data) => Set::from(data).internal_delete(agent, property_key),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -1159,16 +1238,18 @@ impl InternalMethods for Object {
         }
     }
 
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         match self {
-            Object::Object(idx) => OrdinaryObject::from(idx).own_property_keys(agent),
-            Object::Array(idx) => Array::from(idx).own_property_keys(agent),
-            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).own_property_keys(agent),
-            Object::Date(idx) => Date::from(idx).own_property_keys(agent),
-            Object::Error(idx) => Error::from(idx).own_property_keys(agent),
-            Object::BoundFunction(idx) => Function::from(idx).own_property_keys(agent),
-            Object::BuiltinFunction(idx) => Function::from(idx).own_property_keys(agent),
-            Object::ECMAScriptFunction(idx) => Function::from(idx).own_property_keys(agent),
+            Object::Object(idx) => OrdinaryObject::from(idx).internal_own_property_keys(agent),
+            Object::Array(idx) => Array::from(idx).internal_own_property_keys(agent),
+            Object::ArrayBuffer(idx) => ArrayBuffer::from(idx).internal_own_property_keys(agent),
+            Object::Date(idx) => Date::from(idx).internal_own_property_keys(agent),
+            Object::Error(idx) => Error::from(idx).internal_own_property_keys(agent),
+            Object::BoundFunction(idx) => Function::from(idx).internal_own_property_keys(agent),
+            Object::BuiltinFunction(idx) => Function::from(idx).internal_own_property_keys(agent),
+            Object::ECMAScriptFunction(idx) => {
+                Function::from(idx).internal_own_property_keys(agent)
+            }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction => todo!(),
             Object::BuiltinPromiseResolveFunction => todo!(),
@@ -1183,11 +1264,11 @@ impl InternalMethods for Object {
             Object::Arguments => todo!(),
             Object::DataView(_) => todo!(),
             Object::FinalizationRegistry(_) => todo!(),
-            Object::Map(data) => Map::from(data).own_property_keys(agent),
+            Object::Map(data) => Map::from(data).internal_own_property_keys(agent),
             Object::Promise(_) => todo!(),
             Object::Proxy(_) => todo!(),
             Object::RegExp(_) => todo!(),
-            Object::Set(data) => Set::from(data).own_property_keys(agent),
+            Object::Set(data) => Set::from(data).internal_own_property_keys(agent),
             Object::SharedArrayBuffer(_) => todo!(),
             Object::WeakMap(_) => todo!(),
             Object::WeakRef(_) => todo!(),
@@ -1211,7 +1292,7 @@ impl InternalMethods for Object {
         }
     }
 
-    fn call(
+    fn internal_call(
         self,
         agent: &mut Agent,
         this_value: Value,
@@ -1219,20 +1300,20 @@ impl InternalMethods for Object {
     ) -> JsResult<Value> {
         match self {
             Object::BoundFunction(idx) => {
-                Function::from(idx).call(agent, this_value, arguments_list)
+                Function::from(idx).internal_call(agent, this_value, arguments_list)
             }
             Object::BuiltinFunction(idx) => {
-                Function::from(idx).call(agent, this_value, arguments_list)
+                Function::from(idx).internal_call(agent, this_value, arguments_list)
             }
             Object::ECMAScriptFunction(idx) => {
-                Function::from(idx).call(agent, this_value, arguments_list)
+                Function::from(idx).internal_call(agent, this_value, arguments_list)
             }
             Object::EmbedderObject(_) => todo!(),
             _ => unreachable!(),
         }
     }
 
-    fn construct(
+    fn internal_construct(
         self,
         agent: &mut Agent,
         arguments_list: ArgumentsList,
@@ -1240,13 +1321,13 @@ impl InternalMethods for Object {
     ) -> JsResult<Object> {
         match self {
             Object::BoundFunction(idx) => {
-                Function::from(idx).construct(agent, arguments_list, new_target)
+                Function::from(idx).internal_construct(agent, arguments_list, new_target)
             }
             Object::BuiltinFunction(idx) => {
-                Function::from(idx).construct(agent, arguments_list, new_target)
+                Function::from(idx).internal_construct(agent, arguments_list, new_target)
             }
             Object::ECMAScriptFunction(idx) => {
-                Function::from(idx).construct(agent, arguments_list, new_target)
+                Function::from(idx).internal_construct(agent, arguments_list, new_target)
             }
             _ => unreachable!(),
         }

--- a/nova_vm/src/ecmascript/types/language/object/internal_methods.rs
+++ b/nova_vm/src/ecmascript/types/language/object/internal_methods.rs
@@ -11,26 +11,30 @@ where
     Self: Sized + Clone + Copy + Into<Object>,
 {
     /// \[\[GetPrototypeOf\]\]
-    fn get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>>;
+    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>>;
 
     /// \[\[SetPrototypeOf\]\]
-    fn set_prototype_of(self, agent: &mut Agent, prototype: Option<Object>) -> JsResult<bool>;
+    fn internal_set_prototype_of(
+        self,
+        agent: &mut Agent,
+        prototype: Option<Object>,
+    ) -> JsResult<bool>;
 
     /// \[\[IsExtensible\]\]
-    fn is_extensible(self, agent: &mut Agent) -> JsResult<bool>;
+    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool>;
 
     /// \[\[PreventExtensions\]\]
-    fn prevent_extensions(self, agent: &mut Agent) -> JsResult<bool>;
+    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool>;
 
     /// \[\[GetOwnProperty\]\]
-    fn get_own_property(
+    fn internal_get_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>>;
 
     /// \[\[DefineOwnProperty\]\]
-    fn define_own_property(
+    fn internal_define_own_property(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -38,13 +42,18 @@ where
     ) -> JsResult<bool>;
 
     /// \[\[HasProperty\]\]
-    fn has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool>;
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool>;
 
     /// \[\[Get\]\]
-    fn get(self, agent: &mut Agent, property_key: PropertyKey, receiver: Value) -> JsResult<Value>;
+    fn internal_get(
+        self,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
+    ) -> JsResult<Value>;
 
     /// \[\[Set\]\]
-    fn set(
+    fn internal_set(
         self,
         agent: &mut Agent,
         property_key: PropertyKey,
@@ -53,13 +62,13 @@ where
     ) -> JsResult<bool>;
 
     /// \[\[Delete\]\]
-    fn delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool>;
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool>;
 
     /// \[\[OwnPropertyKeys\]\]
-    fn own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>>;
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>>;
 
     /// \[\[Call\]\]
-    fn call(
+    fn internal_call(
         self,
         _agent: &mut Agent,
         _this_value: Value,
@@ -69,7 +78,7 @@ where
     }
 
     /// \[\[Construct\]\]
-    fn construct(
+    fn internal_construct(
         self,
         _agent: &mut Agent,
         _arguments_list: ArgumentsList,

--- a/nova_vm/src/ecmascript/types/language/object/internal_slots.rs
+++ b/nova_vm/src/ecmascript/types/language/object/internal_slots.rs
@@ -11,18 +11,18 @@ where
     /// Every ordinary object has a Boolean-valued \[\[Extensible\]\] internal
     /// slot which is used to fulfill the extensibility-related internal method
     /// invariants specified in [6.1.7.3](https://tc39.es/ecma262/#sec-invariants-of-the-essential-internal-methods).
-    fn extensible(self, agent: &Agent) -> bool;
+    fn internal_extensible(self, agent: &Agent) -> bool;
 
     /// #### \[\[Extensible\]\]
-    fn set_extensible(self, agent: &mut Agent, value: bool);
+    fn internal_set_extensible(self, agent: &mut Agent, value: bool);
 
     /// #### \[\[Prototype\]\]
     ///
     /// All ordinary objects have an internal slot called \[\[Prototype\]\].
     /// The value of this internal slot is either null or an object and is used
     /// for implementing inheritance.
-    fn prototype(self, agent: &Agent) -> Option<Object>;
+    fn internal_prototype(self, agent: &Agent) -> Option<Object>;
 
     /// #### \[\[Prototype\]\]
-    fn set_prototype(self, agent: &mut Agent, prototype: Option<Object>);
+    fn internal_set_prototype(self, agent: &mut Agent, prototype: Option<Object>);
 }

--- a/nova_vm/src/ecmascript/types/spec/reference.rs
+++ b/nova_vm/src/ecmascript/types/spec/reference.rs
@@ -118,7 +118,7 @@ pub(crate) fn get_value(agent: &mut Agent, reference: &Reference) -> JsResult<Va
             };
             if let Ok(object) = Object::try_from(value) {
                 // c. Return ? baseObj.[[Get]](V.[[ReferencedName]], GetThisValue(V)).
-                Ok(object.get(agent, referenced_name, get_this_value(reference))?)
+                Ok(object.internal_get(agent, referenced_name, get_this_value(reference))?)
             } else {
                 // Primitive value. annoying stuff.
                 match value {
@@ -134,27 +134,27 @@ pub(crate) fn get_value(agent: &mut Agent, reference: &Reference) -> JsResult<Va
                         .current_realm()
                         .intrinsics()
                         .boolean_prototype()
-                        .get(agent, referenced_name, value),
+                        .internal_get(agent, referenced_name, value),
                     Value::String(_) | Value::SmallString(_) => agent
                         .current_realm()
                         .intrinsics()
                         .string_prototype()
-                        .get(agent, referenced_name, value),
-                    Value::Symbol(_) => agent.current_realm().intrinsics().symbol_prototype().get(
-                        agent,
-                        referenced_name,
-                        value,
-                    ),
+                        .internal_get(agent, referenced_name, value),
+                    Value::Symbol(_) => agent
+                        .current_realm()
+                        .intrinsics()
+                        .symbol_prototype()
+                        .internal_get(agent, referenced_name, value),
                     Value::Number(_) | Value::Integer(_) | Value::Float(_) => agent
                         .current_realm()
                         .intrinsics()
                         .number_prototype()
-                        .get(agent, referenced_name, value),
+                        .internal_get(agent, referenced_name, value),
                     Value::BigInt(_) | Value::SmallBigInt(_) => agent
                         .current_realm()
                         .intrinsics()
                         .big_int_prototype()
-                        .get(agent, referenced_name, value),
+                        .internal_get(agent, referenced_name, value),
                     _ => unreachable!(),
                 }
             }
@@ -229,7 +229,7 @@ pub(crate) fn put_value(agent: &mut Agent, v: &Reference, w: Value) -> JsResult<
             ReferencedName::Symbol(_) => todo!(),
             ReferencedName::PrivateName => todo!(),
         };
-        let succeeded = base_obj.set(agent, referenced_name, w, this_value)?;
+        let succeeded = base_obj.internal_set(agent, referenced_name, w, this_value)?;
         if !succeeded && v.strict {
             // d. If succeeded is false and V.[[Strict]] is true, throw a TypeError exception.
             return Err(


### PR DESCRIPTION
This is copied from how LibJS names the methods. It should also make it a bit easier to tell these apart from other methods.