### PR TITLE
feat(ecmascript): Module object internal methods

### DIFF
--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -1,10 +1,17 @@
 use crate::ecmascript::{
+    abstract_operations::testing_and_comparison::same_value,
+    builtins::ordinary::ordinary_get_own_property,
     execution::{Agent, JsResult},
     scripts_and_modules::module::ModuleIdentifier,
     types::{
         InternalMethods, IntoObject, IntoValue, Object, OrdinaryObjectInternalSlots,
         PropertyDescriptor, PropertyKey, Value,
     },
+};
+
+use super::ordinary::{
+    ordinary_define_own_property, ordinary_delete, ordinary_get, ordinary_has_property,
+    ordinary_own_property_keys, set_immutable_prototype,
 };
 
 pub mod data;
@@ -48,78 +55,191 @@ impl From<Module> for Object {
     }
 }
 
-impl OrdinaryObjectInternalSlots for Module {
-    fn internal_extensible(self, _agent: &Agent) -> bool {
-        todo!();
-    }
-
-    fn internal_set_extensible(self, _agent: &mut Agent, _value: bool) {
-        todo!();
-    }
-
-    fn internal_prototype(self, _agent: &Agent) -> Option<Object> {
-        todo!();
-    }
-
-    fn internal_set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {
-        todo!();
+impl Module {
+    fn get_backing_object(self, agent: &mut Agent) -> Option<Object> {
+        agent
+            .heap
+            .get_module(self.0)
+            .object_index
+            .map(|idx| idx.into())
     }
 }
 
+impl OrdinaryObjectInternalSlots for Module {
+    fn internal_extensible(self, _agent: &Agent) -> bool {
+        false
+    }
+
+    fn internal_set_extensible(self, _agent: &mut Agent, _value: bool) {}
+
+    fn internal_prototype(self, _agent: &Agent) -> Option<Object> {
+        None
+    }
+
+    fn internal_set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {}
+}
+
 impl InternalMethods for Module {
-    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
-        Ok(self.internal_prototype(agent))
+    fn internal_get_prototype_of(self, _agent: &mut Agent) -> JsResult<Option<Object>> {
+        Ok(None)
     }
 
     fn internal_set_prototype_of(
         self,
-        _agent: &mut Agent,
-        _prototype: Option<Object>,
+        agent: &mut Agent,
+        prototype: Option<Object>,
     ) -> JsResult<bool> {
-        todo!();
+        set_immutable_prototype(agent, self.into_object(), prototype)
     }
 
-    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
-        Ok(self.internal_extensible(agent))
+    fn internal_is_extensible(self, _agent: &mut Agent) -> JsResult<bool> {
+        Ok(false)
     }
 
-    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        self.internal_set_extensible(agent, false);
+    fn internal_prevent_extensions(self, _agent: &mut Agent) -> JsResult<bool> {
         Ok(true)
     }
 
+    /// 10.4.6.5 [[GetOwnProperty]] ( P )
+    ///
+    /// The [[GetOwnProperty]] internal method of a module namespace exotic
+    /// object O takes argument P (a property key) and returns either a normal
+    /// completion containing either a Property Descriptor or undefined, or a
+    /// throw completion.
     fn internal_get_own_property(
         self,
-        _agent: &mut Agent,
-        _property_key: PropertyKey,
+        agent: &mut Agent,
+        property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
-        todo!();
+        match property_key {
+            PropertyKey::Symbol(_) => {
+                // 1. If P is a Symbol, return OrdinaryGetOwnProperty(O, P).
+                Ok(self
+                    .get_backing_object(agent)
+                    .and_then(|object| ordinary_get_own_property(agent, object, property_key)))
+            }
+            // TODO: Check this but it should not be possible to export any
+            // integer-valued names.
+            PropertyKey::Integer(_) => Ok(None),
+            PropertyKey::SmallString(_) | PropertyKey::String(_) => {
+                // TODO: Actually implement module exports.
+                // 2. Let exports be O.[[Exports]].
+                // 3. If exports does not contain P, return undefined.
+                // 4. Let value be ? O.[[Get]](P, O).
+                // 5. Return PropertyDescriptor { [[Value]]: value, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: false }.
+                Ok(None)
+            }
+        }
     }
 
     fn internal_define_own_property(
         self,
-        _agent: &mut Agent,
-        _property_key: PropertyKey,
-        _property_descriptor: PropertyDescriptor,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
-        todo!();
+        match property_key {
+            PropertyKey::Symbol(_) => {
+                // 1. If P is a Symbol, return ! OrdinaryDefineOwnProperty(O, P, Desc).
+                Ok(self.get_backing_object(agent).map_or(false, |object| {
+                    ordinary_define_own_property(agent, object, property_key, property_descriptor)
+                        .unwrap()
+                }))
+            }
+            // TODO: Check this but it should not be possible to export any
+            // integer-valued names.
+            PropertyKey::Integer(_) => Ok(false),
+            PropertyKey::SmallString(_) | PropertyKey::String(_) => {
+                // 2. Let current be ? O.[[GetOwnProperty]](P).
+                let current = self.internal_get_own_property(agent, property_key)?;
+                // 3. If current is undefined, return false.
+                let Some(current) = current else {
+                    return Ok(false);
+                };
+                // 4. If Desc has a [[Configurable]] field and Desc.[[Configurable]] is true, return false.
+                if property_descriptor.configurable == Some(true) {
+                    return Ok(false);
+                }
+                // 5. If Desc has an [[Enumerable]] field and Desc.[[Enumerable]] is false, return false.
+                if property_descriptor.enumerable == Some(false) {
+                    return Ok(false);
+                }
+                // 6. If IsAccessorDescriptor(Desc) is true, return false.
+                if property_descriptor.is_accessor_descriptor() {
+                    return Ok(false);
+                }
+                // 7. If Desc has a [[Writable]] field and Desc.[[Writable]] is false, return false.
+                if property_descriptor.writable == Some(false) {
+                    return Ok(false);
+                }
+                // 8. If Desc has a [[Value]] field, return SameValue(Desc.[[Value]], current.[[Value]]).
+                if let Some(value) = property_descriptor.value {
+                    Ok(same_value(agent, value, current.value.unwrap()))
+                } else {
+                    // 9. Return true.
+                    Ok(true)
+                }
+            }
+        }
     }
 
-    fn internal_has_property(
-        self,
-        _agent: &mut Agent,
-        _property_key: PropertyKey,
-    ) -> JsResult<bool> {
-        todo!();
+    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+        match property_key {
+            PropertyKey::Integer(_) => Ok(false),
+            PropertyKey::SmallString(_) | PropertyKey::String(_) => {
+                // 2. Let exports be O.[[Exports]].
+                // 3. If exports contains P, return true.
+                // 4. Return false.
+                todo!();
+            }
+            PropertyKey::Symbol(_) => {
+                // 1. If P is a Symbol, return ! OrdinaryHasProperty(O, P).
+                Ok(self.get_backing_object(agent).map_or(false, |object| {
+                    ordinary_has_property(agent, object, property_key).unwrap()
+                }))
+            }
+        }
     }
 
     fn internal_get(
         self,
-        _agent: &mut Agent,
-        _property_key: PropertyKey,
-        _receiver: Value,
+        agent: &mut Agent,
+        property_key: PropertyKey,
+        receiver: Value,
     ) -> JsResult<Value> {
-        todo!();
+        // NOTE: ResolveExport is side-effect free. Each time this operation
+        // is called with a specific exportName, resolveSet pair as arguments
+        // it must return the same result. An implementation might choose to
+        // pre-compute or cache the ResolveExport results for the [[Exports]]
+        // of each module namespace exotic object.
+
+        match property_key {
+            // 1. If P is a Symbol, then
+            PropertyKey::Symbol(_) => {
+                // a. Return ! OrdinaryGet(O, P, Receiver).
+                Ok(self
+                    .get_backing_object(agent)
+                    .map_or(Value::Undefined, |object| {
+                        ordinary_get(agent, object, property_key, receiver).unwrap()
+                    }))
+            }
+            PropertyKey::Integer(_) => Ok(Value::Undefined),
+            PropertyKey::SmallString(_) | PropertyKey::String(_) => {
+                // 2. Let exports be O.[[Exports]].
+                // 3. If exports does not contain P, return undefined.
+                // 4. Let m be O.[[Module]].
+                // 5. Let binding be m.ResolveExport(P).
+                // 6. Assert: binding is a ResolvedBinding Record.
+                // 7. Let targetModule be binding.[[Module]].
+                // 8. Assert: targetModule is not undefined.
+                // 9. If binding.[[BindingName]] is NAMESPACE, then
+                // a. Return GetModuleNamespace(targetModule).
+                // 10. Let targetEnv be targetModule.[[Environment]].
+                // 11. If targetEnv is EMPTY, throw a ReferenceError exception.
+                // 12. Return ? targetEnv.GetBindingValue(binding.[[BindingName]], true).
+                todo!()
+            }
+        }
     }
 
     fn internal_set(
@@ -129,14 +249,35 @@ impl InternalMethods for Module {
         _value: Value,
         _receiver: Value,
     ) -> JsResult<bool> {
-        todo!();
+        Ok(false)
     }
 
-    fn internal_delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
-        todo!();
+    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+        match property_key {
+            PropertyKey::Symbol(_) => {
+                // 1. If P is a Symbol, then
+                // a. Return ! OrdinaryDelete(O, P).
+                Ok(self.get_backing_object(agent).map_or(true, |object| {
+                    ordinary_delete(agent, object, property_key).unwrap()
+                }))
+            }
+            PropertyKey::Integer(_) => Ok(false),
+            PropertyKey::SmallString(_) | PropertyKey::String(_) => {
+                // 2. Let exports be O.[[Exports]].
+                // 3. If exports contains P, return false.
+                // 4. Return true.
+                Ok(true)
+            }
+        }
     }
 
-    fn internal_own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
-        todo!();
+    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+        // 1. Let exports be O.[[Exports]].
+        // 2. Let symbolKeys be OrdinaryOwnPropertyKeys(O).
+        let symbol_keys = self
+            .get_backing_object(agent)
+            .map_or(vec![], |object| ordinary_own_property_keys(agent, object));
+        // 3. Return the list-concatenation of exports and symbolKeys.
+        Ok(symbol_keys)
     }
 }

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -80,10 +80,12 @@ impl OrdinaryObjectInternalSlots for Module {
 }
 
 impl InternalMethods for Module {
+    /// ### [10.4.6.1 \[\[GetPrototypeOf\]\] ( )](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getprototypeof)
     fn internal_get_prototype_of(self, _agent: &mut Agent) -> JsResult<Option<Object>> {
         Ok(None)
     }
 
+    /// ### [10.4.6.2 \[\[SetPrototypeOf\]\] ( V )](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-setprototypeof-v)
     fn internal_set_prototype_of(
         self,
         agent: &mut Agent,
@@ -92,20 +94,17 @@ impl InternalMethods for Module {
         set_immutable_prototype(agent, self.into_object(), prototype)
     }
 
+    /// ### [10.4.6.3 \[\[IsExtensible\]\] ( )](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-isextensible)
     fn internal_is_extensible(self, _agent: &mut Agent) -> JsResult<bool> {
         Ok(false)
     }
 
+    /// ### [10.4.6.4 \[\[PreventExtensions\]\] ( )](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-preventextensions)
     fn internal_prevent_extensions(self, _agent: &mut Agent) -> JsResult<bool> {
         Ok(true)
     }
 
-    /// 10.4.6.5 [[GetOwnProperty]] ( P )
-    ///
-    /// The [[GetOwnProperty]] internal method of a module namespace exotic
-    /// object O takes argument P (a property key) and returns either a normal
-    /// completion containing either a Property Descriptor or undefined, or a
-    /// throw completion.
+    /// 10.4.6.5 \[\[GetOwnProperty\]\] ( P )
     fn internal_get_own_property(
         self,
         agent: &mut Agent,
@@ -150,6 +149,7 @@ impl InternalMethods for Module {
         }
     }
 
+    /// ### [10.4.6.6 \[\[DefineOwnProperty\]\] ( P, Desc )](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-defineownproperty-p-desc)
     fn internal_define_own_property(
         self,
         agent: &mut Agent,
@@ -201,6 +201,7 @@ impl InternalMethods for Module {
         }
     }
 
+    /// ### [10.4.6.7 \[\[HasProperty\]\] ( P )](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-hasproperty-p)
     fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         match property_key {
             PropertyKey::Integer(_) => Ok(false),
@@ -229,6 +230,7 @@ impl InternalMethods for Module {
         }
     }
 
+    /// ### [10.4.6.8 \[\[Get\]\] ( P, Receiver )](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver)
     fn internal_get(
         self,
         agent: &mut Agent,
@@ -303,6 +305,7 @@ impl InternalMethods for Module {
         }
     }
 
+    /// ### [10.4.6.9 \[\[Set\]\] ( P, V, Receiver )](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-set-p-v-receiver)
     fn internal_set(
         self,
         _agent: &mut Agent,
@@ -313,6 +316,7 @@ impl InternalMethods for Module {
         Ok(false)
     }
 
+    /// ### [10.4.6.10 \[\[Delete\]\] ( P )](https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-delete-p)
     fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
         match property_key {
             PropertyKey::Symbol(_) => {
@@ -342,6 +346,7 @@ impl InternalMethods for Module {
         }
     }
 
+    /// ### [10.4.6.11 \[\[OwnPropertyKeys\]\] ( )])(https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-ownpropertykeys)
     fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         // 1. Let exports be O.[[Exports]].
         let exports = agent

--- a/nova_vm/src/ecmascript/builtins/module/data.rs
+++ b/nova_vm/src/ecmascript/builtins/module/data.rs
@@ -1,6 +1,81 @@
-use crate::heap::indexes::ObjectIndex;
+use small_string::SmallString;
+
+use crate::{
+    ecmascript::{
+        execution::{ModuleEnvironmentIndex, RealmIdentifier},
+        scripts_and_modules::module::ModuleIdentifier,
+        types::{PropertyKey, String},
+    },
+    heap::indexes::{ObjectIndex, StringIndex},
+};
+
+use super::Module;
 
 #[derive(Debug, Clone)]
 pub struct ModuleHeapData {
     pub(crate) object_index: Option<ObjectIndex>,
+    pub(crate) module: ModuleRecord,
+    pub(crate) exports: Box<[String]>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ModuleRecord {
+    /// \[\[Realm]]
+    ///
+    /// The Realm within which this module was created.
+    realm: RealmIdentifier,
+    /// \[\[Environment]]
+    ///
+    /// The Environment Record containing the top level bindings for this
+    /// module. This field is set when the module is linked.
+    pub(super) environment: Option<ModuleEnvironmentIndex>,
+    /// \[\[Namespace]]
+    ///
+    /// The Module Namespace Object (28.3) if one has been created for this
+    /// module.
+    namespace: Option<Module>,
+    /// \[\[HostDefined]]
+    ///
+    /// Field reserved for use by host environments that need to associate
+    /// additional information with a module.
+    host_defined: (),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ResolvedBindingName {
+    String(StringIndex),
+    SmallString(SmallString),
+    Namespace,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ResolvedBinding {
+    /// \[\[Module]]
+    pub(super) module: Option<ModuleIdentifier>,
+    /// \[\[BindingName]]
+    pub(super) binding_name: ResolvedBindingName,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ResolveExportResult {
+    Ambiguous,
+    Resolved(ResolvedBinding),
+}
+
+impl ModuleRecord {
+    /// Return the binding of a name exported by this module. Bindings are
+    /// represented by a ResolvedBinding Record, of the form { \[\[Module]]:
+    /// Module Record, \[\[BindingName]]: String | NAMESPACE }. If the export
+    /// is a Module Namespace Object without a direct binding in any module,
+    /// \[\[BindingName]] will be set to NAMESPACE. Return null if the name
+    /// cannot be resolved, or AMBIGUOUS if multiple bindings were found.
+    ///
+    /// Each time this operation is called with a specific exportName,
+    /// resolveSet pair as arguments it must return the same result.
+    ///
+    /// LoadRequestedModules must have completed successfully prior to
+    /// invoking this method.
+    pub(crate) fn resolve_export(&self, _property_key: PropertyKey) -> Option<ResolveExportResult> {
+        todo!()
+    }
 }

--- a/nova_vm/src/ecmascript/builtins/ordinary.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary.rs
@@ -111,7 +111,7 @@ impl InternalMethods for OrdinaryObject {
     /// ### [10.1.11 \[\[OwnPropertyKeys\]\] ( )](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys)
     fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
         // 1. Return OrdinaryOwnPropertyKeys(O).
-        ordinary_own_property_keys(agent, self.into())
+        Ok(ordinary_own_property_keys(agent, self.into()))
     }
 }
 
@@ -724,12 +724,8 @@ pub(crate) fn ordinary_delete(
 }
 
 /// ### [10.1.11.1 OrdinaryOwnPropertyKeys ( O )](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys)
-pub(crate) fn ordinary_own_property_keys(
-    _agent: &mut Agent,
-    _object: Object,
-) -> JsResult<Vec<PropertyKey>> {
+pub(crate) fn ordinary_own_property_keys(_agent: &mut Agent, _object: Object) -> Vec<PropertyKey> {
     // 1. Let keys be a new empty List.
-    let keys = Vec::new();
 
     // 2. For each own property key P of O such that P is an array index, in ascending numeric
     //    index order, do
@@ -766,7 +762,7 @@ pub(crate) fn ordinary_own_property_keys(
     // }
 
     // 5. Return keys.
-    Ok(keys)
+    Vec::new()
 }
 
 /// ### [10.1.12 OrdinaryObjectCreate ( proto \[ , additionalInternalSlotsList \] )](https://tc39.es/ecma262/#sec-ordinaryobjectcreate)
@@ -1180,4 +1176,22 @@ pub(crate) fn get_prototype_from_constructor(
             Ok(proto)
         }
     }
+}
+
+/// 10.4.7.2 SetImmutablePrototype ( O, V )
+///
+/// The abstract operation SetImmutablePrototype takes arguments O (an Object)
+/// and V (an Object or null) and returns either a normal completion containing
+/// a Boolean or a throw completion.
+#[inline]
+pub(crate) fn set_immutable_prototype(
+    agent: &mut Agent,
+    o: Object,
+    v: Option<Object>,
+) -> JsResult<bool> {
+    // 1. Let current be ? O.[[GetPrototypeOf]]().
+    let current = o.internal_get_prototype_of(agent)?;
+    // 2. If SameValue(V, current) is true, return true.
+    // 3. Return false.
+    Ok(same_value(agent, v, current))
 }

--- a/nova_vm/src/ecmascript/builtins/ordinary.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary.rs
@@ -724,7 +724,7 @@ pub(crate) fn ordinary_delete(
 }
 
 /// ### [10.1.11.1 OrdinaryOwnPropertyKeys ( O )](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys)
-pub(crate) fn ordinary_own_property_keys(_agent: &mut Agent, _object: Object) -> Vec<PropertyKey> {
+pub(crate) fn ordinary_own_property_keys(_agent: &Agent, _object: Object) -> Vec<PropertyKey> {
     // 1. Let keys be a new empty List.
 
     // 2. For each own property key P of O such that P is an array index, in ascending numeric

--- a/nova_vm/src/ecmascript/execution.rs
+++ b/nova_vm/src/ecmascript/execution.rs
@@ -9,8 +9,9 @@ pub use default_host_hooks::DefaultHostHooks;
 pub(crate) use environments::{
     new_declarative_environment, new_function_environment, DeclarativeEnvironment,
     DeclarativeEnvironmentIndex, EnvironmentIndex, Environments, FunctionEnvironment,
-    FunctionEnvironmentIndex, GlobalEnvironment, GlobalEnvironmentIndex, ObjectEnvironment,
-    ObjectEnvironmentIndex, PrivateEnvironment, PrivateEnvironmentIndex, ThisBindingStatus,
+    FunctionEnvironmentIndex, GlobalEnvironment, GlobalEnvironmentIndex, ModuleEnvironmentIndex,
+    ObjectEnvironment, ObjectEnvironmentIndex, PrivateEnvironment, PrivateEnvironmentIndex,
+    ThisBindingStatus,
 };
 pub(crate) use execution_context::*;
 pub use realm::{

--- a/nova_vm/src/ecmascript/execution/environments/module_environment.rs
+++ b/nova_vm/src/ecmascript/execution/environments/module_environment.rs
@@ -1,0 +1,19 @@
+use super::DeclarativeEnvironment;
+
+/// ### [9.1.1.5 Module Environment Records](https://tc39.es/ecma262/#sec-module-environment-records)
+/// A Module Environment Record is a Declarative Environment Record that is
+/// used to represent the outer scope of an ECMAScript Module. In additional to
+/// normal mutable and immutable bindings, Module Environment Records also
+/// provide immutable import bindings which are bindings that provide indirect
+/// access to a target binding that exists in another Environment Record.
+///
+/// Module Environment Records support all of the Declarative Environment
+/// Record methods listed in Table 16 and share the same specifications for all
+/// of those methods except for GetBindingValue, DeleteBinding, HasThisBinding
+/// and GetThisBinding.
+///
+/// NOTE: There is no data-wise difference between a DeclarativeEnvironment and
+/// a ModuleEnvironment, so we treat them exactly the same way.
+#[derive(Debug, Clone)]
+#[repr(transparent)]
+pub(crate) struct ModuleEnvironment(DeclarativeEnvironment);

--- a/nova_vm/src/heap.rs
+++ b/nova_vm/src/heap.rs
@@ -527,6 +527,22 @@ impl Heap {
             .expect("ScriptIdentifier matched a freed Script")
     }
 
+    pub(crate) fn get_module(&self, id: ModuleIdentifier) -> &ModuleHeapData {
+        self.modules
+            .get(id.into_index())
+            .expect("ModuleIdentifier did not match a Module")
+            .as_ref()
+            .expect("ModuleIdentifier matched a freed Module")
+    }
+
+    pub(crate) fn get_module_mut(&mut self, id: ModuleIdentifier) -> &mut ModuleHeapData {
+        self.modules
+            .get_mut(id.into_index())
+            .expect("ModuleIdentifier did not match a Module")
+            .as_mut()
+            .expect("ModuleIdentifier matched a freed Module")
+    }
+
     /// Allocate a string onto the Agent heap
     ///
     /// This method will currently iterate through all heap strings to look for


### PR DESCRIPTION
I'll probably be using this as a "show-off" on how to implement internal methods for most exotic objects. Module strikes a relative nice balance: It doesn't have special properties by-name in itself but on the other hand it does through the exported properties. It's also has quite a bit of special internal method definitions but those are fairly simple.

Hopefully this will serve as a good template for others on how to go about doing this for other object types.