### PR TITLE
feat(ecmascript): Add object property assignment

### DIFF
--- a/nova_vm/src/ecmascript/types/language/object/property_storage.rs
+++ b/nova_vm/src/ecmascript/types/language/object/property_storage.rs
@@ -30,16 +30,10 @@ impl PropertyStorage {
         let object = self.into_value();
 
         match object {
-            Value::Object(object) => {
-                let _keys = &agent[object].keys;
-                // realm.heap.elements.get(keys).iter().any(|k| {
-                //     if let Some(value) = k {
-                //         value.equals(agent, key)
-                //     }
-                //     false
-                // });
-                true
-            }
+            Value::Object(object) => agent
+                .heap
+                .elements
+                .has(agent[object].keys, key.into_value()),
             Value::Array(array) => {
                 if key.equals(agent, PropertyKey::from(BUILTIN_STRING_MEMORY.length)) {
                     return true;

--- a/nova_vm/src/engine/bytecode/executable.rs
+++ b/nova_vm/src/engine/bytecode/executable.rs
@@ -567,11 +567,16 @@ impl CompileEvaluation for ast::AssignmentExpression<'_> {
             todo!("{:?}", self.left);
         };
 
-        let ast::SimpleAssignmentTarget::AssignmentTargetIdentifier(identifier) = &target else {
-            todo!("{target:?}");
-        };
+        match &target {
+            ast::SimpleAssignmentTarget::AssignmentTargetIdentifier(identifier) => {
+                identifier.compile(ctx);
+            }
+            ast::SimpleAssignmentTarget::MemberAssignmentTarget(expression) => {
+                expression.compile(ctx)
+            }
+            _ => todo!("{target:?}"),
+        }
 
-        identifier.compile(ctx);
         ctx.exe.add_instruction(Instruction::PushReference);
 
         self.right.compile(ctx);

--- a/nova_vm/src/heap/element_array.rs
+++ b/nova_vm/src/heap/element_array.rs
@@ -1333,6 +1333,7 @@ impl ElementArrays {
                 .values
                 .get(vector.elements_index.into_index())
                 .unwrap()
+                .as_ref()
                 .unwrap()
                 .as_slice()[0..vector.len as usize]
                 .contains(&Some(element)),
@@ -1341,6 +1342,7 @@ impl ElementArrays {
                 .values
                 .get(vector.elements_index.into_index())
                 .unwrap()
+                .as_ref()
                 .unwrap()
                 .as_slice()[0..vector.len as usize]
                 .contains(&Some(element)),
@@ -1349,6 +1351,7 @@ impl ElementArrays {
                 .values
                 .get(vector.elements_index.into_index())
                 .unwrap()
+                .as_ref()
                 .unwrap()
                 .as_slice()[0..vector.len as usize]
                 .contains(&Some(element)),
@@ -1357,6 +1360,7 @@ impl ElementArrays {
                 .values
                 .get(vector.elements_index.into_index())
                 .unwrap()
+                .as_ref()
                 .unwrap()
                 .as_slice()[0..vector.len as usize]
                 .contains(&Some(element)),
@@ -1365,6 +1369,7 @@ impl ElementArrays {
                 .values
                 .get(vector.elements_index.into_index())
                 .unwrap()
+                .as_ref()
                 .unwrap()
                 .as_slice()[0..vector.len as usize]
                 .contains(&Some(element)),
@@ -1373,6 +1378,7 @@ impl ElementArrays {
                 .values
                 .get(vector.elements_index.into_index())
                 .unwrap()
+                .as_ref()
                 .unwrap()
                 .as_slice()[0..vector.len as usize]
                 .contains(&Some(element)),
@@ -1381,6 +1387,7 @@ impl ElementArrays {
                 .values
                 .get(vector.elements_index.into_index())
                 .unwrap()
+                .as_ref()
                 .unwrap()
                 .as_slice()[0..vector.len as usize]
                 .contains(&Some(element)),
@@ -1389,6 +1396,7 @@ impl ElementArrays {
                 .values
                 .get(vector.elements_index.into_index())
                 .unwrap()
+                .as_ref()
                 .unwrap()
                 .as_slice()[0..vector.len as usize]
                 .contains(&Some(element)),


### PR DESCRIPTION
This patch implements object property assignment (`a.b = c`).

Additionally, in order to make an assertion in `ordinary_set_with_own_descriptor` not fail, it also implements `PropertyStorage::has` on objects, as well as fixes a stack overflow in `ElementArray::has` caused by the fact that the element arrays were being stored on the stack as part of the computation.
