### PR TITLE
feat(ecmascript): Function argument bindings for simple parameter lists

### DIFF
--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -1209,4 +1209,23 @@ mod test {
         let result = script_evaluation(&mut agent, script).unwrap();
         assert_eq!(result, Value::Integer(SmallInteger::from(42)));
     }
+
+    #[test]
+    fn function_argument_bindings() {
+        let allocator = Allocator::default();
+
+        let mut agent = Agent::new(Options::default(), &DefaultHostHooks);
+        initialize_default_realm(&mut agent);
+        let realm = agent.current_realm_id();
+
+        let script = parse_script(
+            &allocator,
+            "const foo = function (a) { return a + 10; }; foo(32)".into(),
+            realm,
+            None,
+        )
+        .unwrap();
+        let result = script_evaluation(&mut agent, script).unwrap();
+        assert_eq!(result, Value::Integer(SmallInteger::from(42)));
+    }
 }

--- a/nova_vm/src/ecmascript/types/spec/reference.rs
+++ b/nova_vm/src/ecmascript/types/spec/reference.rs
@@ -259,6 +259,32 @@ pub(crate) fn put_value(agent: &mut Agent, v: &Reference, w: Value) -> JsResult<
     // The object that may be created in step 3.a is not accessible outside of the above abstract operation and the ordinary object [[Set]] internal method. An implementation might choose to avoid the actual creation of that object.
 }
 
+/// ### {6.2.5.8 InitializeReferencedBinding ( V, W )}(https://tc39.es/ecma262/#sec-initializereferencedbinding)
+/// The abstract operation InitializeReferencedBinding takes arguments V (a Reference Record) and W
+/// (an ECMAScript language value) and returns either a normal completion containing unused or an
+/// abrupt completion.
+pub(crate) fn initialize_referenced_binding(
+    agent: &mut Agent,
+    v: Reference,
+    w: Value,
+) -> JsResult<()> {
+    // 1. Assert: IsUnresolvableReference(V) is false.
+    debug_assert!(!is_unresolvable_reference(&v));
+    // 2. Let base be V.[[Base]].
+    let base = v.base;
+    // 3. Assert: base is an Environment Record.
+    let Base::Environment(base) = base else {
+        unreachable!()
+    };
+    let referenced_name = match v.referenced_name {
+        ReferencedName::String(data) => String::String(data),
+        ReferencedName::SmallString(data) => String::SmallString(data),
+        ReferencedName::Symbol(_) | ReferencedName::PrivateName => unreachable!(),
+    };
+    // 4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
+    base.initialize_binding(agent, referenced_name, w)
+}
+
 /// ### {6.2.5.7 GetThisValue ( V )}(https://tc39.es/ecma262/#sec-getthisvalue)
 /// The abstract operation GetThisValue takes argument V (a Reference Record)
 /// and returns an ECMAScript language value.

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -18,8 +18,8 @@ use crate::ecmascript::{
         JsResult, ProtoIntrinsics,
     },
     types::{
-        get_value, is_unresolvable_reference, put_value, Base, BigInt, Function, IntoValue, Number,
-        Numeric, Object, PropertyKey, Reference, ReferencedName, String, Value,
+        get_value, initialize_referenced_binding, put_value, Base, BigInt, Function, IntoValue,
+        Number, Numeric, Object, PropertyKey, Reference, ReferencedName, String, Value,
         BUILTIN_STRING_MEMORY,
     },
 };
@@ -437,21 +437,7 @@ impl Vm {
             Instruction::InitializeReferencedBinding => {
                 let v = vm.reference.take().unwrap();
                 let w = vm.result.take().unwrap();
-                // 1. Assert: IsUnresolvableReference(V) is false.
-                debug_assert!(!is_unresolvable_reference(&v));
-                // 2. Let base be V.[[Base]].
-                let base = v.base;
-                // 3. Assert: base is an Environment Record.
-                let Base::Environment(base) = base else {
-                    unreachable!()
-                };
-                let referenced_name = match v.referenced_name {
-                    ReferencedName::String(data) => String::String(data),
-                    ReferencedName::SmallString(data) => String::SmallString(data),
-                    ReferencedName::Symbol(_) | ReferencedName::PrivateName => unreachable!(),
-                };
-                // 4. Return ? base.InitializeBinding(V.[[ReferencedName]], W).
-                base.initialize_binding(agent, referenced_name, w).unwrap();
+                initialize_referenced_binding(agent, v, w)?;
             }
             Instruction::EnterDeclarativeEnvironment => {
                 let outer_env = agent


### PR DESCRIPTION
This patch adds bindings for function arguments for functions that have simple parameter lists (no bindings, initializers or spread arguments).

This wasn't implemented before because the spec text uses iterator machinery to handle complex parameters, resulting in all arguments evaluating to `undefined`. However, for simple parameter lists, the implementation is simple enough, so this patch implements it.
