### PR TITLE
feat(ecmascript): Support getters and setters in `PropertyStorage`

### DIFF
--- a/nova_vm/src/ecmascript/builtins/ordinary.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary.rs
@@ -435,7 +435,7 @@ fn validate_and_apply_property_descriptor(
             }
         }
         // e. Else if current.[[Writable]] is false, then
-        else if let Some(false) = current.writable {
+        else if current.writable == Some(false) {
             // i. If Desc has a [[Writable]] field and Desc.[[Writable]] is true, return false.
             if let Some(true) = descriptor.writable {
                 return Ok(false);

--- a/nova_vm/src/ecmascript/builtins/ordinary.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary.rs
@@ -362,17 +362,12 @@ fn validate_and_apply_property_descriptor(
             //    [[Enumerable]], and [[Configurable]] attributes are set to the value of the
             //    corresponding field in Desc if Desc has that field, or to the attribute's default
             //    value otherwise.
-            // try object.propertyStorage().set(property_key, PropertyDescriptor{
-            //     .value = descriptor.value orelse .undefined,
-            //     .writable = descriptor.writable orelse false,
-            //     .enumerable = descriptor.enumerable orelse false,
-            //     .configurable = descriptor.configurable orelse false,
-            // });
             object.property_storage().set(
                 agent,
                 property_key,
                 PropertyDescriptor {
                     value: Some(descriptor.value.unwrap_or(Value::Undefined)),
+                    writable: Some(descriptor.writable.unwrap_or(false)),
                     enumerable: Some(descriptor.enumerable.unwrap_or(false)),
                     configurable: Some(descriptor.configurable.unwrap_or(false)),
                     ..Default::default()
@@ -401,10 +396,8 @@ fn validate_and_apply_property_descriptor(
 
         // b. If Desc has an [[Enumerable]] field and SameValue(Desc.[[Enumerable]], current.[[Enumerable]])
         //    is false, return false.
-        if let Some(true) = descriptor.enumerable {
-            if descriptor.enumerable != current.enumerable {
-                return Ok(false);
-            }
+        if descriptor.enumerable.is_some() && descriptor.enumerable != current.enumerable {
+            return Ok(false);
         }
 
         // c. If IsGenericDescriptor(Desc) is false and SameValue(IsAccessorDescriptor(Desc), IsAccessorDescriptor(current))
@@ -442,7 +435,7 @@ fn validate_and_apply_property_descriptor(
             }
         }
         // e. Else if current.[[Writable]] is false, then
-        else if let Some(true) = current.writable {
+        else if let Some(false) = current.writable {
             // i. If Desc has a [[Writable]] field and Desc.[[Writable]] is true, return false.
             if let Some(true) = descriptor.writable {
                 return Ok(false);
@@ -541,7 +534,7 @@ fn validate_and_apply_property_descriptor(
                 property_key,
                 PropertyDescriptor {
                     value: descriptor.value.or(current.value),
-                    writable: Some(descriptor.writable.unwrap_or(false)),
+                    writable: descriptor.writable.or(current.writable),
                     get: descriptor.get.or(current.get),
                     set: descriptor.set.or(current.set),
                     enumerable: descriptor.enumerable.or(current.enumerable),

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -849,6 +849,19 @@ mod test {
     }
 
     #[test]
+    fn empty_declared_function_call() {
+        let allocator = Allocator::default();
+
+        let mut agent = Agent::new(Options::default(), &DefaultHostHooks);
+        let realm = create_realm(&mut agent);
+        set_realm_global_object(&mut agent, realm, None, None);
+
+        let script = parse_script(&allocator, "function f() {}; f();".into(), realm, None).unwrap();
+        let result = script_evaluation(&mut agent, script).unwrap();
+        assert!(result.is_undefined());
+    }
+
+    #[test]
     fn non_empty_iife_function_call() {
         let allocator = Allocator::default();
 

--- a/nova_vm/src/heap/element_array.rs
+++ b/nova_vm/src/heap/element_array.rs
@@ -591,7 +591,7 @@ impl ElementDescriptor {
             descriptor.unwrap_or(ElementDescriptor::WritableEnumerableConfigurableData);
         match descriptor {
             ElementDescriptor::WritableEnumerableConfigurableData => PropertyDescriptor {
-                value: value,
+                value,
                 configurable: Some(true),
                 enumerable: Some(true),
                 get: None,
@@ -599,7 +599,7 @@ impl ElementDescriptor {
                 writable: Some(true),
             },
             ElementDescriptor::WritableEnumerableUnconfigurableData => PropertyDescriptor {
-                value: value,
+                value,
                 configurable: Some(false),
                 enumerable: Some(true),
                 get: None,
@@ -607,7 +607,7 @@ impl ElementDescriptor {
                 writable: Some(true),
             },
             ElementDescriptor::WritableUnenumerableConfigurableData => PropertyDescriptor {
-                value: value,
+                value,
                 configurable: Some(true),
                 enumerable: Some(false),
                 get: None,
@@ -615,7 +615,7 @@ impl ElementDescriptor {
                 writable: Some(true),
             },
             ElementDescriptor::WritableUnenumerableUnconfigurableData => PropertyDescriptor {
-                value: value,
+                value,
                 configurable: Some(false),
                 enumerable: Some(false),
                 get: None,
@@ -623,7 +623,7 @@ impl ElementDescriptor {
                 writable: Some(true),
             },
             ElementDescriptor::ReadOnlyEnumerableConfigurableData => PropertyDescriptor {
-                value: value,
+                value,
                 configurable: Some(true),
                 enumerable: Some(true),
                 get: None,
@@ -631,7 +631,7 @@ impl ElementDescriptor {
                 writable: Some(false),
             },
             ElementDescriptor::ReadOnlyEnumerableUnconfigurableData => PropertyDescriptor {
-                value: value,
+                value,
                 configurable: Some(false),
                 enumerable: Some(true),
                 get: None,
@@ -639,7 +639,7 @@ impl ElementDescriptor {
                 writable: Some(false),
             },
             ElementDescriptor::ReadOnlyUnenumerableConfigurableData => PropertyDescriptor {
-                value: value,
+                value,
                 configurable: Some(true),
                 enumerable: Some(false),
                 get: None,
@@ -647,7 +647,7 @@ impl ElementDescriptor {
                 writable: Some(false),
             },
             ElementDescriptor::ReadOnlyUnenumerableUnconfigurableData => PropertyDescriptor {
-                value: value,
+                value,
                 configurable: Some(false),
                 enumerable: Some(false),
                 get: None,


### PR DESCRIPTION
Although currently JS user code can't define getters and setters, there is one usage in internal Nova code in the creation of the `arguments` object for non-lexical-this functions. This change makes it possible to call such functions without panicking.
