### PR TITLE
fix(ecmascript): Make sure built-in functions have `name` and `length`

### DIFF
--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -1352,8 +1352,28 @@ mod test {
         let result = script_evaluation(&mut agent, script).unwrap();
         assert_eq!(result, Value::from_static_str(&mut agent, "foo"));
 
+        let script = parse_script(&allocator, "foo.length".into(), realm, None).unwrap();
+        let result = script_evaluation(&mut agent, script).unwrap();
+        assert_eq!(result, Value::Integer(SmallInteger::zero()));
+
         let script = parse_script(&allocator, "foo.prototype".into(), realm, None).unwrap();
         let result = script_evaluation(&mut agent, script).unwrap();
         assert!(result.is_object())
+    }
+
+    fn name_and_length_on_builtin_functions() {
+        let allocator = Allocator::default();
+
+        let mut agent = Agent::new(Options::default(), &DefaultHostHooks);
+        initialize_default_realm(&mut agent);
+        let realm = agent.current_realm_id();
+
+        let script = parse_script(&allocator, "TypeError.name".into(), realm, None).unwrap();
+        let result = script_evaluation(&mut agent, script).unwrap();
+        assert_eq!(result, Value::from_static_str(&mut agent, "TypeError"));
+
+        let script = parse_script(&allocator, "TypeError.length".into(), realm, None).unwrap();
+        let result = script_evaluation(&mut agent, script).unwrap();
+        assert_eq!(result, Value::Integer(SmallInteger::from(1)));
     }
 }


### PR DESCRIPTION
When built-in functions are created, the `initial_name` and `length` fields of `BuiltinFunctionHeapData` are populated. This means that, if there is no backing object when the function is created, the `name` and `length` properties will have the value given by those fields. This is the case even if a backing object needs to be created later on, since those fields will be added to the backing object.

However, if properties are added to the built-in function as it is being constructed, then there will be a backing object without the `name` and `length` properties, so they will appear to not be set. This is always the case for built-in constructor functions, since they will always have a `prototype` property.

The long-term fix for this would be to avoid duplicating heap data fields in the backing object somehow. However, in the meantime, this patch makes sure that all built-in functions that are created with a backing object have the `name` and `length` properties in it.
