### PR TITLE
feat(ecmascript): Allow object creation with a different prototype

### DIFF
--- a/nova_vm/src/ecmascript/builtins/arguments.rs
+++ b/nova_vm/src/ecmascript/builtins/arguments.rs
@@ -124,7 +124,8 @@ pub(crate) fn create_unmapped_arguments_object(
     let len = arguments_list.len();
     let len = Number::from_f64(agent, len as f64).into_value();
     // 2. Let obj be OrdinaryObjectCreate(%Object.prototype%, « [[ParameterMap]] »).
-    let obj = ordinary_object_create_with_intrinsics(agent, Some(ProtoIntrinsics::Object));
+    // TODO: We need a heap data type with the [[ParameterMap]] internal slot.
+    let obj = ordinary_object_create_with_intrinsics(agent, Some(ProtoIntrinsics::Object), None);
     // 3. Set obj.[[ParameterMap]] to undefined.
     // 4. Perform ! DefinePropertyOrThrow(obj, "length", PropertyDescriptor {
     let key = PropertyKey::from(BUILTIN_STRING_MEMORY.length);

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -780,7 +780,7 @@ pub(crate) fn make_constructor(
     let prototype = prototype.unwrap_or_else(|| {
         // a. Set prototype to OrdinaryObjectCreate(%Object.prototype%).
         let prototype =
-            ordinary_object_create_with_intrinsics(agent, Some(ProtoIntrinsics::Object));
+            ordinary_object_create_with_intrinsics(agent, Some(ProtoIntrinsics::Object), None);
         // b. Perform ! DefinePropertyOrThrow(prototype, "constructor", PropertyDescriptor { [[Value]]: F, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: true }).
         let key = PropertyKey::from(BUILTIN_STRING_MEMORY.constructor);
         define_property_or_throw(

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/boolean_objects/boolean_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/boolean_objects/boolean_constructor.rs
@@ -42,7 +42,7 @@ impl BooleanConstructor {
             return Ok(b.into());
         };
         let new_target = Function::try_from(new_target).unwrap();
-        let _ = ordinary_create_from_constructor(agent, new_target, ProtoIntrinsics::Boolean, ())?;
+        let _ = ordinary_create_from_constructor(agent, new_target, ProtoIntrinsics::Boolean)?;
         todo!();
     }
 

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/error_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/error_constructor.rs
@@ -63,7 +63,7 @@ impl ErrorConstructor {
             |new_target| Function::try_from(new_target).unwrap(),
         );
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%Error.prototype%", « [[ErrorData]] »).
-        let o = ordinary_create_from_constructor(agent, new_target, ProtoIntrinsics::Error, ())?;
+        let o = ordinary_create_from_constructor(agent, new_target, ProtoIntrinsics::Error)?;
         let o = Error::try_from(o).unwrap();
         // b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "message", msg).
         let heap_data = &mut agent[o];

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/native_error_constructors.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/native_error_constructors.rs
@@ -116,7 +116,6 @@ impl NativeErrorConstructors {
             agent,
             Function::try_from(new_target).unwrap(),
             intrinsic,
-            (),
         )?;
         let msg = if !message.is_undefined() {
             Some(to_string(agent, message)?)

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/object_objects/object_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/object_objects/object_constructor.rs
@@ -266,13 +266,12 @@ impl ObjectConstructor {
                 // SAFETY: 'new_target' is checked to be is_some() above
                 unsafe { new_target.unwrap_unchecked() }.try_into().unwrap(),
                 ProtoIntrinsics::Object,
-                (),
             )
             .map(|value| value.into_value())
         } else if value == Value::Undefined || value == Value::Null {
             // 2. If value is either undefined or null, return OrdinaryObjectCreate(%Object.prototype%).
             Ok(
-                ordinary_object_create_with_intrinsics(agent, Some(ProtoIntrinsics::Object))
+                ordinary_object_create_with_intrinsics(agent, Some(ProtoIntrinsics::Object), None)
                     .into_value(),
             )
         } else {

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_constructor.rs
@@ -107,7 +107,7 @@ impl ArrayConstructor {
         // 4. If numberOfArgs = 0, then
         if number_of_args == 0 {
             // a. Return ! ArrayCreate(0, proto).
-            return Ok(array_create(agent, 0, 0, Some(proto)).unwrap().into_value());
+            return Ok(array_create(agent, 0, 0, proto).unwrap().into_value());
         }
 
         // 5. Else if numberOfArgs = 1, then
@@ -116,7 +116,7 @@ impl ArrayConstructor {
             let len = arguments.get(0);
 
             // b. Let array be ! ArrayCreate(0, proto).
-            let array = array_create(agent, 0, 0, Some(proto)).unwrap();
+            let array = array_create(agent, 0, 0, proto).unwrap();
 
             // c. If len is not a Number, then
             let int_len = if !len.is_number() {
@@ -162,7 +162,7 @@ impl ArrayConstructor {
         debug_assert!(number_of_args >= 2);
 
         // b. Let array be ? ArrayCreate(numberOfArgs, proto).
-        let array = array_create(agent, number_of_args, 0, Some(proto))?;
+        let array = array_create(agent, number_of_args, 0, proto)?;
         // NOTE: `array_create` guarantees that it is less than `u32::MAX`
         let number_of_args = number_of_args as u32;
 

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/date_objects/date_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/date_objects/date_constructor.rs
@@ -110,7 +110,6 @@ impl DateConstructor {
             agent,
             Function::try_from(new_target).unwrap(),
             ProtoIntrinsics::Date,
-            (),
         )?;
         // 7. Set O.[[DateValue]] to dv.
         agent[Date::try_from(o).unwrap()].date = Some(dv);

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -285,8 +285,11 @@ impl Vm {
                 vm.result = Some(typeof_operator(agent, val).into())
             }
             Instruction::ObjectCreate => {
-                let object =
-                    ordinary_object_create_with_intrinsics(agent, Some(ProtoIntrinsics::Object));
+                let object = ordinary_object_create_with_intrinsics(
+                    agent,
+                    Some(ProtoIntrinsics::Object),
+                    None,
+                );
                 vm.stack.push(object.into())
             }
             Instruction::InstantiateOrdinaryFunctionExpression => {


### PR DESCRIPTION
Per the spec, OrdinaryCreateFromConstructor should get the `prototype` property of the passed constructor, and if that is an object, it should create a new object whose prototype is that property; otherwise, the prototype would be set to the passed intrinsic default prototype.

In the current implementation of this method, the `prototype` of the passed constructor is obtained, but then it is ignored. The given intrinsic default prototype is used to determine in which heap to store the object, which gives it the right default prototype, but it does not check whether the constructor's `prototype` property matches that default prototype.

It seems like this gets the right result for all of the times where Nova currently does object construction. However, allowing creating an object with a prototype different from the heap's default would be needed for constructing ECMAScript functions.

As part of that, this patch changes `get_prototype_from_constructor` to return a `JsResult<Option<Object>>`, guaranteeing that it will not give the caller an object which is the `ProtoIntrinsics`'s corresponding prototype. It also changes `ordinary_object_create_with_intrinsics` to take an optional prototype object aside from the optional `ProtoIntrinsics`. 

It also changes `ordinary_create_from_constructor` to use the prototype obtained from the constructor, as well as to remove the `_internal_slots_list` parameter. In the spec this parameter is used to create the object with the right internal slots, but in Nova the equivalent of this is choosing in which heap the object is created, which the `ProtoIntrinsics` argument already does.
