### PR TITLE
feat(ecmascript): Allow constructing ECMAScript functions

### DIFF
--- a/nova_vm/src/ecmascript/abstract_operations/testing_and_comparison.rs
+++ b/nova_vm/src/ecmascript/abstract_operations/testing_and_comparison.rs
@@ -71,7 +71,10 @@ pub(crate) fn is_constructor(agent: &mut Agent, constructor: Value) -> bool {
             let behaviour = agent[idx].behaviour;
             matches!(behaviour, Behaviour::Constructor(_))
         }
-        Value::ECMAScriptFunction(idx) => agent[idx].ecmascript_function.is_class_constructor,
+        Value::ECMAScriptFunction(idx) => agent[idx]
+            .ecmascript_function
+            .constructor_status
+            .is_constructor(),
         // TODO: Proxy
         _ => false,
     }

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -534,7 +534,6 @@ impl InternalMethods for ECMAScriptFunction {
         //   a. If result.[[Value]] is an Object, return result.[[Value]].
         if let Ok(value) = Object::try_from(value) {
             return Ok(value);
-            return Ok(Object::try_from(value).unwrap());
         }
         //   b. If kind is base, return thisArgument.
         if is_base {
@@ -838,7 +837,7 @@ pub(crate) fn make_constructor(
         Function::ECMAScriptFunction(idx) => {
             let data = &mut agent[idx];
             // a. Assert: IsConstructor(F) is false.
-            assert!(!data.ecmascript_function.constructor_status.is_constructor());
+            debug_assert!(!data.ecmascript_function.constructor_status.is_constructor());
             // b. Assert: F is an extensible object that does not have a "prototype" own property.
             // TODO: Handle Some() object indexes?
             assert!(data.object_index.is_none());

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -532,7 +532,8 @@ impl InternalMethods for ECMAScriptFunction {
         let value = result?;
         // 10. If result is a return completion, then
         //   a. If result.[[Value]] is an Object, return result.[[Value]].
-        if value.is_object() {
+        if let Ok(value) = Object::try_from(value) {
+            return Ok(value);
             return Ok(Object::try_from(value).unwrap());
         }
         //   b. If kind is base, return thisArgument.

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -1399,7 +1399,7 @@ mod test {
         let script = parse_script(&allocator, "new foo()".into(), realm, None).unwrap();
         let result = match script_evaluation(&mut agent, script) {
             Ok(result) => result,
-            Err(err) => panic!("{}", err.to_string(&mut agent).as_str(&mut agent)),
+            Err(err) => panic!("{}", err.to_string(&mut agent).as_str(&agent)),
         };
         let instance = Object::try_from(result).unwrap();
         assert_eq!(

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -1377,4 +1377,34 @@ mod test {
         let result = script_evaluation(&mut agent, script).unwrap();
         assert_eq!(result, Value::Integer(SmallInteger::from(1)));
     }
+
+    #[test]
+    fn constructor() {
+        let allocator = Allocator::default();
+
+        let mut agent = Agent::new(Options::default(), &DefaultHostHooks);
+        initialize_default_realm(&mut agent);
+        let realm = agent.current_realm_id();
+
+        let script = parse_script(
+            &allocator,
+            "function foo() {}; foo.prototype".into(),
+            realm,
+            None,
+        )
+        .unwrap();
+        let result = script_evaluation(&mut agent, script).unwrap();
+        let foo_prototype = Object::try_from(result).unwrap();
+
+        let script = parse_script(&allocator, "new foo()".into(), realm, None).unwrap();
+        let result = match script_evaluation(&mut agent, script) {
+            Ok(result) => result,
+            Err(err) => panic!("{}", err.to_string(&mut agent).as_str(&mut agent)),
+        };
+        let instance = Object::try_from(result).unwrap();
+        assert_eq!(
+            instance.internal_get_prototype_of(&mut agent).unwrap(),
+            Some(foo_prototype)
+        );
+    }
 }


### PR DESCRIPTION
As part of making this work, this patch merges the internal slots `[[ConstructorKind]]` and `[[IsClassConstructor]]`, as well as the presence or absence of the `[[Construct]]` internal method (which hadn't been implemented in Nova yet) into a single `ConstructorStatus` enum.
