### PR TITLE
feat(ecmascript): Implement the `this` keyword

### DIFF
--- a/nova_vm/src/ecmascript/execution.rs
+++ b/nova_vm/src/ecmascript/execution.rs
@@ -7,11 +7,11 @@ mod realm;
 pub use agent::{Agent, JsResult};
 pub use default_host_hooks::DefaultHostHooks;
 pub(crate) use environments::{
-    new_declarative_environment, new_function_environment, DeclarativeEnvironment,
-    DeclarativeEnvironmentIndex, EnvironmentIndex, Environments, FunctionEnvironment,
-    FunctionEnvironmentIndex, GlobalEnvironment, GlobalEnvironmentIndex, ModuleEnvironmentIndex,
-    ObjectEnvironment, ObjectEnvironmentIndex, PrivateEnvironment, PrivateEnvironmentIndex,
-    ThisBindingStatus,
+    get_this_environment, new_declarative_environment, new_function_environment,
+    DeclarativeEnvironment, DeclarativeEnvironmentIndex, EnvironmentIndex, Environments,
+    FunctionEnvironment, FunctionEnvironmentIndex, GlobalEnvironment, GlobalEnvironmentIndex,
+    ModuleEnvironmentIndex, ObjectEnvironment, ObjectEnvironmentIndex, PrivateEnvironment,
+    PrivateEnvironmentIndex, ThisBindingStatus,
 };
 pub(crate) use execution_context::*;
 pub use realm::{

--- a/nova_vm/src/ecmascript/execution/environments.rs
+++ b/nova_vm/src/ecmascript/execution/environments.rs
@@ -556,7 +556,7 @@ impl Environments {
     }
 }
 
-/// ### {9.4.3 GetThisEnvironment ( )}(https://tc39.es/ecma262/#sec-getthisenvironment)
+/// ### [9.4.3 GetThisEnvironment ( )](https://tc39.es/ecma262/#sec-getthisenvironment)
 /// The abstract operation GetThisEnvironment takes no arguments and returns an
 /// Environment Record. It finds the Environment Record that currently supplies
 /// the binding of the keyword this.

--- a/nova_vm/src/ecmascript/execution/environments.rs
+++ b/nova_vm/src/ecmascript/execution/environments.rs
@@ -555,3 +555,29 @@ impl Environments {
             .expect("ObjectEnvironmentIndex pointed to a None")
     }
 }
+
+/// ### {9.4.3 GetThisEnvironment ( )}(https://tc39.es/ecma262/#sec-getthisenvironment)
+/// The abstract operation GetThisEnvironment takes no arguments and returns an
+/// Environment Record. It finds the Environment Record that currently supplies
+/// the binding of the keyword this.
+pub(crate) fn get_this_environment(agent: &mut Agent) -> EnvironmentIndex {
+    // 1. Let env be the running execution context's LexicalEnvironment.
+    let mut env = agent
+        .running_execution_context()
+        .ecmascript_code
+        .as_ref()
+        .unwrap()
+        .lexical_environment;
+    // 2. Repeat,
+    loop {
+        // a. Let exists be env.HasThisBinding().
+        // b. If exists is true, return env.
+        if env.has_this_binding(agent) {
+            return env;
+        }
+        // c. Let outer be env.[[OuterEnv]].
+        // d. Assert: outer is not null.
+        // e. Set env to outer.
+        env = env.get_outer_env(agent).unwrap();
+    }
+}

--- a/nova_vm/src/ecmascript/execution/environments/function_environment.rs
+++ b/nova_vm/src/ecmascript/execution/environments/function_environment.rs
@@ -122,6 +122,25 @@ impl FunctionEnvironmentIndex {
         self.heap_data(agent).this_binding_status
     }
 
+    /// ### [9.1.1.3.4 GetThisBinding ( )](https://tc39.es/ecma262/#sec-function-environment-records-getthisbinding)
+    /// The GetThisBinding concrete method of a Function Environment Record
+    /// envRec takes no arguments and returns either a normal completion
+    /// containing an ECMAScript language value or a throw completion.
+    pub(crate) fn get_this_binding(self, agent: &mut Agent) -> JsResult<Value> {
+        // 1. Assert: envRec.[[ThisBindingStatus]] is not lexical.
+        // 2. If envRec.[[ThisBindingStatus]] is uninitialized, throw a ReferenceError exception.
+        // 3. Return envRec.[[ThisValue]].
+        let env_rec = self.heap_data(agent);
+        match env_rec.this_binding_status {
+            ThisBindingStatus::Lexical => unreachable!(),
+            ThisBindingStatus::Initialized => Ok(env_rec.this_value.unwrap()),
+            ThisBindingStatus::Uninitialized => {
+                Err(agent
+                    .throw_exception(ExceptionType::ReferenceError, "Uninitialized this binding"))
+            }
+        }
+    }
+
     /// ### [9.1.1.1.1 HasBinding ( N )](https://tc39.es/ecma262/#sec-declarative-environment-records-hasbinding-n)
     pub(crate) fn has_binding(self, agent: &Agent, name: String) -> bool {
         let env_rec = self.heap_data(agent);

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -1407,4 +1407,33 @@ mod test {
             Some(foo_prototype)
         );
     }
+
+    #[test]
+    fn this_expression() {
+        let allocator = Allocator::default();
+
+        let mut agent = Agent::new(Options::default(), &DefaultHostHooks);
+        initialize_default_realm(&mut agent);
+        let realm = agent.current_realm_id();
+
+        let script = parse_script(
+            &allocator,
+            "function foo() { this.bar = 42; }; new foo().bar".into(),
+            realm,
+            None,
+        )
+        .unwrap();
+        let result = script_evaluation(&mut agent, script).unwrap();
+        assert_eq!(result, Value::Integer(SmallInteger::from(42)));
+
+        let script = parse_script(
+            &allocator,
+            "foo.prototype.baz = function() { return this.bar + 10; }; (new foo()).baz()".into(),
+            realm,
+            None,
+        )
+        .unwrap();
+        let result = script_evaluation(&mut agent, script).unwrap();
+        assert_eq!(result, Value::Integer(SmallInteger::from(52)));
+    }
 }

--- a/nova_vm/src/engine/bytecode/executable.rs
+++ b/nova_vm/src/engine/bytecode/executable.rs
@@ -801,6 +801,12 @@ impl CompileEvaluation for ast::PrivateFieldExpression<'_> {
     }
 }
 
+impl CompileEvaluation for ast::ThisExpression {
+    fn compile(&self, ctx: &mut CompileContext) {
+        ctx.exe.add_instruction(Instruction::ResolveThisBinding);
+    }
+}
+
 impl CompileEvaluation for ast::Expression<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
         match self {
@@ -822,6 +828,7 @@ impl CompileEvaluation for ast::Expression<'_> {
             ast::Expression::UpdateExpression(x) => x.compile(ctx),
             ast::Expression::ArrayExpression(x) => x.compile(ctx),
             ast::Expression::NewExpression(x) => x.compile(ctx),
+            ast::Expression::ThisExpression(x) => x.compile(ctx),
             other => todo!("{other:?}"),
         }
     }


### PR DESCRIPTION
This patch also fixes a bug in which functions created with the `InstantiateOrdinaryFunctionExpression` bytecode instruction were created with a lexical this mode, when it should be either strict or global. The lexical this mode is only used for arrow functions, and it causes the `this` resolution to be wrong in other functions.

Do not merge before #196.
