### PR TITLE
chore(nova_cli): Don't print debug information by default

### DIFF
--- a/nova_cli/src/main.rs
+++ b/nova_cli/src/main.rs
@@ -25,6 +25,9 @@ enum Command {
 
     /// Evaluates a file
     Eval {
+        #[arg(short, long)]
+        verbose: bool,
+
         /// The file to evaluate
         path: String,
     },
@@ -43,7 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             println!("{:?}", result.program);
         }
-        Command::Eval { path } => {
+        Command::Eval { verbose, path } => {
             let file = std::fs::read_to_string(path)?;
             let allocator = Default::default();
 
@@ -54,7 +57,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let script = parse_script(&allocator, file.into(), realm, None).unwrap();
             let result = script_evaluation(&mut agent, script).unwrap();
 
-            println!("{:?}", result);
+            if verbose {
+                println!("{:?}", result);
+            }
         }
     }
 

--- a/nova_vm/src/ecmascript/execution/agent.rs
+++ b/nova_vm/src/ecmascript/execution/agent.rs
@@ -22,8 +22,7 @@ use std::collections::HashMap;
 #[derive(Debug, Default)]
 pub struct Options {
     pub disable_gc: bool,
-    pub print_ast: bool,
-    pub print_bytecode: bool,
+    pub print_internals: bool,
 }
 
 pub type JsResult<T> = std::result::Result<T, JsError>;

--- a/nova_vm/src/engine/bytecode/executable.rs
+++ b/nova_vm/src/engine/bytecode/executable.rs
@@ -90,9 +90,11 @@ impl Executable {
     }
 
     pub(crate) fn compile_script(agent: &mut Agent, script: ScriptIdentifier) -> Executable {
-        eprintln!();
-        eprintln!("=== Compiling Script ===");
-        eprintln!();
+        if agent.options.print_internals {
+            eprintln!();
+            eprintln!("=== Compiling Script ===");
+            eprintln!();
+        }
         // SAFETY: Script uniquely owns the Program and the body buffer does
         // not move under any circumstances during heap operations.
         let body: &[Statement] =
@@ -102,9 +104,11 @@ impl Executable {
     }
 
     pub(crate) fn compile_function_body(agent: &mut Agent, body: &FunctionBody<'_>) -> Executable {
-        eprintln!();
-        eprintln!("=== Compiling Function ===");
-        eprintln!();
+        if agent.options.print_internals {
+            eprintln!();
+            eprintln!("=== Compiling Function ===");
+            eprintln!();
+        }
         // SAFETY: Script referred by the Function uniquely owns the Program
         // and the body buffer does not move under any circumstances during
         // heap operations.


### PR DESCRIPTION
To reenable printing that information, this patch also adds a `--verbose` flag to `nova_cli`.
