### PR TITLE
feat(nova_cli): Add a `print` global function

### DIFF
--- a/nova_cli/src/main.rs
+++ b/nova_cli/src/main.rs
@@ -1,7 +1,8 @@
 use clap::{Parser as ClapParser, Subcommand};
 use nova_vm::ecmascript::{
-    execution::{agent::Options, initialize_default_realm, Agent, DefaultHostHooks},
+    execution::{agent::Options, initialize_host_defined_realm, Agent, DefaultHostHooks, Realm},
     scripts_and_modules::script::{parse_script, script_evaluation},
+    types::Object,
 };
 use oxc_parser::Parser;
 use oxc_span::SourceType;
@@ -51,7 +52,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let allocator = Default::default();
 
             let mut agent = Agent::new(Options::default(), &DefaultHostHooks);
-            initialize_default_realm(&mut agent);
+            {
+                let create_global_object: Option<fn(&mut Realm) -> Object> = None;
+                let create_global_this_value: Option<fn(&mut Realm) -> Object> = None;
+                initialize_host_defined_realm(
+                    &mut agent,
+                    create_global_object,
+                    create_global_this_value,
+                    Some(initialize_global_object),
+                );
+            }
             let realm = agent.current_realm_id();
 
             let script = parse_script(&allocator, file.into(), realm, None).unwrap();
@@ -64,4 +74,38 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+fn initialize_global_object(agent: &mut Agent, global: Object) {
+    use nova_vm::ecmascript::{
+        builtins::{create_builtin_function, ArgumentsList, Behaviour, BuiltinFunctionArgs},
+        execution::JsResult,
+        types::{InternalMethods, IntoValue, PropertyDescriptor, PropertyKey, Value},
+    };
+
+    // `print` function
+    fn print(agent: &mut Agent, _this: Value, args: ArgumentsList) -> JsResult<Value> {
+        if args.len() == 0 || args[0].is_undefined() {
+            println!();
+        } else {
+            println!("{}", args[0].to_string(agent)?.as_str(agent));
+        }
+        Ok(Value::Undefined)
+    }
+    let function = create_builtin_function(
+        agent,
+        Behaviour::Regular(print),
+        BuiltinFunctionArgs::new(1, "print", agent.current_realm_id()),
+    );
+    let property_key = PropertyKey::from_static_str(agent, "print");
+    global
+        .internal_define_own_property(
+            agent,
+            property_key,
+            PropertyDescriptor {
+                value: Some(function.into_value()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 }

--- a/nova_vm/src/ecmascript/execution.rs
+++ b/nova_vm/src/ecmascript/execution.rs
@@ -16,5 +16,6 @@ pub(crate) use environments::{
 pub(crate) use execution_context::*;
 pub use realm::{
     create_realm, initialize_default_realm, initialize_host_defined_realm, set_realm_global_object,
+    Realm,
 };
-pub(crate) use realm::{Intrinsics, ProtoIntrinsics, Realm, RealmIdentifier};
+pub(crate) use realm::{Intrinsics, ProtoIntrinsics, RealmIdentifier};

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     ecmascript::{
         abstract_operations::type_conversion::{
-            to_big_int, to_int32, to_number, to_numeric, to_uint32,
+            to_big_int, to_int32, to_number, to_numeric, to_string, to_uint32,
         },
         execution::{Agent, JsResult},
         scripts_and_modules::module::ModuleIdentifier,
@@ -400,6 +400,10 @@ impl Value {
 
     pub fn to_uint32(self, agent: &mut Agent) -> JsResult<u32> {
         to_uint32(agent, self)
+    }
+
+    pub fn to_string(self, agent: &mut Agent) -> JsResult<String> {
+        to_string(agent, self)
     }
 
     /// ### [ℝ](https://tc39.es/ecma262/#%E2%84%9D)


### PR DESCRIPTION
In order to implement this, this patch also publicly exposes `Realm` (since using that type is needed to call `initialize_host_defined_realm`), and it also adds a public `Value::to_string` method.
