### PR TITLE
feat(vm): instanceof

### DIFF
--- a/nova_vm/src/ecmascript/abstract_operations/testing_and_comparison.rs
+++ b/nova_vm/src/ecmascript/abstract_operations/testing_and_comparison.rs
@@ -49,12 +49,12 @@ pub(crate) fn is_array(_agent: &Agent, argument: Value) -> JsResult<bool> {
 /// The abstract operation IsCallable takes argument argument (an ECMAScript
 /// language value) and returns a Boolean. It determines if argument is a
 /// callable function with a [[Call]] internal method.
-pub(crate) fn is_callable(argument: Value) -> bool {
+pub(crate) fn is_callable(argument: impl IntoValue) -> bool {
     // 1. If argument is not an Object, return false.
     // 2. If argument has a [[Call]] internal method, return true.
     // 3. Return false.
     matches!(
-        argument,
+        argument.into_value(),
         Value::BoundFunction(_) | Value::BuiltinFunction(_) | Value::ECMAScriptFunction(_)
     )
 }

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/async_from_sync_iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/async_from_sync_iterator_prototype.rs
@@ -41,10 +41,12 @@ impl AsyncFromSyncIteratorPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let async_iterator_prototype = intrinsics.async_iterator_prototype();
         let this = intrinsics.async_from_sync_iterator_prototype();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(3)
+            .with_prototype(async_iterator_prototype)
             .with_builtin_function_property::<AsyncFromSyncIteratorPrototypeNext>()
             .with_builtin_function_property::<AsyncFromSyncIteratorPrototypeReturn>()
             .with_builtin_function_property::<AsyncFromSyncIteratorPrototypeThrow>()

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/async_iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/async_iterator_prototype.rs
@@ -26,10 +26,12 @@ impl AsyncIteratorPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.async_iterator_prototype();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(1)
+            .with_prototype(object_prototype)
             .with_builtin_function_getter_property::<AsyncIteratorPrototypeIterator>()
             .build();
     }

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/iterator_prototype.rs
@@ -27,10 +27,12 @@ impl IteratorPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.iterator_prototype();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(1)
+            .with_prototype(object_prototype)
             .with_builtin_function_getter_property::<IteratorPrototypeIterator>()
             .build();
     }

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_prototype.rs
@@ -44,11 +44,13 @@ impl PromisePrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.promise_prototype();
         let promise_constructor = intrinsics.promise();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(5)
+            .with_prototype(object_prototype)
             .with_builtin_function_property::<PromisePrototypeCatch>()
             .with_constructor_property(promise_constructor)
             .with_builtin_function_property::<PromisePrototypeFinally>()

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/boolean_objects/boolean_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/boolean_objects/boolean_prototype.rs
@@ -43,11 +43,13 @@ impl BooleanPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.boolean_prototype();
         let boolean_constructor = intrinsics.boolean();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(3)
+            .with_prototype(object_prototype)
             .with_constructor_property(boolean_constructor)
             .with_builtin_function_property::<BooleanPrototypeToString>()
             .with_builtin_function_property::<BooleanPrototypeValueOf>()

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/error_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/error_prototype.rs
@@ -59,11 +59,13 @@ impl ErrorPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.error_prototype();
         let error_constructor = intrinsics.error();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(4)
+            .with_prototype(object_prototype)
             .with_constructor_property(error_constructor)
             .with_property(|builder| {
                 builder

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/native_error_prototypes.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/native_error_prototypes.rs
@@ -8,6 +8,7 @@ pub(crate) struct NativeErrorPrototypes;
 impl NativeErrorPrototypes {
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let error_prototype = intrinsics.error_prototype();
         let eval_constructor = intrinsics.eval_error();
         let eval_this = intrinsics.eval_error_prototype();
         let range_constructor = intrinsics.range_error();
@@ -23,6 +24,7 @@ impl NativeErrorPrototypes {
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, eval_this)
             .with_property_capacity(3)
+            .with_prototype(error_prototype)
             .with_constructor_property(eval_constructor)
             .with_property(|builder| {
                 builder
@@ -41,6 +43,7 @@ impl NativeErrorPrototypes {
             .build();
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, range_this)
             .with_property_capacity(3)
+            .with_prototype(error_prototype)
             .with_constructor_property(range_constructor)
             .with_property(|builder| {
                 builder
@@ -59,6 +62,7 @@ impl NativeErrorPrototypes {
             .build();
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, reference_this)
             .with_property_capacity(3)
+            .with_prototype(error_prototype)
             .with_constructor_property(reference_constructor)
             .with_property(|builder| {
                 builder
@@ -77,6 +81,7 @@ impl NativeErrorPrototypes {
             .build();
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, syntax_this)
             .with_property_capacity(3)
+            .with_prototype(error_prototype)
             .with_constructor_property(syntax_constructor)
             .with_property(|builder| {
                 builder
@@ -95,6 +100,7 @@ impl NativeErrorPrototypes {
             .build();
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, type_this)
             .with_property_capacity(3)
+            .with_prototype(error_prototype)
             .with_constructor_property(type_constructor)
             .with_property(|builder| {
                 builder
@@ -113,6 +119,7 @@ impl NativeErrorPrototypes {
             .build();
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, uri_this)
             .with_property_capacity(3)
+            .with_prototype(error_prototype)
             .with_constructor_property(uri_constructor)
             .with_property(|builder| {
                 builder

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/function_objects/function_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/function_objects/function_constructor.rs
@@ -39,11 +39,12 @@ impl FunctionConstructor {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
-        let function_prototype = intrinsics.function_prototype();
+        let function_prototype = intrinsics.function_prototype().into_object();
 
         BuiltinFunctionBuilder::new_intrinsic_constructor::<FunctionConstructor>(agent, realm)
             .with_property_capacity(1)
-            .with_prototype_property(function_prototype.into_object())
+            .with_prototype(function_prototype)
+            .with_prototype_property(function_prototype)
             .build();
     }
 }

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/function_objects/function_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/function_objects/function_prototype.rs
@@ -9,7 +9,9 @@ use crate::{
             ArgumentsList, Behaviour, Builtin, BuiltinIntrinsic, BuiltinIntrinsicConstructor,
         },
         execution::{agent::ExceptionType, Agent, JsResult, RealmIdentifier},
-        types::{Function, IntoFunction, IntoValue, String, Value, BUILTIN_STRING_MEMORY},
+        types::{
+            Function, IntoFunction, IntoObject, IntoValue, String, Value, BUILTIN_STRING_MEMORY,
+        },
     },
     heap::{IntrinsicConstructorIndexes, IntrinsicFunctionIndexes, WellKnownSymbolIndexes},
 };
@@ -206,12 +208,13 @@ impl FunctionPrototype {
         ThrowTypeError::create_intrinsic(agent, realm);
 
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype().into_object();
         let throw_type_error = intrinsics.throw_type_error().into_function();
         let function_constructor = intrinsics.function();
 
         BuiltinFunctionBuilder::new_intrinsic_constructor::<FunctionPrototype>(agent, realm)
             .with_property_capacity(8)
-            .with_null_prototype()
+            .with_prototype(object_prototype)
             // 10.2.4 AddRestrictedFunctionProperties ( F, realm )
             .with_property(|builder| {
                 builder

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/object_objects/object_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/object_objects/object_prototype.rs
@@ -157,7 +157,6 @@ impl ObjectPrototype {
             Value::Number(_) | Value::Integer(_) | Value::Float(_) => {
                 Ok(BUILTIN_STRING_MEMORY._object_Number_.into_value())
             }
-            Value::Object(_) => todo!(),
             // 4. Let isArray be ? IsArray(O).
             // 5. If isArray is true, let builtinTag be "Array".
             Value::Array(_) => Ok(BUILTIN_STRING_MEMORY._object_Array_.into_value()),

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/symbol_objects/symbol_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/symbol_objects/symbol_prototype.rs
@@ -75,6 +75,7 @@ impl SymbolPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.symbol_prototype();
         let symbol_constructor = intrinsics.symbol();
 
@@ -125,6 +126,7 @@ impl SymbolPrototype {
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(6)
+            .with_prototype(object_prototype)
             .with_constructor_property(symbol_constructor)
             .with_builtin_function_getter_property::<SymbolPrototypeGetDescription>()
             .with_builtin_function_property::<SymbolPrototypeToString>()

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_constructor.rs
@@ -445,10 +445,12 @@ impl ArrayConstructor {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let function_prototype = intrinsics.function_prototype().into_object();
         let array_prototype = intrinsics.array_prototype();
 
         BuiltinFunctionBuilder::new_intrinsic_constructor::<ArrayConstructor>(agent, realm)
             .with_property_capacity(5)
+            .with_prototype(function_prototype)
             .with_builtin_function_property::<ArrayFrom>()
             .with_builtin_function_property::<ArrayIsArray>()
             .with_builtin_function_property::<ArrayOf>()

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
@@ -419,12 +419,14 @@ impl ArrayPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.array_prototype();
         let array_constructor = intrinsics.array();
         let array_prototype_values = intrinsics.array_prototype_values();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(41)
+            .with_prototype(object_prototype)
             .with_builtin_function_property::<ArrayPrototypeAt>()
             .with_builtin_function_property::<ArrayPrototypeConcat>()
             .with_constructor_property(array_constructor)

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_intrinsic_object.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_intrinsic_object.rs
@@ -515,12 +515,14 @@ impl TypedArrayPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.typed_array_prototype();
         let typed_array_constructor = intrinsics.typed_array();
         let typed_array_prototype_values = intrinsics.typed_array_prototype_values();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(38)
+            .with_prototype(object_prototype)
             .with_builtin_function_property::<TypedArrayPrototypeAt>()
             .with_builtin_function_getter_property::<TypedArrayPrototypeGetBuffer>()
             .with_builtin_function_getter_property::<TypedArrayPrototypeGetByteLength>()

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_prototype.rs
@@ -123,6 +123,7 @@ impl MapPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.map_prototype();
         let map_constructor = intrinsics.map();
 
@@ -130,6 +131,7 @@ impl MapPrototype {
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(13)
+            .with_prototype(object_prototype)
             .with_builtin_function_property::<MapPrototypeClear>()
             .with_constructor_property(map_constructor)
             .with_builtin_function_property::<MapPrototypeDelete>()

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_prototype.rs
@@ -110,12 +110,14 @@ impl SetPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.set_prototype();
         let set_constructor = intrinsics.set();
         let set_prototype_values = intrinsics.set_prototype_values();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(12)
+            .with_prototype(object_prototype)
             .with_builtin_function_property::<SetPrototypeAdd>()
             .with_builtin_function_property::<SetPrototypeClear>()
             .with_constructor_property(set_constructor)

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/weak_map_objects/weak_map_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/weak_map_objects/weak_map_prototype.rs
@@ -54,11 +54,13 @@ impl WeakMapPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.weak_map_prototype();
         let weak_map_constructor = intrinsics.weak_map();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(6)
+            .with_prototype(object_prototype)
             .with_constructor_property(weak_map_constructor)
             .with_builtin_function_property::<WeakMapPrototypeDelete>()
             .with_builtin_function_property::<WeakMapPrototypeGet>()

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/weak_set_objects/weak_set_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/weak_set_objects/weak_set_prototype.rs
@@ -44,11 +44,13 @@ impl WeakSetPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.weak_set_prototype();
         let weak_set_constructor = intrinsics.weak_set();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(5)
+            .with_prototype(object_prototype)
             .with_builtin_function_property::<WeakSetPrototypeAdd>()
             .with_constructor_property(weak_set_constructor)
             .with_builtin_function_property::<WeakSetPrototypeDelete>()

--- a/nova_vm/src/ecmascript/builtins/managing_memory/finalization_registry_objects/finalization_registry_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/managing_memory/finalization_registry_objects/finalization_registry_prototype.rs
@@ -34,11 +34,13 @@ impl FinalizationRegistryPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.finalization_registry_prototype();
         let finalization_registry_constructor = intrinsics.finalization_registry();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(4)
+            .with_prototype(object_prototype)
             .with_constructor_property(finalization_registry_constructor)
             .with_builtin_function_property::<FinalizationRegistryPrototypeRegister>()
             .with_builtin_function_property::<FinalizationRegistryPrototypeUnregister>()

--- a/nova_vm/src/ecmascript/builtins/managing_memory/weak_ref_objects/weak_ref_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/managing_memory/weak_ref_objects/weak_ref_prototype.rs
@@ -24,11 +24,13 @@ impl WeakRefPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.weak_ref_prototype();
         let weak_ref_constructor = intrinsics.weak_ref();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(3)
+            .with_prototype(object_prototype)
             .with_constructor_property(weak_ref_constructor)
             .with_builtin_function_property::<WeakRefPrototypeDeref>()
             .with_property(|builder| {

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/bigint_objects/bigint_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/bigint_objects/bigint_prototype.rs
@@ -70,11 +70,13 @@ impl BigIntPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.big_int_prototype();
         let big_int_constructor = intrinsics.big_int();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(5)
+            .with_prototype(object_prototype)
             .with_constructor_property(big_int_constructor)
             .with_builtin_function_property::<BigIntPrototypeToLocaleString>()
             .with_builtin_function_property::<BigIntPrototypeToString>()

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/date_objects/date_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/date_objects/date_prototype.rs
@@ -576,11 +576,13 @@ impl DatePrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.date_prototype();
         let date_constructor = intrinsics.date();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(45)
+            .with_prototype(object_prototype)
             .with_constructor_property(date_constructor)
             .with_builtin_function_property::<DatePrototypeGetDate>()
             .with_builtin_function_property::<DatePrototypeGetDay>()

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/math_object.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/math_object.rs
@@ -529,10 +529,12 @@ impl MathObject {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.math();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(44)
+            .with_prototype(object_prototype)
             .with_property(|builder| {
                 builder
                     .with_key(BUILTIN_STRING_MEMORY.E.into())

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/number_objects/number_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/number_objects/number_prototype.rs
@@ -176,11 +176,13 @@ impl NumberPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.number_prototype();
         let number_constructor = intrinsics.number();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(7)
+            .with_prototype(object_prototype)
             .with_constructor_property(number_constructor)
             .with_builtin_function_property::<NumberPrototypeToExponential>()
             .with_builtin_function_property::<NumberPrototypeToFixed>()

--- a/nova_vm/src/ecmascript/builtins/ordinary.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary.rs
@@ -1108,7 +1108,7 @@ pub(crate) fn get_prototype_from_constructor(
     // intended to be used as the [[Prototype]] value of an object.
     // 2. Let proto be ? Get(constructor, "prototype").
     let prototype_key = BUILTIN_STRING_MEMORY.prototype.into();
-    let proto = get(agent, constructor.into(), prototype_key)?;
+    let proto = get(agent, constructor, prototype_key)?;
     // 3. If proto is not an Object, then
     //   a. Let realm be ? GetFunctionRealm(constructor).
     //   b. Set proto to realm's intrinsic object named intrinsicDefaultProto.

--- a/nova_vm/src/ecmascript/builtins/reflection/reflect_object.rs
+++ b/nova_vm/src/ecmascript/builtins/reflection/reflect_object.rs
@@ -221,10 +221,12 @@ impl ReflectObject {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.reflect();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(14)
+            .with_prototype(object_prototype)
             .with_builtin_function_property::<ReflectObjectApply>()
             .with_builtin_function_property::<ReflectObjectConstruct>()
             .with_builtin_function_property::<ReflectObjectDefineProperty>()

--- a/nova_vm/src/ecmascript/builtins/structured_data/array_buffer_objects/array_buffer_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/array_buffer_objects/array_buffer_prototype.rs
@@ -118,11 +118,13 @@ impl ArrayBufferPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.array_buffer_prototype();
         let array_buffer_constructor = intrinsics.array_buffer();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(10)
+            .with_prototype(object_prototype)
             .with_builtin_function_getter_property::<ArrayBufferPrototypeGetByteLength>()
             .with_constructor_property(array_buffer_constructor)
             .with_builtin_function_getter_property::<ArrayBufferPrototypeGetDetached>()

--- a/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
@@ -204,10 +204,12 @@ impl AtomicsObject {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.atomics();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(14)
+            .with_prototype(object_prototype)
             .with_builtin_function_property::<AtomicsObjectAdd>()
             .with_builtin_function_property::<AtomicsObjectAnd>()
             .with_builtin_function_property::<AtomicsObjectCompareExchange>()

--- a/nova_vm/src/ecmascript/builtins/structured_data/data_view_objects/data_view_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/data_view_objects/data_view_prototype.rs
@@ -261,11 +261,13 @@ impl DataViewPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.data_view_prototype();
         let data_view_constructor = intrinsics.data_view();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(25)
+            .with_prototype(object_prototype)
             .with_builtin_function_getter_property::<DataViewPrototypeGetBuffer>()
             .with_builtin_function_getter_property::<DataViewPrototypeGetByteLength>()
             .with_builtin_function_getter_property::<DataViewPrototypeGetByteOffset>()

--- a/nova_vm/src/ecmascript/builtins/structured_data/json_object.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/json_object.rs
@@ -45,10 +45,12 @@ impl JSONObject {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.json();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(3)
+            .with_prototype(object_prototype)
             .with_builtin_function_property::<JSONObjectParse>()
             .with_builtin_function_property::<JSONObjectStringify>()
             .with_property(|builder| {

--- a/nova_vm/src/ecmascript/builtins/structured_data/shared_array_buffer_objects/shared_array_buffer_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/shared_array_buffer_objects/shared_array_buffer_prototype.rs
@@ -82,11 +82,13 @@ impl SharedArrayBufferPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.shared_array_buffer_prototype();
         let shared_array_buffer_constructor = intrinsics.shared_array_buffer();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(7)
+            .with_prototype(object_prototype)
             .with_builtin_function_getter_property::<SharedArrayBufferPrototypeGetByteLength>()
             .with_constructor_property(shared_array_buffer_constructor)
             .with_builtin_function_property::<SharedArrayBufferPrototypeGrow>()

--- a/nova_vm/src/ecmascript/builtins/text_processing/regexp_objects/regexp_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/text_processing/regexp_objects/regexp_prototype.rs
@@ -242,11 +242,13 @@ impl RegExpPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.reg_exp_prototype();
         let reg_exp_constructor = intrinsics.reg_exp();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(19)
+            .with_prototype(object_prototype)
             .with_constructor_property(reg_exp_constructor)
             .with_builtin_intrinsic_function_property::<RegExpPrototypeExec>()
             .with_builtin_function_getter_property::<RegExpPrototypeGetDotAll>()

--- a/nova_vm/src/ecmascript/builtins/text_processing/string_objects/string_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/text_processing/string_objects/string_prototype.rs
@@ -385,11 +385,13 @@ impl StringPrototype {
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {
         let intrinsics = agent.get_realm(realm).intrinsics();
+        let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.string_prototype();
         let string_constructor = intrinsics.string();
 
         OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
             .with_property_capacity(36)
+            .with_prototype(object_prototype)
             .with_builtin_function_property::<StringPrototypeGetAt>()
             .with_builtin_function_property::<StringPrototypeCharAt>()
             .with_builtin_function_property::<StringPrototypeCharCodeAt>()

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -1486,4 +1486,34 @@ mod test {
         let value = script_evaluation(&mut agent, script).unwrap();
         assert_eq!(value, Value::from_static_str(&mut agent, "Symbol(foo)"));
     }
+
+    #[test]
+    fn instanceof() {
+        let allocator = Allocator::default();
+
+        let mut agent = Agent::new(Options::default(), &DefaultHostHooks);
+        initialize_default_realm(&mut agent);
+        let realm = agent.current_realm_id();
+
+        let script = parse_script(&allocator, "3 instanceof Number".into(), realm, None).unwrap();
+        assert_eq!(script_evaluation(&mut agent, script).unwrap(), false.into());
+
+        let script =
+            parse_script(&allocator, "'foo' instanceof String".into(), realm, None).unwrap();
+        assert_eq!(script_evaluation(&mut agent, script).unwrap(), false.into());
+
+        let script =
+            parse_script(&allocator, "({}) instanceof Object".into(), realm, None).unwrap();
+        assert_eq!(script_evaluation(&mut agent, script).unwrap(), true.into());
+
+        let script = parse_script(&allocator, "({}) instanceof Array".into(), realm, None).unwrap();
+        assert_eq!(script_evaluation(&mut agent, script).unwrap(), false.into());
+
+        let script =
+            parse_script(&allocator, "([]) instanceof Object".into(), realm, None).unwrap();
+        assert_eq!(script_evaluation(&mut agent, script).unwrap(), true.into());
+
+        let script = parse_script(&allocator, "([]) instanceof Array".into(), realm, None).unwrap();
+        assert_eq!(script_evaluation(&mut agent, script).unwrap(), true.into());
+    }
 }

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -109,6 +109,67 @@ pub enum Object {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct OrdinaryObject(pub(crate) ObjectIndex);
 
+impl IntoValue for Object {
+    fn into_value(self) -> Value {
+        match self {
+            Object::Object(data) => Value::Object(data),
+            Object::BoundFunction(data) => Value::BoundFunction(data),
+            Object::BuiltinFunction(data) => Value::BuiltinFunction(data),
+            Object::ECMAScriptFunction(data) => Value::ECMAScriptFunction(data),
+            Object::BuiltinGeneratorFunction => todo!(),
+            Object::BuiltinConstructorFunction => todo!(),
+            Object::BuiltinPromiseResolveFunction => todo!(),
+            Object::BuiltinPromiseRejectFunction(data) => Value::BuiltinPromiseRejectFunction(data),
+            Object::BuiltinPromiseCollectorFunction => todo!(),
+            Object::BuiltinProxyRevokerFunction => todo!(),
+            Object::ECMAScriptAsyncFunction => todo!(),
+            Object::ECMAScriptAsyncGeneratorFunction => todo!(),
+            Object::ECMAScriptConstructorFunction => todo!(),
+            Object::ECMAScriptGeneratorFunction => todo!(),
+            Object::PrimitiveObject(data) => Value::PrimitiveObject(data),
+            Object::Arguments => todo!(),
+            Object::Array(data) => Value::Array(data),
+            Object::ArrayBuffer(data) => Value::ArrayBuffer(data),
+            Object::DataView(data) => Value::DataView(data),
+            Object::Date(data) => Value::Date(data),
+            Object::Error(data) => Value::Error(data),
+            Object::FinalizationRegistry(data) => Value::FinalizationRegistry(data),
+            Object::Map(data) => Value::Map(data),
+            Object::Promise(data) => Value::Promise(data),
+            Object::Proxy(data) => Value::Proxy(data),
+            Object::RegExp(data) => Value::RegExp(data),
+            Object::Set(data) => Value::Set(data),
+            Object::SharedArrayBuffer(data) => Value::SharedArrayBuffer(data),
+            Object::WeakMap(data) => Value::WeakMap(data),
+            Object::WeakRef(data) => Value::WeakRef(data),
+            Object::WeakSet(data) => Value::WeakSet(data),
+            Object::Int8Array(data) => Value::Int8Array(data),
+            Object::Uint8Array(data) => Value::Uint8Array(data),
+            Object::Uint8ClampedArray(data) => Value::Uint8ClampedArray(data),
+            Object::Int16Array(data) => Value::Int16Array(data),
+            Object::Uint16Array(data) => Value::Uint16Array(data),
+            Object::Int32Array(data) => Value::Int32Array(data),
+            Object::Uint32Array(data) => Value::Uint32Array(data),
+            Object::BigInt64Array(data) => Value::BigInt64Array(data),
+            Object::BigUint64Array(data) => Value::BigUint64Array(data),
+            Object::Float32Array(data) => Value::Float32Array(data),
+            Object::Float64Array(data) => Value::Float64Array(data),
+            Object::AsyncFromSyncIterator => todo!(),
+            Object::AsyncIterator => todo!(),
+            Object::Iterator => todo!(),
+            Object::Module(data) => Value::Module(data),
+            Object::EmbedderObject(data) => Value::EmbedderObject(data),
+        }
+    }
+}
+
+impl IntoObject for Object {
+    #[inline(always)]
+    fn into_object(self) -> Object {
+        self
+    }
+}
+
 impl IntoObject for OrdinaryObject {
     fn into_object(self) -> Object {
         self.into()

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -497,6 +497,13 @@ impl_value_from_n!(i16);
 impl_value_from_n!(u32);
 impl_value_from_n!(i32);
 
+impl IntoValue for Value {
+    #[inline(always)]
+    fn into_value(self) -> Value {
+        self
+    }
+}
+
 impl HeapMarkAndSweep for Value {
     fn mark_values(&self, queues: &mut WorkQueues) {
         match self {

--- a/nova_vm/src/engine/bytecode.rs
+++ b/nova_vm/src/engine/bytecode.rs
@@ -4,4 +4,4 @@ mod vm;
 
 pub(crate) use executable::{Executable, FunctionExpression, IndexType};
 pub(crate) use instructions::{Instruction, InstructionIter};
-pub(crate) use vm::Vm;
+pub(crate) use vm::{instanceof_operator, Vm};


### PR DESCRIPTION
Add support for `instanceof` operator in the VM, and additionally fix a lot of missing prototype inheritance in intrinsic objects.