### PR TITLE
feat(vm): Limited array destructuring support

### DIFF
--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -1525,14 +1525,21 @@ mod test {
         initialize_default_realm(&mut agent);
         let realm = agent.current_realm_id();
 
-        let script =
-            parse_script(&allocator, "const [a, b] = [1, 2];".into(), realm, None).unwrap();
+        let script = parse_script(
+            &allocator,
+            "const [a, b, , c] = [1, 2, 3, 4];".into(),
+            realm,
+            None,
+        )
+        .unwrap();
         script_evaluation(&mut agent, script).unwrap();
         let a_key = String::from_static_str(&mut agent, "a");
         let b_key = String::from_static_str(&mut agent, "b");
+        let c_key = String::from_static_str(&mut agent, "c");
         let global_env = agent.get_realm(realm).global_env.unwrap();
         assert!(global_env.has_lexical_declaration(&agent, a_key));
         assert!(global_env.has_lexical_declaration(&agent, b_key));
+        assert!(global_env.has_lexical_declaration(&agent, c_key));
         assert_eq!(
             global_env
                 .get_binding_value(&mut agent, a_key, true)
@@ -1544,6 +1551,12 @@ mod test {
                 .get_binding_value(&mut agent, b_key, true)
                 .unwrap(),
             2.into()
+        );
+        assert_eq!(
+            global_env
+                .get_binding_value(&mut agent, c_key, true)
+                .unwrap(),
+            4.into()
         );
     }
 }

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -1516,4 +1516,34 @@ mod test {
         let script = parse_script(&allocator, "([]) instanceof Array".into(), realm, None).unwrap();
         assert_eq!(script_evaluation(&mut agent, script).unwrap(), true.into());
     }
+
+    #[test]
+    fn array_binding_pattern() {
+        let allocator = Allocator::default();
+
+        let mut agent = Agent::new(Options::default(), &DefaultHostHooks);
+        initialize_default_realm(&mut agent);
+        let realm = agent.current_realm_id();
+
+        let script =
+            parse_script(&allocator, "const [a, b] = [1, 2];".into(), realm, None).unwrap();
+        script_evaluation(&mut agent, script).unwrap();
+        let a_key = String::from_static_str(&mut agent, "a");
+        let b_key = String::from_static_str(&mut agent, "b");
+        let global_env = agent.get_realm(realm).global_env.unwrap();
+        assert!(global_env.has_lexical_declaration(&agent, a_key));
+        assert!(global_env.has_lexical_declaration(&agent, b_key));
+        assert_eq!(
+            global_env
+                .get_binding_value(&mut agent, a_key, true)
+                .unwrap(),
+            1.into()
+        );
+        assert_eq!(
+            global_env
+                .get_binding_value(&mut agent, b_key, true)
+                .unwrap(),
+            2.into()
+        );
+    }
 }

--- a/nova_vm/src/ecmascript/types/language/object/property_key.rs
+++ b/nova_vm/src/ecmascript/types/language/object/property_key.rs
@@ -77,6 +77,42 @@ impl PropertyKey {
     }
 }
 
+impl From<u32> for PropertyKey {
+    fn from(value: u32) -> Self {
+        PropertyKey::Integer(value.into())
+    }
+}
+
+impl From<u16> for PropertyKey {
+    fn from(value: u16) -> Self {
+        PropertyKey::Integer(value.into())
+    }
+}
+
+impl From<u8> for PropertyKey {
+    fn from(value: u8) -> Self {
+        PropertyKey::Integer(value.into())
+    }
+}
+
+impl From<i32> for PropertyKey {
+    fn from(value: i32) -> Self {
+        PropertyKey::Integer(value.into())
+    }
+}
+
+impl From<i16> for PropertyKey {
+    fn from(value: i16) -> Self {
+        PropertyKey::Integer(value.into())
+    }
+}
+
+impl From<i8> for PropertyKey {
+    fn from(value: i8) -> Self {
+        PropertyKey::Integer(value.into())
+    }
+}
+
 impl From<SmallInteger> for PropertyKey {
     fn from(value: SmallInteger) -> Self {
         PropertyKey::Integer(value)

--- a/nova_vm/src/engine/bytecode/instructions.rs
+++ b/nova_vm/src/engine/bytecode/instructions.rs
@@ -160,6 +160,19 @@ pub enum Instruction {
     /// Reset the running execution context's LexicalEnvironment to its current
     /// value's \[\[OuterEnv]].
     ExitDeclarativeEnvironment,
+    /// Begin binding values using a sync iterator
+    BeginArrayBindingPattern,
+    /// Bind current result to given identifier
+    ArrayBindingPatternBind,
+    /// Bind current result to given identifier, falling back to an initializer
+    /// if the current result is undefined.
+    ArrayBindingPatternBindWithInitializer,
+    /// Skip the next iterator value
+    ArrayBindingPatternSkip,
+    /// Load the next iterator value onto the stack
+    ArrayBindingPatternGetValue,
+    /// Finish binding values using a sync iterator
+    FinishArrayBindingPattern,
 }
 
 impl Instruction {
@@ -181,7 +194,9 @@ impl Instruction {
             | Self::StoreConstant
             | Self::ResolveBinding
             | Self::CreateImmutableBinding
-            | Self::CreateMutableBinding => 1,
+            | Self::CreateMutableBinding
+            | Self::ArrayBindingPatternBind
+            | Self::ArrayBindingPatternBindWithInitializer => 1,
             _ => 0,
         }
     }
@@ -198,6 +213,8 @@ impl Instruction {
                 | Self::ResolveBinding
                 | Self::CreateImmutableBinding
                 | Self::CreateMutableBinding
+                | Self::ArrayBindingPatternBind
+                | Self::ArrayBindingPatternBindWithInitializer
         )
     }
 

--- a/nova_vm/src/engine/bytecode/instructions.rs
+++ b/nova_vm/src/engine/bytecode/instructions.rs
@@ -160,8 +160,6 @@ pub enum Instruction {
     /// Reset the running execution context's LexicalEnvironment to its current
     /// value's \[\[OuterEnv]].
     ExitDeclarativeEnvironment,
-    /// Begin binding values using destructuring for known repetitions
-    BeginSimpleObjectBindingPattern,
     /// Begin binding values using destructuring
     BeginObjectBindingPattern,
     /// Begin binding values using a sync iterator for known repetitions
@@ -175,6 +173,8 @@ pub enum Instruction {
     /// const [a] = x;
     /// ```
     BindingPatternBind,
+    /// Bind current result to
+    BindingPatternBindNamed,
     /// Bind all remaining values to given identifier
     ///
     /// ```js
@@ -225,6 +225,8 @@ pub enum Instruction {
 impl Instruction {
     pub fn argument_count(self) -> u8 {
         match self {
+            // Number of repetitions and lexical status
+            Self::BeginSimpleArrayBindingPattern => 2,
             Self::ArrayCreate
             | Self::ArraySetLength
             | Self::ArraySetValue
@@ -242,8 +244,8 @@ impl Instruction {
             | Self::ResolveBinding
             | Self::CreateImmutableBinding
             | Self::CreateMutableBinding
-            | Self::BeginSimpleArrayBindingPattern
-            | Self::BeginSimpleObjectBindingPattern
+            | Self::BeginArrayBindingPattern
+            | Self::BeginObjectBindingPattern
             | Self::BindingPatternBind
             | Self::BindingPatternBindWithInitializer => 1,
             _ => 0,

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -664,6 +664,9 @@ impl Vm {
                             }
                             Instruction::ArrayBindingPatternBindWithInitializer => todo!(),
                             Instruction::ArrayBindingPatternSkip => {
+                                if !done && closure(agent, &mut index)?.is_none() {
+                                    done = true;
+                                }
                                 index += 1;
                             }
                             Instruction::ArrayBindingPatternGetValue => todo!(),

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -602,7 +602,7 @@ impl Vm {
                 vm.result = Some(instanceof_operator(agent, lval, rval)?.into());
             }
             Instruction::BeginSimpleArrayBindingPattern => {
-                let lexical = instr.args[0].unwrap() == 1;
+                let lexical = instr.args[1].unwrap() == 1;
                 let env = if lexical {
                     // Lexical binding, const [] = a; or let [] = a;
                     Some(


### PR DESCRIPTION
Some of the ugliest code I've done in a little while.

Basically: Add minimal support for array destructuring. It only works as long as `Array.prototype[Symbol.iterator]` is untouched and even then only basic destructuring works. It's mostly a miracle that even that works to begin with.