### PR TITLE
chore(repo): Add minimal version of toolchain used

### DIFF
--- a/toolchain.toml
+++ b/toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.78.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This pr adds a new file that specifies the rust version we use to develop nova