### PR TITLE
fix(vm): Properly pass this value to EvaluateCall

### DIFF
--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/function_objects/function_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/function_objects/function_prototype.rs
@@ -133,7 +133,7 @@ impl FunctionPrototype {
         let func = Function::try_from(this_value).unwrap();
         // TODO: PrepareForTailCall
         let this_arg = args.get(0);
-        let args = ArgumentsList(&args[1..]);
+        let args = ArgumentsList(if args.len() > 0 { &args[1..] } else { &args });
         call_function(agent, func, this_arg, Some(args))
     }
 

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -119,9 +119,9 @@ impl TryFrom<Value> for Function {
     type Error = ();
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         match value {
-            Value::BoundFunction(d) => Ok(Function::from(d)),
-            Value::BuiltinFunction(d) => Ok(Function::from(d)),
-            Value::ECMAScriptFunction(d) => Ok(Function::from(d)),
+            Value::BoundFunction(d) => Ok(Function::BoundFunction(d)),
+            Value::BuiltinFunction(d) => Ok(Function::BuiltinFunction(d)),
+            Value::ECMAScriptFunction(d) => Ok(Function::ECMAScriptFunction(d)),
             Value::BuiltinGeneratorFunction => Ok(Function::BuiltinGeneratorFunction),
             Value::BuiltinConstructorFunction => Ok(Function::BuiltinConstructorFunction),
             Value::BuiltinPromiseResolveFunction => Ok(Function::BuiltinPromiseResolveFunction),

--- a/nova_vm/src/engine/bytecode/executable.rs
+++ b/nova_vm/src/engine/bytecode/executable.rs
@@ -1121,14 +1121,19 @@ impl CompileEvaluation for ast::Argument<'_> {
 impl CompileEvaluation for CallExpression<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
         self.callee.compile(ctx);
-        if is_reference(&self.callee) {
+        let is_ref = is_reference(&self.callee);
+        if is_ref {
             ctx.exe.add_instruction(Instruction::GetValueKeepReference);
+            ctx.exe.add_instruction(Instruction::PushReference);
         }
         ctx.exe.add_instruction(Instruction::Load);
         for ele in &self.arguments {
             ele.compile(ctx);
         }
 
+        if is_ref {
+            ctx.exe.add_instruction(Instruction::PopReference);
+        }
         ctx.exe
             .add_instruction_with_immediate(Instruction::EvaluateCall, self.arguments.len());
     }


### PR DESCRIPTION
The reference was being lost to parameter resolution.