### PR TITLE
feat(ecmascript): Handle indexed keys in value references

### DIFF
--- a/nova_vm/src/ecmascript/execution/environments.rs
+++ b/nova_vm/src/ecmascript/execution/environments.rs
@@ -38,7 +38,7 @@ pub(crate) use object_environment::ObjectEnvironment;
 pub(crate) use private_environment::PrivateEnvironment;
 
 use crate::{
-    ecmascript::types::{Base, Object, Reference, ReferencedName, String, Value},
+    ecmascript::types::{Base, Object, Reference, String, Value},
     heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
 };
 
@@ -420,7 +420,7 @@ pub(crate) fn get_identifier_reference(
             // [[Base]]: UNRESOLVABLE,
             base: Base::Unresolvable,
             // [[ReferencedName]]: name,
-            referenced_name: ReferencedName::from(name),
+            referenced_name: name.into(),
             // [[Strict]]: strict,
             strict,
             // [[ThisValue]]: EMPTY
@@ -439,7 +439,7 @@ pub(crate) fn get_identifier_reference(
             // [[Base]]: env,
             base: Base::Environment(env),
             // [[ReferencedName]]: name,
-            referenced_name: ReferencedName::from(name),
+            referenced_name: name.into(),
             // [[Strict]]: strict,
             strict,
             // [[ThisValue]]: EMPTY

--- a/nova_vm/src/ecmascript/types.rs
+++ b/nova_vm/src/ecmascript/types.rs
@@ -7,5 +7,5 @@ pub use language::{
     IntoNumeric, IntoObject, IntoPrimitive, IntoValue, Number, Numeric, Object, OrdinaryObject,
     Primitive, PropertyKey, String, Symbol, Value,
 };
+pub use spec::PropertyDescriptor;
 pub(crate) use spec::*;
-pub use spec::{PropertyDescriptor, ReferencedName};

--- a/nova_vm/src/ecmascript/types/spec.rs
+++ b/nova_vm/src/ecmascript/types/spec.rs
@@ -4,5 +4,4 @@ mod reference;
 
 pub(crate) use data_block::DataBlock;
 pub use property_descriptor::PropertyDescriptor;
-pub use reference::ReferencedName;
 pub(crate) use reference::*;

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -26,8 +26,8 @@ use crate::{
         },
         types::{
             get_value, initialize_referenced_binding, put_value, Base, BigInt, Function,
-            IntoFunction, IntoValue, Number, Numeric, Object, PropertyKey, Reference,
-            ReferencedName, String, Value, BUILTIN_STRING_MEMORY,
+            IntoFunction, IntoValue, Number, Numeric, Object, PropertyKey, Reference, String,
+            Value, BUILTIN_STRING_MEMORY,
         },
     },
     heap::WellKnownSymbolIndexes,
@@ -444,12 +444,7 @@ impl Vm {
 
                 vm.reference = Some(Reference {
                     base: Base::Value(base_value),
-                    referenced_name: match property_key {
-                        PropertyKey::SmallString(s) => ReferencedName::SmallString(s),
-                        PropertyKey::String(s) => ReferencedName::String(s),
-                        PropertyKey::Symbol(s) => ReferencedName::Symbol(s),
-                        _ => todo!("Index properties in ReferencedName"),
-                    },
+                    referenced_name: property_key,
                     strict,
                     this_value: None,
                 });
@@ -462,7 +457,7 @@ impl Vm {
 
                 vm.reference = Some(Reference {
                     base: Base::Value(base_value),
-                    referenced_name: ReferencedName::from(property_name_string),
+                    referenced_name: property_name_string.into(),
                     strict,
                     this_value: None,
                 });
@@ -818,7 +813,7 @@ impl Vm {
 
                 let reference = Reference {
                     base: Base::Value(value),
-                    referenced_name: ReferencedName::from(property_name_string),
+                    referenced_name: property_name_string.into(),
                     strict,
                     this_value: None,
                 };


### PR DESCRIPTION
`ReferencedName` ended up being a mistaken and unnecessary copy of `PropertyKey`. This replaces the former's usage with the latter, and unifies and fixes array index checks in Array internal methods.

This then makes it possible to both set and get values by index in Arrays.