### PR TITLE
fix(small_string): Support null-terminated small strings

### DIFF
--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -244,9 +244,7 @@ impl String {
                     let string_len = string.len(agent);
                     if *len + string_len <= 7 {
                         let String::SmallString(smstr) = string else {
-                            // TODO: This is reachable if `string` ends with a
-                            // null byte.
-                            todo!()
+                            unreachable!()
                         };
                         data[*len..(*len + string_len)]
                             .copy_from_slice(&smstr.data()[..string_len]);

--- a/nova_vm/src/heap.rs
+++ b/nova_vm/src/heap.rs
@@ -270,7 +270,7 @@ impl Heap {
     }
 
     fn find_equal_string(&self, message: &str) -> Option<String> {
-        debug_assert!(message.len() > 7 || message.ends_with('\0'));
+        debug_assert!(message.len() > 7);
         self.strings
             .iter()
             .position(|opt| opt.as_ref().map_or(false, |data| data.as_str() == message))

--- a/small_string/lib.rs
+++ b/small_string/lib.rs
@@ -17,13 +17,10 @@ impl SmallString {
     };
 
     pub fn len(&self) -> usize {
-        // Find the last non-0xFF character and add one to its index to get length.
-        self.bytes
-            .as_slice()
-            .iter()
-            .rev()
-            .position(|&x| x != 0xFF)
-            .map_or(0, |i| 7 - i)
+        // Find the first 0xFF byte. Small strings must be valid UTF-8, and
+        // UTF-8 can never contain 0xFF, so that must mark the end of the
+        // string.
+        self.bytes.iter().position(|&x| x == 0xFF).unwrap_or(7)
     }
 
     #[inline]


### PR DESCRIPTION
Currently small strings use the zero byte as filler between the end of the string and the end of the buffer. This makes it impossible to represent strings ending in `\0` as a small string, even if they fit the length requirements.

However, since small strings are always UTF-8, it is possible to use a byte like 0xFF as the filler byte, since valid UTF-8 (or WTF-8) strings will never contain that byte. This makes it possible to represent the null character at the end of a small string while distinguishing it from the end of the string.