### PR TITLE
feat(tests): Add `eval-test` subcommand to the test262 runner

### DIFF
--- a/tests/test262_runner.rs
+++ b/tests/test262_runner.rs
@@ -156,7 +156,7 @@ impl BaseTest262Runner {
                         std::io::stderr().write_all(&buffer).unwrap();
                     }
                     buffer == expected_stderr_prefix.as_bytes()
-                },
+                }
                 Err(e) => {
                     if e.kind() == ErrorKind::UnexpectedEof {
                         false


### PR DESCRIPTION
This patch adds the `eval-test` subcommand to the test262 runner, which runs an individual test262 test in the same way the regular test262 runner would, except that it prints its output.

To be able to do this, this patch creates a `BaseTest262Runner` struct, which is used to run a single test and get its result, splitting it from the `Test262Runner` struct which walks through the test directories and compares the test results with a map of expectations.