### PR TITLE
fix(repo): Make `cargo run` on the root directory run `nova_cli`

### DIFF
--- a/nova_cli/Cargo.toml
+++ b/nova_cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nova_cli"
 version = "0.1.0"
 edition = "2021"
+default-run = "nova_cli"
 
 [dependencies]
 clap = { version = "4.5.0", features = ["derive"] }


### PR DESCRIPTION
Before #229, running `cargo run` on the root directory of the Nova checkout used to run the `nova_cli` binary, because that was the only binary in the workspace. However, that PR added the `test262` binary in the `tests` crate, which made the command for running the CLI be `cargo run --bin nova_cli`.

This patch fixes that by setting the `default-run` manifest key of the `nova_cli` crate to the `nova_cli` binary. Since that is the only `default-run` manifest key in the entire workspace, that will set the default behavior of `cargo run` across the workspace, while still making it possible to run the `test262` binary with the `--bin` flag.