### PR TITLE
refactor(heap): Implement Index traits on heap vectors

### DIFF
--- a/nova_vm/src/ecmascript/builders/builtin_function_builder.rs
+++ b/nova_vm/src/ecmascript/builders/builtin_function_builder.rs
@@ -533,7 +533,7 @@ impl<'agent>
             .agent
             .heap
             .builtin_functions
-            .get_mut(self.this.0.into_index())
+            .get_mut(self.this.get_index())
             .unwrap();
         assert!(slot.is_none());
         *slot = Some(data);
@@ -609,7 +609,7 @@ impl<'agent>
         let slot = agent
             .heap
             .builtin_functions
-            .get_mut(self.this.0.into_index())
+            .get_mut(self.this.get_index())
             .unwrap();
         assert!(slot.is_none());
         *slot = Some(data);
@@ -679,7 +679,7 @@ impl<'agent>
         let slot = agent
             .heap
             .builtin_functions
-            .get_mut(self.this.0.into_index())
+            .get_mut(self.this.get_index())
             .unwrap();
         assert!(slot.is_none());
         *slot = Some(data);

--- a/nova_vm/src/ecmascript/builtins/array_buffer.rs
+++ b/nova_vm/src/ecmascript/builtins/array_buffer.rs
@@ -67,32 +67,30 @@ impl Index<ArrayBuffer> for Agent {
     type Output = ArrayBufferHeapData;
 
     fn index(&self, index: ArrayBuffer) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.array_buffers[index]
     }
 }
 
 impl IndexMut<ArrayBuffer> for Agent {
     fn index_mut(&mut self, index: ArrayBuffer) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.array_buffers[index]
     }
 }
 
-impl Index<ArrayBuffer> for Heap {
+impl Index<ArrayBuffer> for Vec<Option<ArrayBufferHeapData>> {
     type Output = ArrayBufferHeapData;
 
     fn index(&self, index: ArrayBuffer) -> &Self::Output {
-        self.array_buffers
-            .get(index.0.into_index())
+        self.get(index.get_index())
             .expect("ArrayBuffer out of bounds")
             .as_ref()
             .expect("ArrayBuffer slot empty")
     }
 }
 
-impl IndexMut<ArrayBuffer> for Heap {
+impl IndexMut<ArrayBuffer> for Vec<Option<ArrayBufferHeapData>> {
     fn index_mut(&mut self, index: ArrayBuffer) -> &mut Self::Output {
-        self.array_buffers
-            .get_mut(index.0.into_index())
+        self.get_mut(index.get_index())
             .expect("ArrayBuffer out of bounds")
             .as_mut()
             .expect("ArrayBuffer slot empty")

--- a/nova_vm/src/ecmascript/builtins/bound_function.rs
+++ b/nova_vm/src/ecmascript/builtins/bound_function.rs
@@ -305,20 +305,30 @@ impl Index<BoundFunction> for Agent {
     type Output = BoundFunctionHeapData;
 
     fn index(&self, index: BoundFunction) -> &Self::Output {
-        self.heap
-            .bound_functions
-            .get(index.0.into_index())
+        &self.heap.bound_functions[index]
+    }
+}
+
+impl IndexMut<BoundFunction> for Agent {
+    fn index_mut(&mut self, index: BoundFunction) -> &mut Self::Output {
+        &mut self.heap.bound_functions[index]
+    }
+}
+
+impl Index<BoundFunction> for Vec<Option<BoundFunctionHeapData>> {
+    type Output = BoundFunctionHeapData;
+
+    fn index(&self, index: BoundFunction) -> &Self::Output {
+        self.get(index.get_index())
             .expect("BoundFunction out of bounds")
             .as_ref()
             .expect("BoundFunction slot empty")
     }
 }
 
-impl IndexMut<BoundFunction> for Agent {
+impl IndexMut<BoundFunction> for Vec<Option<BoundFunctionHeapData>> {
     fn index_mut(&mut self, index: BoundFunction) -> &mut Self::Output {
-        self.heap
-            .bound_functions
-            .get_mut(index.0.into_index())
+        self.get_mut(index.get_index())
             .expect("BoundFunction out of bounds")
             .as_mut()
             .expect("BoundFunction slot empty")

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -153,32 +153,30 @@ impl Index<BuiltinFunction> for Agent {
     type Output = BuiltinFunctionHeapData;
 
     fn index(&self, index: BuiltinFunction) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.builtin_functions[index]
     }
 }
 
 impl IndexMut<BuiltinFunction> for Agent {
     fn index_mut(&mut self, index: BuiltinFunction) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.builtin_functions[index]
     }
 }
 
-impl Index<BuiltinFunction> for Heap {
+impl Index<BuiltinFunction> for Vec<Option<BuiltinFunctionHeapData>> {
     type Output = BuiltinFunctionHeapData;
 
     fn index(&self, index: BuiltinFunction) -> &Self::Output {
-        self.builtin_functions
-            .get(index.0.into_index())
+        self.get(index.get_index())
             .expect("BuiltinFunction out of bounds")
             .as_ref()
             .expect("BuiltinFunction slot empty")
     }
 }
 
-impl IndexMut<BuiltinFunction> for Heap {
+impl IndexMut<BuiltinFunction> for Vec<Option<BuiltinFunctionHeapData>> {
     fn index_mut(&mut self, index: BuiltinFunction) -> &mut Self::Output {
-        self.builtin_functions
-            .get_mut(index.0.into_index())
+        self.get_mut(index.get_index())
             .expect("BuiltinFunction out of bounds")
             .as_mut()
             .expect("BuiltinFunction slot empty")
@@ -513,11 +511,13 @@ pub(crate) fn builtin_call_or_construct(
     caller_context.suspend();
     // 5. Let calleeRealm be F.[[Realm]].
     let Agent {
-        heap,
+        heap: Heap {
+            builtin_functions, ..
+        },
         execution_context_stack,
         ..
     } = agent;
-    let heap_data = &heap[f];
+    let heap_data = &builtin_functions[f];
     let callee_realm = heap_data.realm;
     // 3. Let calleeContext be a new execution context.
     let callee_context = ExecutionContext {

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_capability_records.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_capability_records.rs
@@ -76,20 +76,30 @@ impl Index<PromiseCapability> for Agent {
     type Output = PromiseCapabilityRecord;
 
     fn index(&self, index: PromiseCapability) -> &Self::Output {
-        self.heap
-            .promise_capability_records
-            .get(index.get_index())
+        &self.heap.promise_capability_records[index]
+    }
+}
+
+impl IndexMut<PromiseCapability> for Agent {
+    fn index_mut(&mut self, index: PromiseCapability) -> &mut Self::Output {
+        &mut self.heap.promise_capability_records[index]
+    }
+}
+
+impl Index<PromiseCapability> for Vec<Option<PromiseCapabilityRecord>> {
+    type Output = PromiseCapabilityRecord;
+
+    fn index(&self, index: PromiseCapability) -> &Self::Output {
+        self.get(index.get_index())
             .expect("PromiseCapability out of bounds")
             .as_ref()
             .expect("PromiseCapability slot empty")
     }
 }
 
-impl IndexMut<PromiseCapability> for Agent {
+impl IndexMut<PromiseCapability> for Vec<Option<PromiseCapabilityRecord>> {
     fn index_mut(&mut self, index: PromiseCapability) -> &mut Self::Output {
-        self.heap
-            .promise_capability_records
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("PromiseCapability out of bounds")
             .as_mut()
             .expect("PromiseCapability slot empty")

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_reaction_records.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_reaction_records.rs
@@ -67,20 +67,30 @@ impl Index<PromiseReaction> for Agent {
     type Output = PromiseReactionRecord;
 
     fn index(&self, index: PromiseReaction) -> &Self::Output {
-        self.heap
-            .promise_reaction_records
-            .get(index.get_index())
+        &self.heap.promise_reaction_records[index]
+    }
+}
+
+impl IndexMut<PromiseReaction> for Agent {
+    fn index_mut(&mut self, index: PromiseReaction) -> &mut Self::Output {
+        &mut self.heap.promise_reaction_records[index]
+    }
+}
+
+impl Index<PromiseReaction> for Vec<Option<PromiseReactionRecord>> {
+    type Output = PromiseReactionRecord;
+
+    fn index(&self, index: PromiseReaction) -> &Self::Output {
+        self.get(index.get_index())
             .expect("PromiseReaction out of bounds")
             .as_ref()
             .expect("PromiseReaction slot empty")
     }
 }
 
-impl IndexMut<PromiseReaction> for Agent {
+impl IndexMut<PromiseReaction> for Vec<Option<PromiseReactionRecord>> {
     fn index_mut(&mut self, index: PromiseReaction) -> &mut Self::Output {
-        self.heap
-            .promise_reaction_records
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("PromiseReaction out of bounds")
             .as_mut()
             .expect("PromiseReaction slot empty")

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_reject_function.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_reject_function.rs
@@ -278,20 +278,30 @@ impl Index<BuiltinPromiseRejectFunction> for Agent {
     type Output = PromiseRejectFunctionHeapData;
 
     fn index(&self, index: BuiltinPromiseRejectFunction) -> &Self::Output {
-        self.heap
-            .promise_reject_functions
-            .get(index.get_index())
+        &self.heap.promise_reject_functions[index]
+    }
+}
+
+impl IndexMut<BuiltinPromiseRejectFunction> for Agent {
+    fn index_mut(&mut self, index: BuiltinPromiseRejectFunction) -> &mut Self::Output {
+        &mut self.heap.promise_reject_functions[index]
+    }
+}
+
+impl Index<BuiltinPromiseRejectFunction> for Vec<Option<PromiseRejectFunctionHeapData>> {
+    type Output = PromiseRejectFunctionHeapData;
+
+    fn index(&self, index: BuiltinPromiseRejectFunction) -> &Self::Output {
+        self.get(index.get_index())
             .expect("BuiltinPromiseRejectFunction out of bounds")
             .as_ref()
             .expect("BuiltinPromiseRejectFunction slot empty")
     }
 }
 
-impl IndexMut<BuiltinPromiseRejectFunction> for Agent {
+impl IndexMut<BuiltinPromiseRejectFunction> for Vec<Option<PromiseRejectFunctionHeapData>> {
     fn index_mut(&mut self, index: BuiltinPromiseRejectFunction) -> &mut Self::Output {
-        self.heap
-            .promise_reject_functions
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("BuiltinPromiseRejectFunction out of bounds")
             .as_mut()
             .expect("BuiltinPromiseRejectFunction slot empty")

--- a/nova_vm/src/ecmascript/builtins/data_view.rs
+++ b/nova_vm/src/ecmascript/builtins/data_view.rs
@@ -62,32 +62,30 @@ impl Index<DataView> for Agent {
     type Output = DataViewHeapData;
 
     fn index(&self, index: DataView) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.data_views[index]
     }
 }
 
 impl IndexMut<DataView> for Agent {
     fn index_mut(&mut self, index: DataView) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.data_views[index]
     }
 }
 
-impl Index<DataView> for Heap {
+impl Index<DataView> for Vec<Option<DataViewHeapData>> {
     type Output = DataViewHeapData;
 
     fn index(&self, index: DataView) -> &Self::Output {
-        self.data_views
-            .get(index.0.into_index())
+        self.get(index.get_index())
             .expect("DataView out of bounds")
             .as_ref()
             .expect("DataView slot empty")
     }
 }
 
-impl IndexMut<DataView> for Heap {
+impl IndexMut<DataView> for Vec<Option<DataViewHeapData>> {
     fn index_mut(&mut self, index: DataView) -> &mut Self::Output {
-        self.data_views
-            .get_mut(index.0.into_index())
+        self.get_mut(index.get_index())
             .expect("DataView out of bounds")
             .as_mut()
             .expect("DataView slot empty")
@@ -119,30 +117,6 @@ impl InternalSlots for DataView {
 }
 
 impl InternalMethods for DataView {}
-
-impl Index<DataViewIndex> for Agent {
-    type Output = DataViewHeapData;
-
-    fn index(&self, index: DataViewIndex) -> &Self::Output {
-        self.heap
-            .data_views
-            .get(index.into_index())
-            .expect("DataViewIndex out of bounds")
-            .as_ref()
-            .expect("DataViewIndex slot empty")
-    }
-}
-
-impl IndexMut<DataViewIndex> for Agent {
-    fn index_mut(&mut self, index: DataViewIndex) -> &mut Self::Output {
-        self.heap
-            .data_views
-            .get_mut(index.into_index())
-            .expect("DataViewIndex out of bounds")
-            .as_mut()
-            .expect("DataViewIndex slot empty")
-    }
-}
 
 impl CreateHeapData<DataViewHeapData, DataView> for Heap {
     fn create(&mut self, data: DataViewHeapData) -> DataView {

--- a/nova_vm/src/ecmascript/builtins/date.rs
+++ b/nova_vm/src/ecmascript/builtins/date.rs
@@ -106,20 +106,30 @@ impl Index<Date> for Agent {
     type Output = DateHeapData;
 
     fn index(&self, index: Date) -> &Self::Output {
-        self.heap
-            .dates
-            .get(index.get_index())
+        &self.heap.dates[index]
+    }
+}
+
+impl IndexMut<Date> for Agent {
+    fn index_mut(&mut self, index: Date) -> &mut Self::Output {
+        &mut self.heap.dates[index]
+    }
+}
+
+impl Index<Date> for Vec<Option<DateHeapData>> {
+    type Output = DateHeapData;
+
+    fn index(&self, index: Date) -> &Self::Output {
+        self.get(index.get_index())
             .expect("Date out of bounds")
             .as_ref()
             .expect("Date slot empty")
     }
 }
 
-impl IndexMut<Date> for Agent {
+impl IndexMut<Date> for Vec<Option<DateHeapData>> {
     fn index_mut(&mut self, index: Date) -> &mut Self::Output {
-        self.heap
-            .dates
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("Date out of bounds")
             .as_mut()
             .expect("Date slot empty")

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -188,32 +188,30 @@ impl Index<ECMAScriptFunction> for Agent {
     type Output = ECMAScriptFunctionHeapData;
 
     fn index(&self, index: ECMAScriptFunction) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.ecmascript_functions[index]
     }
 }
 
 impl IndexMut<ECMAScriptFunction> for Agent {
     fn index_mut(&mut self, index: ECMAScriptFunction) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.ecmascript_functions[index]
     }
 }
 
-impl Index<ECMAScriptFunction> for Heap {
+impl Index<ECMAScriptFunction> for Vec<Option<ECMAScriptFunctionHeapData>> {
     type Output = ECMAScriptFunctionHeapData;
 
     fn index(&self, index: ECMAScriptFunction) -> &Self::Output {
-        self.ecmascript_functions
-            .get(index.0.into_index())
+        self.get(index.get_index())
             .expect("ECMAScriptFunction out of bounds")
             .as_ref()
             .expect("ECMAScriptFunction slot empty")
     }
 }
 
-impl IndexMut<ECMAScriptFunction> for Heap {
+impl IndexMut<ECMAScriptFunction> for Vec<Option<ECMAScriptFunctionHeapData>> {
     fn index_mut(&mut self, index: ECMAScriptFunction) -> &mut Self::Output {
-        self.ecmascript_functions
-            .get_mut(index.0.into_index())
+        self.get_mut(index.get_index())
             .expect("ECMAScriptFunction out of bounds")
             .as_mut()
             .expect("ECMAScriptFunction slot empty")

--- a/nova_vm/src/ecmascript/builtins/embedder_object.rs
+++ b/nova_vm/src/ecmascript/builtins/embedder_object.rs
@@ -173,20 +173,30 @@ impl Index<EmbedderObject> for Agent {
     type Output = EmbedderObjectHeapData;
 
     fn index(&self, index: EmbedderObject) -> &Self::Output {
-        self.heap
-            .embedder_objects
-            .get(index.0.into_index())
+        &self.heap.embedder_objects[index]
+    }
+}
+
+impl IndexMut<EmbedderObject> for Agent {
+    fn index_mut(&mut self, index: EmbedderObject) -> &mut Self::Output {
+        &mut self.heap.embedder_objects[index]
+    }
+}
+
+impl Index<EmbedderObject> for Vec<Option<EmbedderObjectHeapData>> {
+    type Output = EmbedderObjectHeapData;
+
+    fn index(&self, index: EmbedderObject) -> &Self::Output {
+        self.get(index.get_index())
             .expect("EmbedderObject out of bounds")
             .as_ref()
             .expect("EmbedderObject slot empty")
     }
 }
 
-impl IndexMut<EmbedderObject> for Agent {
+impl IndexMut<EmbedderObject> for Vec<Option<EmbedderObjectHeapData>> {
     fn index_mut(&mut self, index: EmbedderObject) -> &mut Self::Output {
-        self.heap
-            .embedder_objects
-            .get_mut(index.0.into_index())
+        self.get_mut(index.get_index())
             .expect("EmbedderObject out of bounds")
             .as_mut()
             .expect("EmbedderObject slot empty")

--- a/nova_vm/src/ecmascript/builtins/error.rs
+++ b/nova_vm/src/ecmascript/builtins/error.rs
@@ -266,20 +266,30 @@ impl Index<Error> for Agent {
     type Output = ErrorHeapData;
 
     fn index(&self, index: Error) -> &Self::Output {
-        self.heap
-            .errors
-            .get(index.get_index())
+        &self.heap.errors[index]
+    }
+}
+
+impl IndexMut<Error> for Agent {
+    fn index_mut(&mut self, index: Error) -> &mut Self::Output {
+        &mut self.heap.errors[index]
+    }
+}
+
+impl Index<Error> for Vec<Option<ErrorHeapData>> {
+    type Output = ErrorHeapData;
+
+    fn index(&self, index: Error) -> &Self::Output {
+        self.get(index.get_index())
             .expect("Error out of bounds")
             .as_ref()
             .expect("Error slot empty")
     }
 }
 
-impl IndexMut<Error> for Agent {
+impl IndexMut<Error> for Vec<Option<ErrorHeapData>> {
     fn index_mut(&mut self, index: Error) -> &mut Self::Output {
-        self.heap
-            .errors
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("Error out of bounds")
             .as_mut()
             .expect("Error slot empty")

--- a/nova_vm/src/ecmascript/builtins/finalization_registry.rs
+++ b/nova_vm/src/ecmascript/builtins/finalization_registry.rs
@@ -97,20 +97,30 @@ impl Index<FinalizationRegistry> for Agent {
     type Output = FinalizationRegistryHeapData;
 
     fn index(&self, index: FinalizationRegistry) -> &Self::Output {
-        self.heap
-            .finalization_registrys
-            .get(index.get_index())
+        &self.heap.finalization_registrys[index]
+    }
+}
+
+impl IndexMut<FinalizationRegistry> for Agent {
+    fn index_mut(&mut self, index: FinalizationRegistry) -> &mut Self::Output {
+        &mut self.heap.finalization_registrys[index]
+    }
+}
+
+impl Index<FinalizationRegistry> for Vec<Option<FinalizationRegistryHeapData>> {
+    type Output = FinalizationRegistryHeapData;
+
+    fn index(&self, index: FinalizationRegistry) -> &Self::Output {
+        self.get(index.get_index())
             .expect("FinalizationRegistry out of bounds")
             .as_ref()
             .expect("FinalizationRegistry slot empty")
     }
 }
 
-impl IndexMut<FinalizationRegistry> for Agent {
+impl IndexMut<FinalizationRegistry> for Vec<Option<FinalizationRegistryHeapData>> {
     fn index_mut(&mut self, index: FinalizationRegistry) -> &mut Self::Output {
-        self.heap
-            .finalization_registrys
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("FinalizationRegistry out of bounds")
             .as_mut()
             .expect("FinalizationRegistry slot empty")

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/function_objects/function_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/function_objects/function_prototype.rs
@@ -96,23 +96,13 @@ impl FunctionPrototype {
         }
         // TODO: let arg_list = create_list_from_array_like(arg_array);
         let elements = match arg_array {
-            Value::Array(idx) => {
-                agent
-                    .heap
-                    .arrays
-                    .get(idx.into_index())
-                    .unwrap()
-                    .as_ref()
-                    .unwrap()
-                    .elements
-            }
+            Value::Array(array) => array.as_slice(agent),
             _ => {
                 return Err(
                     agent.throw_exception(ExceptionType::TypeError, "Not a valid arguments array")
                 );
             }
         };
-        let elements = agent.heap.elements.get(elements.into());
         let args: Vec<Value> = elements
             .iter()
             .map(|value| value.unwrap_or(Value::Undefined))

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
@@ -1587,10 +1587,7 @@ impl ArrayPrototype {
             let Heap {
                 arrays, elements, ..
             } = &mut agent.heap;
-            arrays
-                .get_mut(array.into_index())
-                .unwrap()
-                .unwrap()
+            arrays[array]
                 .elements
                 .reserve(elements, len as u32 + arg_count as u32);
         }

--- a/nova_vm/src/ecmascript/builtins/map.rs
+++ b/nova_vm/src/ecmascript/builtins/map.rs
@@ -134,20 +134,30 @@ impl Index<Map> for Agent {
     type Output = MapHeapData;
 
     fn index(&self, index: Map) -> &Self::Output {
-        self.heap
-            .maps
-            .get(index.get_index())
+        &self.heap.maps[index]
+    }
+}
+
+impl IndexMut<Map> for Agent {
+    fn index_mut(&mut self, index: Map) -> &mut Self::Output {
+        &mut self.heap.maps[index]
+    }
+}
+
+impl Index<Map> for Vec<Option<MapHeapData>> {
+    type Output = MapHeapData;
+
+    fn index(&self, index: Map) -> &Self::Output {
+        self.get(index.get_index())
             .expect("Map out of bounds")
             .as_ref()
             .expect("Map slot empty")
     }
 }
 
-impl IndexMut<Map> for Agent {
+impl IndexMut<Map> for Vec<Option<MapHeapData>> {
     fn index_mut(&mut self, index: Map) -> &mut Self::Output {
-        self.heap
-            .maps
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("Map out of bounds")
             .as_mut()
             .expect("Map slot empty")

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -12,7 +12,6 @@ use crate::{
         },
     },
     heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
-    Heap,
 };
 
 use self::data::ModuleHeapData;
@@ -67,32 +66,30 @@ impl Index<Module> for Agent {
     type Output = ModuleHeapData;
 
     fn index(&self, index: Module) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.modules[index]
     }
 }
 
 impl IndexMut<Module> for Agent {
     fn index_mut(&mut self, index: Module) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.modules[index]
     }
 }
 
-impl Index<Module> for Heap {
+impl Index<Module> for Vec<Option<ModuleHeapData>> {
     type Output = ModuleHeapData;
 
     fn index(&self, index: Module) -> &Self::Output {
-        self.modules
-            .get(index.0.into_index())
+        self.get(index.get_index())
             .expect("Module out of bounds")
             .as_ref()
             .expect("Module slot empty")
     }
 }
 
-impl IndexMut<Module> for Heap {
+impl IndexMut<Module> for Vec<Option<ModuleHeapData>> {
     fn index_mut(&mut self, index: Module) -> &mut Self::Output {
-        self.modules
-            .get_mut(index.0.into_index())
+        self.get_mut(index.get_index())
             .expect("Module out of bounds")
             .as_mut()
             .expect("Module slot empty")

--- a/nova_vm/src/ecmascript/builtins/ordinary.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary.rs
@@ -18,7 +18,7 @@ use crate::{
         },
     },
     heap::{
-        indexes::ObjectIndex, CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep,
+        indexes::ObjectIndex, CompactionLists, CreateHeapData, HeapMarkAndSweep,
         WellKnownSymbolIndexes, WorkQueues,
     },
 };
@@ -37,35 +37,33 @@ impl Index<OrdinaryObject> for Agent {
     type Output = ObjectHeapData;
 
     fn index(&self, index: OrdinaryObject) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.objects[index]
     }
 }
 
 impl IndexMut<OrdinaryObject> for Agent {
     fn index_mut(&mut self, index: OrdinaryObject) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.objects[index]
     }
 }
 
-impl Index<OrdinaryObject> for Heap {
+impl Index<OrdinaryObject> for Vec<Option<ObjectHeapData>> {
     type Output = ObjectHeapData;
 
     fn index(&self, index: OrdinaryObject) -> &Self::Output {
-        self.objects
-            .get(index.0.into_index())
-            .expect("OrdinaryObject out of bounds")
+        self.get(index.get_index())
+            .expect("Object out of bounds")
             .as_ref()
-            .expect("OrdinaryObject slot empty")
+            .expect("Object slot empty")
     }
 }
 
-impl IndexMut<OrdinaryObject> for Heap {
+impl IndexMut<OrdinaryObject> for Vec<Option<ObjectHeapData>> {
     fn index_mut(&mut self, index: OrdinaryObject) -> &mut Self::Output {
-        self.objects
-            .get_mut(index.0.into_index())
-            .expect("OrdinaryObject out of bounds")
+        self.get_mut(index.get_index())
+            .expect("Object out of bounds")
             .as_mut()
-            .expect("OrdinaryObject slot empty")
+            .expect("Object slot empty")
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -81,20 +81,30 @@ impl Index<PrimitiveObject> for Agent {
     type Output = PrimitiveObjectHeapData;
 
     fn index(&self, index: PrimitiveObject) -> &Self::Output {
-        self.heap
-            .primitive_objects
-            .get(index.0.into_index())
+        &self.heap.primitive_objects[index]
+    }
+}
+
+impl IndexMut<PrimitiveObject> for Agent {
+    fn index_mut(&mut self, index: PrimitiveObject) -> &mut Self::Output {
+        &mut self.heap.primitive_objects[index]
+    }
+}
+
+impl Index<PrimitiveObject> for Vec<Option<PrimitiveObjectHeapData>> {
+    type Output = PrimitiveObjectHeapData;
+
+    fn index(&self, index: PrimitiveObject) -> &Self::Output {
+        self.get(index.get_index())
             .expect("PrimitiveObject out of bounds")
             .as_ref()
             .expect("PrimitiveObject slot empty")
     }
 }
 
-impl IndexMut<PrimitiveObject> for Agent {
+impl IndexMut<PrimitiveObject> for Vec<Option<PrimitiveObjectHeapData>> {
     fn index_mut(&mut self, index: PrimitiveObject) -> &mut Self::Output {
-        self.heap
-            .primitive_objects
-            .get_mut(index.0.into_index())
+        self.get_mut(index.get_index())
             .expect("PrimitiveObject out of bounds")
             .as_mut()
             .expect("PrimitiveObject slot empty")

--- a/nova_vm/src/ecmascript/builtins/promise.rs
+++ b/nova_vm/src/ecmascript/builtins/promise.rs
@@ -104,20 +104,30 @@ impl Index<Promise> for Agent {
     type Output = PromiseHeapData;
 
     fn index(&self, index: Promise) -> &Self::Output {
-        self.heap
-            .promises
-            .get(index.get_index())
+        &self.heap.promises[index]
+    }
+}
+
+impl IndexMut<Promise> for Agent {
+    fn index_mut(&mut self, index: Promise) -> &mut Self::Output {
+        &mut self.heap.promises[index]
+    }
+}
+
+impl Index<Promise> for Vec<Option<PromiseHeapData>> {
+    type Output = PromiseHeapData;
+
+    fn index(&self, index: Promise) -> &Self::Output {
+        self.get(index.get_index())
             .expect("Promise out of bounds")
             .as_ref()
             .expect("Promise slot empty")
     }
 }
 
-impl IndexMut<Promise> for Agent {
+impl IndexMut<Promise> for Vec<Option<PromiseHeapData>> {
     fn index_mut(&mut self, index: Promise) -> &mut Self::Output {
-        self.heap
-            .promises
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("Promise out of bounds")
             .as_mut()
             .expect("Promise slot empty")

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -195,20 +195,30 @@ impl Index<Proxy> for Agent {
     type Output = ProxyHeapData;
 
     fn index(&self, index: Proxy) -> &Self::Output {
-        self.heap
-            .proxys
-            .get(index.get_index())
+        &self.heap.proxys[index]
+    }
+}
+
+impl IndexMut<Proxy> for Agent {
+    fn index_mut(&mut self, index: Proxy) -> &mut Self::Output {
+        &mut self.heap.proxys[index]
+    }
+}
+
+impl Index<Proxy> for Vec<Option<ProxyHeapData>> {
+    type Output = ProxyHeapData;
+
+    fn index(&self, index: Proxy) -> &Self::Output {
+        self.get(index.get_index())
             .expect("Proxy out of bounds")
             .as_ref()
             .expect("Proxy slot empty")
     }
 }
 
-impl IndexMut<Proxy> for Agent {
+impl IndexMut<Proxy> for Vec<Option<ProxyHeapData>> {
     fn index_mut(&mut self, index: Proxy) -> &mut Self::Output {
-        self.heap
-            .proxys
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("Proxy out of bounds")
             .as_mut()
             .expect("Proxy slot empty")

--- a/nova_vm/src/ecmascript/builtins/regexp.rs
+++ b/nova_vm/src/ecmascript/builtins/regexp.rs
@@ -92,20 +92,30 @@ impl Index<RegExp> for Agent {
     type Output = RegExpHeapData;
 
     fn index(&self, index: RegExp) -> &Self::Output {
-        self.heap
-            .regexps
-            .get(index.get_index())
+        &self.heap.regexps[index]
+    }
+}
+
+impl IndexMut<RegExp> for Agent {
+    fn index_mut(&mut self, index: RegExp) -> &mut Self::Output {
+        &mut self.heap.regexps[index]
+    }
+}
+
+impl Index<RegExp> for Vec<Option<RegExpHeapData>> {
+    type Output = RegExpHeapData;
+
+    fn index(&self, index: RegExp) -> &Self::Output {
+        self.get(index.get_index())
             .expect("RegExp out of bounds")
             .as_ref()
             .expect("RegExp slot empty")
     }
 }
 
-impl IndexMut<RegExp> for Agent {
+impl IndexMut<RegExp> for Vec<Option<RegExpHeapData>> {
     fn index_mut(&mut self, index: RegExp) -> &mut Self::Output {
-        self.heap
-            .regexps
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("RegExp out of bounds")
             .as_mut()
             .expect("RegExp slot empty")

--- a/nova_vm/src/ecmascript/builtins/set.rs
+++ b/nova_vm/src/ecmascript/builtins/set.rs
@@ -124,20 +124,30 @@ impl Index<Set> for Agent {
     type Output = SetHeapData;
 
     fn index(&self, index: Set) -> &Self::Output {
-        self.heap
-            .sets
-            .get(index.get_index())
+        &self.heap.sets[index]
+    }
+}
+
+impl IndexMut<Set> for Agent {
+    fn index_mut(&mut self, index: Set) -> &mut Self::Output {
+        &mut self.heap.sets[index]
+    }
+}
+
+impl Index<Set> for Vec<Option<SetHeapData>> {
+    type Output = SetHeapData;
+
+    fn index(&self, index: Set) -> &Self::Output {
+        self.get(index.get_index())
             .expect("Set out of bounds")
             .as_ref()
             .expect("Set slot empty")
     }
 }
 
-impl IndexMut<Set> for Agent {
+impl IndexMut<Set> for Vec<Option<SetHeapData>> {
     fn index_mut(&mut self, index: Set) -> &mut Self::Output {
-        self.heap
-            .sets
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("Set out of bounds")
             .as_mut()
             .expect("Set slot empty")

--- a/nova_vm/src/ecmascript/builtins/shared_array_buffer.rs
+++ b/nova_vm/src/ecmascript/builtins/shared_array_buffer.rs
@@ -71,32 +71,30 @@ impl Index<SharedArrayBuffer> for Agent {
     type Output = SharedArrayBufferHeapData;
 
     fn index(&self, index: SharedArrayBuffer) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.shared_array_buffers[index]
     }
 }
 
 impl IndexMut<SharedArrayBuffer> for Agent {
     fn index_mut(&mut self, index: SharedArrayBuffer) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.shared_array_buffers[index]
     }
 }
 
-impl Index<SharedArrayBuffer> for Heap {
+impl Index<SharedArrayBuffer> for Vec<Option<SharedArrayBufferHeapData>> {
     type Output = SharedArrayBufferHeapData;
 
     fn index(&self, index: SharedArrayBuffer) -> &Self::Output {
-        self.shared_array_buffers
-            .get(index.0.into_index())
+        self.get(index.get_index())
             .expect("SharedArrayBuffer out of bounds")
             .as_ref()
             .expect("SharedArrayBuffer slot empty")
     }
 }
 
-impl IndexMut<SharedArrayBuffer> for Heap {
+impl IndexMut<SharedArrayBuffer> for Vec<Option<SharedArrayBufferHeapData>> {
     fn index_mut(&mut self, index: SharedArrayBuffer) -> &mut Self::Output {
-        self.shared_array_buffers
-            .get_mut(index.0.into_index())
+        self.get_mut(index.get_index())
             .expect("SharedArrayBuffer out of bounds")
             .as_mut()
             .expect("SharedArrayBuffer slot empty")

--- a/nova_vm/src/ecmascript/builtins/weak_map.rs
+++ b/nova_vm/src/ecmascript/builtins/weak_map.rs
@@ -99,20 +99,30 @@ impl Index<WeakMap> for Agent {
     type Output = WeakMapHeapData;
 
     fn index(&self, index: WeakMap) -> &Self::Output {
-        self.heap
-            .weak_maps
-            .get(index.get_index())
+        &self.heap.weak_maps[index]
+    }
+}
+
+impl IndexMut<WeakMap> for Agent {
+    fn index_mut(&mut self, index: WeakMap) -> &mut Self::Output {
+        &mut self.heap.weak_maps[index]
+    }
+}
+
+impl Index<WeakMap> for Vec<Option<WeakMapHeapData>> {
+    type Output = WeakMapHeapData;
+
+    fn index(&self, index: WeakMap) -> &Self::Output {
+        self.get(index.get_index())
             .expect("WeakMap out of bounds")
             .as_ref()
             .expect("WeakMap slot empty")
     }
 }
 
-impl IndexMut<WeakMap> for Agent {
+impl IndexMut<WeakMap> for Vec<Option<WeakMapHeapData>> {
     fn index_mut(&mut self, index: WeakMap) -> &mut Self::Output {
-        self.heap
-            .weak_maps
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("WeakMap out of bounds")
             .as_mut()
             .expect("WeakMap slot empty")

--- a/nova_vm/src/ecmascript/builtins/weak_ref.rs
+++ b/nova_vm/src/ecmascript/builtins/weak_ref.rs
@@ -98,20 +98,30 @@ impl Index<WeakRef> for Agent {
     type Output = WeakRefHeapData;
 
     fn index(&self, index: WeakRef) -> &Self::Output {
-        self.heap
-            .weak_refs
-            .get(index.get_index())
+        &self.heap.weak_refs[index]
+    }
+}
+
+impl IndexMut<WeakRef> for Agent {
+    fn index_mut(&mut self, index: WeakRef) -> &mut Self::Output {
+        &mut self.heap.weak_refs[index]
+    }
+}
+
+impl Index<WeakRef> for Vec<Option<WeakRefHeapData>> {
+    type Output = WeakRefHeapData;
+
+    fn index(&self, index: WeakRef) -> &Self::Output {
+        self.get(index.get_index())
             .expect("WeakRef out of bounds")
             .as_ref()
             .expect("WeakRef slot empty")
     }
 }
 
-impl IndexMut<WeakRef> for Agent {
+impl IndexMut<WeakRef> for Vec<Option<WeakRefHeapData>> {
     fn index_mut(&mut self, index: WeakRef) -> &mut Self::Output {
-        self.heap
-            .weak_refs
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("WeakRef out of bounds")
             .as_mut()
             .expect("WeakRef slot empty")

--- a/nova_vm/src/ecmascript/builtins/weak_set.rs
+++ b/nova_vm/src/ecmascript/builtins/weak_set.rs
@@ -109,20 +109,30 @@ impl Index<WeakSet> for Agent {
     type Output = WeakSetHeapData;
 
     fn index(&self, index: WeakSet) -> &Self::Output {
-        self.heap
-            .weak_sets
-            .get(index.get_index())
+        &self.heap.weak_sets[index]
+    }
+}
+
+impl IndexMut<WeakSet> for Agent {
+    fn index_mut(&mut self, index: WeakSet) -> &mut Self::Output {
+        &mut self.heap.weak_sets[index]
+    }
+}
+
+impl Index<WeakSet> for Vec<Option<WeakSetHeapData>> {
+    type Output = WeakSetHeapData;
+
+    fn index(&self, index: WeakSet) -> &Self::Output {
+        self.get(index.get_index())
             .expect("WeakSet out of bounds")
             .as_ref()
             .expect("WeakSet slot empty")
     }
 }
 
-impl IndexMut<WeakSet> for Agent {
+impl IndexMut<WeakSet> for Vec<Option<WeakSetHeapData>> {
     fn index_mut(&mut self, index: WeakSet) -> &mut Self::Output {
-        self.heap
-            .weak_sets
-            .get_mut(index.get_index())
+        self.get_mut(index.get_index())
             .expect("WeakSet out of bounds")
             .as_mut()
             .expect("WeakSet slot empty")

--- a/nova_vm/src/ecmascript/execution/environments/declarative_environment.rs
+++ b/nova_vm/src/ecmascript/execution/environments/declarative_environment.rs
@@ -162,17 +162,6 @@ impl HeapMarkAndSweep for DeclarativeEnvironment {
 }
 
 impl DeclarativeEnvironmentIndex {
-    pub(super) fn heap_data(self, agent: &Agent) -> &DeclarativeEnvironment {
-        agent.heap.environments.get_declarative_environment(self)
-    }
-
-    pub(super) fn heap_data_mut(self, agent: &mut Agent) -> &mut DeclarativeEnvironment {
-        agent
-            .heap
-            .environments
-            .get_declarative_environment_mut(self)
-    }
-
     /// ### [9.1.1.1.1 HasBinding ( N )](https://tc39.es/ecma262/#sec-declarative-environment-records-hasbinding-n)
     ///
     /// The HasBinding concrete method of a Declarative Environment Record
@@ -180,7 +169,7 @@ impl DeclarativeEnvironmentIndex {
     /// containing a Boolean. It determines if the argument identifier is one
     /// of the identifiers bound by the record.
     pub fn has_binding(self, agent: &Agent, name: String) -> bool {
-        let env_rec = self.heap_data(agent);
+        let env_rec = &agent[self];
         // Delegate to heap data record method.
         env_rec.has_binding(name)
     }
@@ -194,7 +183,7 @@ impl DeclarativeEnvironmentIndex {
     /// already exist in this Environment Record for N. If D is true, the new
     /// binding is marked as being subject to deletion.
     pub fn create_mutable_binding(self, agent: &mut Agent, name: String, is_deletable: bool) {
-        let env_rec = self.heap_data_mut(agent);
+        let env_rec = &mut agent[self];
         // Delegate to heap data record method.
         env_rec.create_mutable_binding(name, is_deletable);
     }
@@ -208,7 +197,7 @@ impl DeclarativeEnvironmentIndex {
     /// not already exist in this Environment Record for N. If S is true, the
     /// new binding is marked as a strict binding.
     pub(crate) fn create_immutable_binding(self, agent: &mut Agent, name: String, is_strict: bool) {
-        let env_rec = self.heap_data_mut(agent);
+        let env_rec = &mut agent[self];
         // Delegate to heap data record method.
         env_rec.create_immutable_binding(name, is_strict);
     }
@@ -222,7 +211,7 @@ impl DeclarativeEnvironmentIndex {
     /// whose name is N to the value V. An uninitialized binding for N must
     /// already exist.
     pub(crate) fn initialize_binding(self, agent: &mut Agent, name: String, value: Value) {
-        let env_rec = self.heap_data_mut(agent);
+        let env_rec = &mut agent[self];
         // Delegate to heap data record method.
         env_rec.initialize_binding(name, value)
     }
@@ -244,7 +233,7 @@ impl DeclarativeEnvironmentIndex {
         value: Value,
         mut is_strict: bool,
     ) -> JsResult<()> {
-        let env_rec = self.heap_data_mut(agent);
+        let env_rec = &mut agent[self];
         // 1. If envRec does not have a binding for N, then
         let Some(binding) = env_rec.bindings.get_mut(&name) else {
             // a. If S is true, throw a ReferenceError exception.
@@ -312,7 +301,7 @@ impl DeclarativeEnvironmentIndex {
         name: String,
         is_strict: bool,
     ) -> JsResult<Value> {
-        let env_rec = self.heap_data(agent);
+        let env_rec = &agent[self];
         // Delegate to heap data record method.
         env_rec.get_binding_value(name, is_strict).map_or_else(
             || {
@@ -332,7 +321,7 @@ impl DeclarativeEnvironmentIndex {
     /// containing a Boolean. It can only delete bindings that have been
     /// explicitly designated as being subject to deletion.
     pub(crate) fn delete_binding(self, agent: &mut Agent, name: String) -> bool {
-        let env_rec = self.heap_data_mut(agent);
+        let env_rec = &mut agent[self];
         // Delegate to heap data record method.
         env_rec.delete_binding(name)
     }

--- a/nova_vm/src/ecmascript/execution/environments/object_environment.rs
+++ b/nova_vm/src/ecmascript/execution/environments/object_environment.rs
@@ -82,10 +82,6 @@ impl HeapMarkAndSweep for ObjectEnvironment {
 }
 
 impl ObjectEnvironmentIndex {
-    pub(super) fn heap_data(self, agent: &Agent) -> &ObjectEnvironment {
-        agent.heap.environments.get_object_environment(self)
-    }
-
     /// ### [9.1.1.2.1 HasBinding ( N )](https://tc39.es/ecma262/#sec-object-environment-records-hasbinding-n)
     ///
     /// The HasBinding concrete method of an Object Environment Record envRec
@@ -93,7 +89,7 @@ impl ObjectEnvironmentIndex {
     /// containing a Boolean or a throw completion. It determines if its
     /// associated binding object has a property whose name is N.
     pub(crate) fn has_binding(self, agent: &mut Agent, n: String) -> JsResult<bool> {
-        let env_rec = self.heap_data(agent);
+        let env_rec = &agent[self];
         // 1. Let bindingObject be envRec.[[BindingObject]].
         let binding_object = env_rec.binding_object;
         let is_with_environment = env_rec.is_with_environment;
@@ -141,7 +137,7 @@ impl ObjectEnvironmentIndex {
         n: String,
         d: bool,
     ) -> JsResult<()> {
-        let env_rec = self.heap_data(agent);
+        let env_rec = &agent[self];
         // 1. Let bindingObject be envRec.[[BindingObject]].
         let binding_object = env_rec.binding_object;
         // 2. Perform ? DefinePropertyOrThrow(bindingObject, N, PropertyDescriptor { [[Value]]: undefined, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: D }).
@@ -209,7 +205,7 @@ impl ObjectEnvironmentIndex {
         v: Value,
         s: bool,
     ) -> JsResult<()> {
-        let env_rec = self.heap_data(agent);
+        let env_rec = &agent[self];
         // 1. Let bindingObject be envRec.[[BindingObject]].
         let binding_object = env_rec.binding_object;
         // 2. Let stillExists be ? HasProperty(bindingObject, N).
@@ -239,7 +235,7 @@ impl ObjectEnvironmentIndex {
         n: String,
         s: bool,
     ) -> JsResult<Value> {
-        let env_rec = self.heap_data(agent);
+        let env_rec = &agent[self];
         // 1. Let bindingObject be envRec.[[BindingObject]].
         let binding_object = env_rec.binding_object;
         let name = PropertyKey::from(n);
@@ -267,7 +263,7 @@ impl ObjectEnvironmentIndex {
     /// delete bindings that correspond to properties of the environment
     /// object whose [[Configurable]] attribute have the value true.
     pub(crate) fn delete_binding(self, agent: &mut Agent, name: String) -> JsResult<bool> {
-        let env_rec = self.heap_data(agent);
+        let env_rec = &agent[self];
         // 1. Let bindingObject be envRec.[[BindingObject]].
         let binding_boject = env_rec.binding_object;
         let name = PropertyKey::from(name);
@@ -301,8 +297,8 @@ impl ObjectEnvironmentIndex {
     ///
     /// The WithBaseObject concrete method of an Object Environment Record
     /// envRec takes no arguments and returns an Object or undefined.
-    pub(crate) fn with_base_object(&self, agent: &Agent) -> Option<Object> {
-        let env_rec = self.heap_data(agent);
+    pub(crate) fn with_base_object(self, agent: &Agent) -> Option<Object> {
+        let env_rec = &agent[self];
         // 1. If envRec.[[IsWithEnvironment]] is true, return envRec.[[BindingObject]].
         if env_rec.is_with_environment {
             Some(env_rec.binding_object)

--- a/nova_vm/src/ecmascript/execution/realm.rs
+++ b/nova_vm/src/ecmascript/execution/realm.rs
@@ -11,7 +11,7 @@ use crate::{
             BUILTIN_STRING_MEMORY,
         },
     },
-    heap::{CompactionLists, Heap, HeapMarkAndSweep, WorkQueues},
+    heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
 };
 pub(crate) use intrinsics::Intrinsics;
 pub(crate) use intrinsics::ProtoIntrinsics;
@@ -57,32 +57,30 @@ impl Index<RealmIdentifier> for Agent {
     type Output = Realm;
 
     fn index(&self, index: RealmIdentifier) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.realms[index]
     }
 }
 
 impl IndexMut<RealmIdentifier> for Agent {
     fn index_mut(&mut self, index: RealmIdentifier) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.realms[index]
     }
 }
 
-impl Index<RealmIdentifier> for Heap {
+impl Index<RealmIdentifier> for Vec<Option<Realm>> {
     type Output = Realm;
 
     fn index(&self, index: RealmIdentifier) -> &Self::Output {
-        self.realms
-            .get(index.into_index())
+        self.get(index.into_index())
             .expect("RealmIdentifier out of bounds")
             .as_ref()
             .expect("RealmIdentifier slot empty")
     }
 }
 
-impl IndexMut<RealmIdentifier> for Heap {
+impl IndexMut<RealmIdentifier> for Vec<Option<Realm>> {
     fn index_mut(&mut self, index: RealmIdentifier) -> &mut Self::Output {
-        self.realms
-            .get_mut(index.into_index())
+        self.get_mut(index.into_index())
             .expect("RealmIdentifier out of bounds")
             .as_mut()
             .expect("RealmIdentifier slot empty")

--- a/nova_vm/src/ecmascript/scripts_and_modules/module.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/module.rs
@@ -3,10 +3,7 @@ use std::{
     ops::{Index, IndexMut},
 };
 
-use crate::{
-    ecmascript::{builtins::module::data::ModuleHeapData, execution::Agent},
-    heap::Heap,
-};
+use crate::ecmascript::{builtins::module::data::ModuleHeapData, execution::Agent};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ModuleIdentifier(u32, PhantomData<ModuleHeapData>);
@@ -44,32 +41,30 @@ impl Index<ModuleIdentifier> for Agent {
     type Output = ModuleHeapData;
 
     fn index(&self, index: ModuleIdentifier) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.modules[index]
     }
 }
 
 impl IndexMut<ModuleIdentifier> for Agent {
     fn index_mut(&mut self, index: ModuleIdentifier) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.modules[index]
     }
 }
 
-impl Index<ModuleIdentifier> for Heap {
+impl Index<ModuleIdentifier> for Vec<Option<ModuleHeapData>> {
     type Output = ModuleHeapData;
 
     fn index(&self, index: ModuleIdentifier) -> &Self::Output {
-        self.modules
-            .get(index.into_index())
+        self.get(index.into_index())
             .expect("ModuleIdentifier out of bounds")
             .as_ref()
             .expect("ModuleIdentifier slot empty")
     }
 }
 
-impl IndexMut<ModuleIdentifier> for Heap {
+impl IndexMut<ModuleIdentifier> for Vec<Option<ModuleHeapData>> {
     fn index_mut(&mut self, index: ModuleIdentifier) -> &mut Self::Output {
-        self.modules
-            .get_mut(index.into_index())
+        self.get_mut(index.into_index())
             .expect("ModuleIdentifier out of bounds")
             .as_mut()
             .expect("ModuleIdentifier slot empty")

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -16,7 +16,7 @@ use crate::{
         types::{IntoValue, String, Value},
     },
     engine::{Executable, Vm},
-    heap::{CompactionLists, Heap, HeapMarkAndSweep, WorkQueues},
+    heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
 };
 use oxc_allocator::Allocator;
 use oxc_ast::{
@@ -71,32 +71,30 @@ impl Index<ScriptIdentifier> for Agent {
     type Output = Script;
 
     fn index(&self, index: ScriptIdentifier) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.scripts[index]
     }
 }
 
 impl IndexMut<ScriptIdentifier> for Agent {
     fn index_mut(&mut self, index: ScriptIdentifier) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.scripts[index]
     }
 }
 
-impl Index<ScriptIdentifier> for Heap {
+impl Index<ScriptIdentifier> for Vec<Option<Script>> {
     type Output = Script;
 
     fn index(&self, index: ScriptIdentifier) -> &Self::Output {
-        self.scripts
-            .get(index.into_index())
+        self.get(index.into_index())
             .expect("ScriptIdentifier out of bounds")
             .as_ref()
             .expect("ScriptIdentifier slot empty")
     }
 }
 
-impl IndexMut<ScriptIdentifier> for Heap {
+impl IndexMut<ScriptIdentifier> for Vec<Option<Script>> {
     fn index_mut(&mut self, index: ScriptIdentifier) -> &mut Self::Output {
-        self.scripts
-            .get_mut(index.into_index())
+        self.get_mut(index.into_index())
             .expect("ScriptIdentifier out of bounds")
             .as_mut()
             .expect("ScriptIdentifier slot empty")

--- a/nova_vm/src/ecmascript/types/language/bigint.rs
+++ b/nova_vm/src/ecmascript/types/language/bigint.rs
@@ -376,20 +376,30 @@ impl Index<HeapBigInt> for Agent {
     type Output = BigIntHeapData;
 
     fn index(&self, index: HeapBigInt) -> &Self::Output {
-        self.heap
-            .bigints
-            .get(index.0.into_index())
+        &self.heap.bigints[index]
+    }
+}
+
+impl IndexMut<HeapBigInt> for Agent {
+    fn index_mut(&mut self, index: HeapBigInt) -> &mut Self::Output {
+        &mut self.heap.bigints[index]
+    }
+}
+
+impl Index<HeapBigInt> for Vec<Option<BigIntHeapData>> {
+    type Output = BigIntHeapData;
+
+    fn index(&self, index: HeapBigInt) -> &Self::Output {
+        self.get(index.get_index())
             .expect("BigInt out of bounds")
             .as_ref()
             .expect("BigInt slot empty")
     }
 }
 
-impl IndexMut<HeapBigInt> for Agent {
+impl IndexMut<HeapBigInt> for Vec<Option<BigIntHeapData>> {
     fn index_mut(&mut self, index: HeapBigInt) -> &mut Self::Output {
-        self.heap
-            .bigints
-            .get_mut(index.0.into_index())
+        self.get_mut(index.get_index())
             .expect("BigInt out of bounds")
             .as_mut()
             .expect("BigInt slot empty")

--- a/nova_vm/src/ecmascript/types/language/number.rs
+++ b/nova_vm/src/ecmascript/types/language/number.rs
@@ -1065,10 +1065,22 @@ impl Index<HeapNumber> for Agent {
     type Output = f64;
 
     fn index(&self, index: HeapNumber) -> &Self::Output {
+        &self.heap.numbers[index]
+    }
+}
+
+impl IndexMut<HeapNumber> for Agent {
+    fn index_mut(&mut self, index: HeapNumber) -> &mut Self::Output {
+        &mut self.heap.numbers[index]
+    }
+}
+
+impl Index<HeapNumber> for Vec<Option<NumberHeapData>> {
+    type Output = f64;
+
+    fn index(&self, index: HeapNumber) -> &Self::Output {
         &self
-            .heap
-            .numbers
-            .get(index.0.into_index())
+            .get(index.get_index())
             .expect("HeapNumber out of bounds")
             .as_ref()
             .expect("HeapNumber slot empty")
@@ -1076,12 +1088,10 @@ impl Index<HeapNumber> for Agent {
     }
 }
 
-impl IndexMut<HeapNumber> for Agent {
+impl IndexMut<HeapNumber> for Vec<Option<NumberHeapData>> {
     fn index_mut(&mut self, index: HeapNumber) -> &mut Self::Output {
         &mut self
-            .heap
-            .numbers
-            .get_mut(index.0.into_index())
+            .get_mut(index.get_index())
             .expect("HeapNumber out of bounds")
             .as_mut()
             .expect("HeapNumber slot empty")

--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -32,20 +32,30 @@ impl Index<HeapString> for Agent {
     type Output = StringHeapData;
 
     fn index(&self, index: HeapString) -> &Self::Output {
-        self.heap
-            .strings
-            .get(index.0.into_index())
+        &self.heap.strings[index]
+    }
+}
+
+impl IndexMut<HeapString> for Agent {
+    fn index_mut(&mut self, index: HeapString) -> &mut Self::Output {
+        &mut self.heap.strings[index]
+    }
+}
+
+impl Index<HeapString> for Vec<Option<StringHeapData>> {
+    type Output = StringHeapData;
+
+    fn index(&self, index: HeapString) -> &Self::Output {
+        self.get(index.get_index())
             .expect("HeapString out of bounds")
             .as_ref()
             .expect("HeapString slot empty")
     }
 }
 
-impl IndexMut<HeapString> for Agent {
+impl IndexMut<HeapString> for Vec<Option<StringHeapData>> {
     fn index_mut(&mut self, index: HeapString) -> &mut Self::Output {
-        self.heap
-            .strings
-            .get_mut(index.0.into_index())
+        self.get_mut(index.get_index())
             .expect("HeapString out of bounds")
             .as_mut()
             .expect("HeapString slot empty")

--- a/nova_vm/src/ecmascript/types/language/symbol.rs
+++ b/nova_vm/src/ecmascript/types/language/symbol.rs
@@ -94,32 +94,30 @@ impl Index<Symbol> for Agent {
     type Output = SymbolHeapData;
 
     fn index(&self, index: Symbol) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.symbols[index]
     }
 }
 
 impl IndexMut<Symbol> for Agent {
     fn index_mut(&mut self, index: Symbol) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.symbols[index]
     }
 }
 
-impl Index<Symbol> for Heap {
+impl Index<Symbol> for Vec<Option<SymbolHeapData>> {
     type Output = SymbolHeapData;
 
     fn index(&self, index: Symbol) -> &Self::Output {
-        self.symbols
-            .get(index.0.into_index())
+        self.get(index.get_index())
             .expect("Symbol out of bounds")
             .as_ref()
             .expect("Symbol slot empty")
     }
 }
 
-impl IndexMut<Symbol> for Heap {
+impl IndexMut<Symbol> for Vec<Option<SymbolHeapData>> {
     fn index_mut(&mut self, index: Symbol) -> &mut Self::Output {
-        self.symbols
-            .get_mut(index.0.into_index())
+        self.get_mut(index.get_index())
             .expect("Symbol out of bounds")
             .as_mut()
             .expect("Symbol slot empty")

--- a/nova_vm/src/heap/element_array.rs
+++ b/nova_vm/src/heap/element_array.rs
@@ -1,7 +1,7 @@
 use super::{
     indexes::ElementIndex,
     object_entry::{ObjectEntry, ObjectEntryPropertyDescriptor},
-    CompactionLists, Heap, HeapMarkAndSweep, WorkQueues,
+    CompactionLists, HeapMarkAndSweep, WorkQueues,
 };
 use crate::ecmascript::{
     builtins::SealableElementsVector,
@@ -286,78 +286,30 @@ impl ElementsVector {
         }
         let next_over_end = match self.cap {
             ElementArrayKey::Empty => unreachable!(),
-            ElementArrayKey::E4 => elements
-                .e2pow4
-                .values
-                .get_mut(self.elements_index.into_index())
-                .expect("Invalid ElementsVector: No item at index")
-                .as_mut()
-                .expect("Invalid ElementsVector: Found None at index")
-                .get_mut(self.len as usize)
-                .expect("Invalid ElementsVector: Length points beyond vector bounds"),
-            ElementArrayKey::E6 => elements
-                .e2pow6
-                .values
-                .get_mut(self.elements_index.into_index())
-                .expect("Invalid ElementsVector: No item at index")
-                .as_mut()
-                .expect("Invalid ElementsVector: Found None at index")
-                .get_mut(self.len as usize)
-                .expect("Invalid ElementsVector: Length points beyond vector bounds"),
-            ElementArrayKey::E8 => elements
-                .e2pow8
-                .values
-                .get_mut(self.elements_index.into_index())
-                .expect("Invalid ElementsVector: No item at index")
-                .as_mut()
-                .expect("Invalid ElementsVector: Found None at index")
-                .get_mut(self.len as usize)
-                .expect("Invalid ElementsVector: Length points beyond vector bounds"),
-            ElementArrayKey::E10 => elements
-                .e2pow10
-                .values
-                .get_mut(self.elements_index.into_index())
-                .expect("Invalid ElementsVector: No item at index")
-                .as_mut()
-                .expect("Invalid ElementsVector: Found None at index")
-                .get_mut(self.len as usize)
-                .expect("Invalid ElementsVector: Length points beyond vector bounds"),
-            ElementArrayKey::E12 => elements
-                .e2pow12
-                .values
-                .get_mut(self.elements_index.into_index())
-                .expect("Invalid ElementsVector: No item at index")
-                .as_mut()
-                .expect("Invalid ElementsVector: Found None at index")
-                .get_mut(self.len as usize)
-                .expect("Invalid ElementsVector: Length points beyond vector bounds"),
-            ElementArrayKey::E16 => elements
-                .e2pow16
-                .values
-                .get_mut(self.elements_index.into_index())
-                .expect("Invalid ElementsVector: No item at index")
-                .as_mut()
-                .expect("Invalid ElementsVector: Found None at index")
-                .get_mut(self.len as usize)
-                .expect("Invalid ElementsVector: Length points beyond vector bounds"),
-            ElementArrayKey::E24 => elements
-                .e2pow24
-                .values
-                .get_mut(self.elements_index.into_index())
-                .expect("Invalid ElementsVector: No item at index")
-                .as_mut()
-                .expect("Invalid ElementsVector: Found None at index")
-                .get_mut(self.len as usize)
-                .expect("Invalid ElementsVector: Length points beyond vector bounds"),
-            ElementArrayKey::E32 => elements
-                .e2pow32
-                .values
-                .get_mut(self.elements_index.into_index())
-                .expect("Invalid ElementsVector: No item at index")
-                .as_mut()
-                .expect("Invalid ElementsVector: Found None at index")
-                .get_mut(self.len as usize)
-                .expect("Invalid ElementsVector: Length points beyond vector bounds"),
+            ElementArrayKey::E4 => {
+                &mut elements.e2pow4.values[self.elements_index][self.len as usize]
+            }
+            ElementArrayKey::E6 => {
+                &mut elements.e2pow6.values[self.elements_index][self.len as usize]
+            }
+            ElementArrayKey::E8 => {
+                &mut elements.e2pow8.values[self.elements_index][self.len as usize]
+            }
+            ElementArrayKey::E10 => {
+                &mut elements.e2pow10.values[self.elements_index][self.len as usize]
+            }
+            ElementArrayKey::E12 => {
+                &mut elements.e2pow12.values[self.elements_index][self.len as usize]
+            }
+            ElementArrayKey::E16 => {
+                &mut elements.e2pow16.values[self.elements_index][self.len as usize]
+            }
+            ElementArrayKey::E24 => {
+                &mut elements.e2pow24.values[self.elements_index][self.len as usize]
+            }
+            ElementArrayKey::E32 => {
+                &mut elements.e2pow32.values[self.elements_index][self.len as usize]
+            }
         };
         *next_over_end = value;
         if let Some(descriptor) = descriptor {
@@ -1104,31 +1056,17 @@ impl IndexMut<ElementsVector> for ElementArrays {
     }
 }
 
-impl Index<ElementsVector> for Heap {
-    type Output = [Option<Value>];
-
-    fn index(&self, index: ElementsVector) -> &Self::Output {
-        &self.elements[index]
-    }
-}
-
-impl IndexMut<ElementsVector> for Heap {
-    fn index_mut(&mut self, index: ElementsVector) -> &mut Self::Output {
-        &mut self.elements[index]
-    }
-}
-
 impl Index<ElementsVector> for Agent {
     type Output = [Option<Value>];
 
     fn index(&self, index: ElementsVector) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.elements[index]
     }
 }
 
 impl IndexMut<ElementsVector> for Agent {
     fn index_mut(&mut self, index: ElementsVector) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.elements[index]
     }
 }
 
@@ -1146,31 +1084,17 @@ impl IndexMut<SealableElementsVector> for ElementArrays {
     }
 }
 
-impl Index<SealableElementsVector> for Heap {
-    type Output = [Option<Value>];
-
-    fn index(&self, index: SealableElementsVector) -> &Self::Output {
-        &self.elements[index]
-    }
-}
-
-impl IndexMut<SealableElementsVector> for Heap {
-    fn index_mut(&mut self, index: SealableElementsVector) -> &mut Self::Output {
-        &mut self.elements[index]
-    }
-}
-
 impl Index<SealableElementsVector> for Agent {
     type Output = [Option<Value>];
 
     fn index(&self, index: SealableElementsVector) -> &Self::Output {
-        &self.heap[index]
+        &self.heap.elements[index]
     }
 }
 
 impl IndexMut<SealableElementsVector> for Agent {
     fn index_mut(&mut self, index: SealableElementsVector) -> &mut Self::Output {
-        &mut self.heap[index]
+        &mut self.heap.elements[index]
     }
 }
 
@@ -1528,140 +1452,52 @@ impl ElementArrays {
     pub fn get(&self, vector: ElementsVector) -> &[Option<Value>] {
         match vector.cap {
             ElementArrayKey::Empty => &[],
-            ElementArrayKey::E4 => &self
-                .e2pow4
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize],
-            ElementArrayKey::E6 => &self
-                .e2pow6
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize],
-            ElementArrayKey::E8 => &self
-                .e2pow8
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize],
-            ElementArrayKey::E10 => &self
-                .e2pow10
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize],
-            ElementArrayKey::E12 => &self
-                .e2pow12
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize],
-            ElementArrayKey::E16 => &self
-                .e2pow16
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize],
-            ElementArrayKey::E24 => &self
-                .e2pow24
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize],
-            ElementArrayKey::E32 => &self
-                .e2pow32
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize],
+            ElementArrayKey::E4 => {
+                &self.e2pow4.values[vector.elements_index].as_slice()[0..vector.len as usize]
+            }
+            ElementArrayKey::E6 => {
+                &self.e2pow6.values[vector.elements_index].as_slice()[0..vector.len as usize]
+            }
+            ElementArrayKey::E8 => {
+                &self.e2pow8.values[vector.elements_index].as_slice()[0..vector.len as usize]
+            }
+            ElementArrayKey::E10 => {
+                &self.e2pow10.values[vector.elements_index].as_slice()[0..vector.len as usize]
+            }
+            ElementArrayKey::E12 => {
+                &self.e2pow12.values[vector.elements_index].as_slice()[0..vector.len as usize]
+            }
+            ElementArrayKey::E16 => {
+                &self.e2pow16.values[vector.elements_index].as_slice()[0..vector.len as usize]
+            }
+            ElementArrayKey::E24 => {
+                &self.e2pow24.values[vector.elements_index].as_slice()[0..vector.len as usize]
+            }
+            ElementArrayKey::E32 => {
+                &self.e2pow32.values[vector.elements_index].as_slice()[0..vector.len as usize]
+            }
         }
     }
 
     pub fn get_mut(&mut self, vector: ElementsVector) -> &mut [Option<Value>] {
         match vector.cap {
             ElementArrayKey::Empty => &mut [],
-            ElementArrayKey::E4 => &mut self
-                .e2pow4
-                .values
-                .get_mut(vector.elements_index.into_index())
-                .unwrap()
-                .as_mut()
-                .unwrap()
-                .as_mut_slice()[0..vector.len as usize],
-            ElementArrayKey::E6 => &mut self
-                .e2pow6
-                .values
-                .get_mut(vector.elements_index.into_index())
-                .unwrap()
-                .as_mut()
-                .unwrap()
-                .as_mut_slice()[0..vector.len as usize],
-            ElementArrayKey::E8 => &mut self
-                .e2pow8
-                .values
-                .get_mut(vector.elements_index.into_index())
-                .unwrap()
-                .as_mut()
-                .unwrap()
-                .as_mut_slice()[0..vector.len as usize],
-            ElementArrayKey::E10 => &mut self
-                .e2pow10
-                .values
-                .get_mut(vector.elements_index.into_index())
-                .unwrap()
-                .as_mut()
-                .unwrap()
-                .as_mut_slice()[0..vector.len as usize],
-            ElementArrayKey::E12 => &mut self
-                .e2pow12
-                .values
-                .get_mut(vector.elements_index.into_index())
-                .unwrap()
-                .as_mut()
-                .unwrap()
-                .as_mut_slice()[0..vector.len as usize],
-            ElementArrayKey::E16 => &mut self
-                .e2pow16
-                .values
-                .get_mut(vector.elements_index.into_index())
-                .unwrap()
-                .as_mut()
-                .unwrap()
-                .as_mut_slice()[0..vector.len as usize],
-            ElementArrayKey::E24 => &mut self
-                .e2pow24
-                .values
-                .get_mut(vector.elements_index.into_index())
-                .unwrap()
-                .as_mut()
-                .unwrap()
-                .as_mut_slice()[0..vector.len as usize],
-            ElementArrayKey::E32 => &mut self
-                .e2pow32
-                .values
-                .get_mut(vector.elements_index.into_index())
-                .unwrap()
-                .as_mut()
-                .unwrap()
-                .as_mut_slice()[0..vector.len as usize],
+            ElementArrayKey::E4 => &mut self.e2pow4.values[vector.elements_index].as_mut_slice()
+                [0..vector.len as usize],
+            ElementArrayKey::E6 => &mut self.e2pow6.values[vector.elements_index].as_mut_slice()
+                [0..vector.len as usize],
+            ElementArrayKey::E8 => &mut self.e2pow8.values[vector.elements_index].as_mut_slice()
+                [0..vector.len as usize],
+            ElementArrayKey::E10 => &mut self.e2pow10.values[vector.elements_index].as_mut_slice()
+                [0..vector.len as usize],
+            ElementArrayKey::E12 => &mut self.e2pow12.values[vector.elements_index].as_mut_slice()
+                [0..vector.len as usize],
+            ElementArrayKey::E16 => &mut self.e2pow16.values[vector.elements_index].as_mut_slice()
+                [0..vector.len as usize],
+            ElementArrayKey::E24 => &mut self.e2pow24.values[vector.elements_index].as_mut_slice()
+                [0..vector.len as usize],
+            ElementArrayKey::E32 => &mut self.e2pow32.values[vector.elements_index].as_mut_slice()
+                [0..vector.len as usize],
         }
     }
 
@@ -1669,6 +1505,7 @@ impl ElementArrays {
         &self,
         vector: ElementsVector,
     ) -> (Option<&HashMap<u32, ElementDescriptor>>, &[Option<Value>]) {
+        let usize_index = vector.elements_index.into_index();
         match vector.cap {
             ElementArrayKey::Empty => (None, &[]),
             ElementArrayKey::E4 => {
@@ -1677,7 +1514,7 @@ impl ElementArrays {
                     epow.descriptors.get(&vector.elements_index),
                     &epow
                         .values
-                        .get(vector.elements_index.into_index())
+                        .get(usize_index)
                         .unwrap()
                         .as_ref()
                         .unwrap()
@@ -1690,7 +1527,7 @@ impl ElementArrays {
                     epow.descriptors.get(&vector.elements_index),
                     &epow
                         .values
-                        .get(vector.elements_index.into_index())
+                        .get(usize_index)
                         .unwrap()
                         .as_ref()
                         .unwrap()
@@ -1703,7 +1540,7 @@ impl ElementArrays {
                     epow.descriptors.get(&vector.elements_index),
                     &epow
                         .values
-                        .get(vector.elements_index.into_index())
+                        .get(usize_index)
                         .unwrap()
                         .as_ref()
                         .unwrap()
@@ -1716,7 +1553,7 @@ impl ElementArrays {
                     epow.descriptors.get(&vector.elements_index),
                     &epow
                         .values
-                        .get(vector.elements_index.into_index())
+                        .get(usize_index)
                         .unwrap()
                         .as_ref()
                         .unwrap()
@@ -1729,7 +1566,7 @@ impl ElementArrays {
                     epow.descriptors.get(&vector.elements_index),
                     &epow
                         .values
-                        .get(vector.elements_index.into_index())
+                        .get(usize_index)
                         .unwrap()
                         .as_ref()
                         .unwrap()
@@ -1742,7 +1579,7 @@ impl ElementArrays {
                     epow.descriptors.get(&vector.elements_index),
                     &epow
                         .values
-                        .get(vector.elements_index.into_index())
+                        .get(usize_index)
                         .unwrap()
                         .as_ref()
                         .unwrap()
@@ -1755,7 +1592,7 @@ impl ElementArrays {
                     epow.descriptors.get(&vector.elements_index),
                     &epow
                         .values
-                        .get(vector.elements_index.into_index())
+                        .get(usize_index)
                         .unwrap()
                         .as_ref()
                         .unwrap()
@@ -1768,7 +1605,7 @@ impl ElementArrays {
                     epow.descriptors.get(&vector.elements_index),
                     &epow
                         .values
-                        .get(vector.elements_index.into_index())
+                        .get(usize_index)
                         .unwrap()
                         .as_ref()
                         .unwrap()
@@ -1838,77 +1675,29 @@ impl ElementArrays {
     pub fn has(&self, vector: ElementsVector, element: Value) -> bool {
         match vector.cap {
             ElementArrayKey::Empty => false,
-            ElementArrayKey::E4 => self
-                .e2pow4
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize]
+            ElementArrayKey::E4 => self.e2pow4.values[vector.elements_index].as_slice()
+                [0..vector.len as usize]
                 .contains(&Some(element)),
-            ElementArrayKey::E6 => self
-                .e2pow6
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize]
+            ElementArrayKey::E6 => self.e2pow6.values[vector.elements_index].as_slice()
+                [0..vector.len as usize]
                 .contains(&Some(element)),
-            ElementArrayKey::E8 => self
-                .e2pow8
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize]
+            ElementArrayKey::E8 => self.e2pow8.values[vector.elements_index].as_slice()
+                [0..vector.len as usize]
                 .contains(&Some(element)),
-            ElementArrayKey::E10 => self
-                .e2pow10
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize]
+            ElementArrayKey::E10 => self.e2pow10.values[vector.elements_index].as_slice()
+                [0..vector.len as usize]
                 .contains(&Some(element)),
-            ElementArrayKey::E12 => self
-                .e2pow12
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize]
+            ElementArrayKey::E12 => self.e2pow12.values[vector.elements_index].as_slice()
+                [0..vector.len as usize]
                 .contains(&Some(element)),
-            ElementArrayKey::E16 => self
-                .e2pow16
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize]
+            ElementArrayKey::E16 => self.e2pow16.values[vector.elements_index].as_slice()
+                [0..vector.len as usize]
                 .contains(&Some(element)),
-            ElementArrayKey::E24 => self
-                .e2pow24
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize]
+            ElementArrayKey::E24 => self.e2pow24.values[vector.elements_index].as_slice()
+                [0..vector.len as usize]
                 .contains(&Some(element)),
-            ElementArrayKey::E32 => self
-                .e2pow32
-                .values
-                .get(vector.elements_index.into_index())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .as_slice()[0..vector.len as usize]
+            ElementArrayKey::E32 => self.e2pow32.values[vector.elements_index].as_slice()
+                [0..vector.len as usize]
                 .contains(&Some(element)),
         }
     }

--- a/nova_vm/src/heap/heap_gc.rs
+++ b/nova_vm/src/heap/heap_gc.rs
@@ -103,6 +103,7 @@ pub fn heap_gc(heap: &mut Heap) {
             function: function_environments,
             global: global_environments,
             object: object_environments,
+            private: _private_environments,
         } = environments;
         let ElementArrays {
             e2pow4,
@@ -795,6 +796,7 @@ fn sweep(heap: &mut Heap, bits: &HeapBits) {
         function,
         global,
         object,
+        private: _private_environments,
     } = environments;
     let ElementArrays {
         e2pow4,

--- a/nova_vm/src/heap/heap_gc.rs
+++ b/nova_vm/src/heap/heap_gc.rs
@@ -214,7 +214,7 @@ pub fn heap_gc(heap: &mut Heap) {
         let mut array_marks: Box<[Array]> = queues.arrays.drain(..).collect();
         array_marks.sort();
         array_marks.iter().for_each(|&idx| {
-            let index = idx.into_index();
+            let index = idx.get_index();
             if let Some(marked) = bits.arrays.get_mut(index) {
                 if *marked {
                     // Already marked, ignore


### PR DESCRIPTION
This makes it easier to write "fast-paths" where we know exactly which parts of the heap we'll be touching.

eg. A function that can only allocate strings and errors, and otherwise reads data from eg. numbers could be written to take an immutable borrow on heap numbers, and a mutable borrow on strings and errors.

The downside is that all of the references need to be passed one-by-one. Maybe some day view types will make their way into Rust, at which point these type of things can be made implicit.