### PR TITLE
refactor(ecmascript): Improve conversions between Number and Rust numeric types

### DIFF
--- a/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
@@ -628,7 +628,7 @@ impl ArrayPrototype {
                 // i. Let kValue be ? Get(O, Pk).
                 let k_value = get(agent, o, pk)?;
                 // ii. Let testResult be ToBoolean(? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »)).
-                let f_k = Number::from(k).into_value();
+                let f_k = Number::try_from(k).unwrap().into_value();
                 let test_result = call_function(
                     agent,
                     callback_fn,
@@ -825,7 +825,7 @@ impl ArrayPrototype {
         // 3. Let findRec be ? FindViaPredicate(O, len, ascending, predicate, thisArg).
         let find_rec = find_via_predicate(agent, o, len, true, predicate, this_arg)?;
         // 4. Return findRec.[[Index]].
-        Ok(Number::from(find_rec.0).into_value())
+        Ok(Number::try_from(find_rec.0).unwrap().into_value())
     }
 
     /// ### [23.1.3.11 Array.prototype.findLast ( predicate \[ , thisArg \] )](https://tc39.es/ecma262/#sec-array.prototype.findlast)
@@ -861,7 +861,7 @@ impl ArrayPrototype {
         // 3. Let findRec be ? FindViaPredicate(O, len, descending, predicate, thisArg).
         let find_rec = find_via_predicate(agent, o, len, false, predicate, this_arg)?;
         // 4. Return findRec.[[Index]].
-        Ok(Number::from(find_rec.0).into_value())
+        Ok(Number::try_from(find_rec.0).unwrap().into_value())
     }
 
     fn flat(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
@@ -1895,7 +1895,7 @@ fn find_via_predicate(
             predicate,
             this_arg,
             Some(ArgumentsList(&[
-                Number::from(k).into_value(),
+                Number::try_from(k).unwrap().into_value(),
                 o.into_value(),
             ])),
         )?;

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/number_objects/number_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/number_objects/number_constructor.rs
@@ -209,7 +209,7 @@ impl NumberConstructor {
                 // https://tc39.es/ecma262/#sec-number.max_safe_integer
                 builder
                     .with_key(BUILTIN_STRING_MEMORY.MAX_SAFE_INTEGER.into())
-                    .with_value_readonly(Number::from(SmallInteger::MAX_NUMBER).into())
+                    .with_value_readonly(Number::try_from(SmallInteger::MAX_NUMBER).unwrap().into())
                     .with_configurable(false)
                     .with_enumerable(false)
                     .build()
@@ -229,7 +229,7 @@ impl NumberConstructor {
                 // https://tc39.es/ecma262/#sec-number.min_safe_integer
                 builder
                     .with_key(BUILTIN_STRING_MEMORY.MIN_SAFE_INTEGER.into())
-                    .with_value_readonly(Number::from(SmallInteger::MIN_NUMBER).into())
+                    .with_value_readonly(Number::try_from(SmallInteger::MIN_NUMBER).unwrap().into())
                     .with_configurable(false)
                     .with_enumerable(false)
                     .build()


### PR DESCRIPTION
The `Number` ECMAScript type had a `From<i64>` implementation, although not all `i64` values can be converted to a `Number`. This implementation, in fact, casts the value into the safe integer range, which is not what is typically expected of the `From<T>` trait.

This patch instead turns this implementation into a `TryFrom<i64>` impl, which returns an `Err` when the value cannot be safely cast.

Additionally, since `Number` did not yet provide utility methods for converting to/from `usize`, which would be common for arrays and strings, this patch adds `TryFrom<usize>` and the `into_usize()` method. Notably, `number.into_usize()` is not equivalent to `number.into_i64() as usize` because negative numbers clamp to 0, rather than clamping to `i64::MIN` and subsequently being bytecast.

Furthermore, this patch also adds documentation to the `into_i64()` and `into_usize()` methods describing the conversion details in cases where the number isn't a valid member of the output type.