### PR TITLE
refactor(ecmascript): Refactor `PromiseCapability` and `PromiseState`

### DIFF
--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_capability_records.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_capability_records.rs
@@ -89,10 +89,11 @@ pub(crate) fn if_abrupt_reject_promise<T>(
     value: JsResult<T>,
     capability: PromiseCapability,
 ) -> JsResult<T> {
-    value.or_else(|err| {
+    value.map_err(|err| {
         capability.reject(agent, err.value());
+
         // Note: We return an error here so that caller gets to call this
         // function with the ? operator
-        Err(JsError::new(capability.promise().into_value()))
+        JsError::new(capability.promise().into_value())
     })
 }

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_capability_records.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_capability_records.rs
@@ -4,116 +4,64 @@
 
 //! ## [27.2.1.1 PromiseCapability Records]()
 
-use std::ops::{Index, IndexMut};
-
 use crate::{
     ecmascript::{
-        abstract_operations::operations_on_objects::call_function,
-        builtins::ArgumentsList,
+        builtins::promise::Promise,
         execution::{agent::JsError, Agent, JsResult},
-        types::{Function, Object, Value},
+        types::{IntoValue, Value},
     },
-    heap::{
-        indexes::BaseIndex, CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, WorkQueues,
-    },
+    heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
 };
 
-#[derive(Debug, Clone, Copy)]
-pub struct PromiseCapabilityRecord {
-    /// \[\[Promise\]\]
-    ///
-    /// an Object
-    ///
-    /// An object that is usable as a promise.
-    pub(crate) promise: Object,
-    /// \[\[Resolve\]\]
-    ///
-    /// a function object
-    ///
-    /// The function that is used to resolve the given promise.
-    pub(crate) resolve: Function,
-    /// \[\[Reject\]\]
-    ///
-    /// a function object
-    ///
-    /// The function that is used to reject the given promise.
-    pub(crate) reject: Function,
+/// A promise capability encapsulates a promise, adding methods that are capable
+/// of resolving or rejecting that promise.
+///
+/// NOTE: In the spec, promise capability records contain an object that is
+/// usable as a promise, together with its resolve and reject functions. In our
+/// current implementation, we only ever support built-in promises, and not
+/// other promise-like objects (e.g. we don't support Promise subclasses), and
+/// for that we don't need to store resolve and reject functions, we can create
+/// them only when needed.
+///
+/// The `must_be_unresolved` boolean is used to map the `AlreadyResolved` state
+/// of a pair of resolve/reject functions with the promise state. If
+/// `must_be_unresolved` is false, the promise counts as already resolved if its
+/// state is Fulfilled or Rejected. If true, it also counts as already resolved
+/// if it's Pending but `is_resolved` is set to true.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct PromiseCapability {
+    promise: Promise,
+    must_be_unresolved: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(transparent)]
-pub(crate) struct PromiseCapability(BaseIndex<PromiseCapabilityRecord>);
-
 impl PromiseCapability {
-    pub(crate) const fn get_index(self) -> usize {
-        self.0.into_index()
+    /// [27.2.1.5 NewPromiseCapability ( C )](https://tc39.es/ecma262/#sec-newpromisecapability)
+    pub(crate) fn new(_agent: &mut Agent) -> Self {
+        todo!()
+    }
+
+    pub(crate) fn promise(&self) -> Promise {
+        self.promise
+    }
+
+    /// [27.2.1.3.2 Promise Resolve Functions](https://tc39.es/ecma262/#sec-promise-resolve-functions)
+    pub(crate) fn resolve(&self, _agent: &mut Agent, _resolution: Value) {
+        todo!()
+    }
+
+    /// [27.2.1.3.1 Promise Reject Functions](https://tc39.es/ecma262/#sec-promise-reject-functions)
+    pub(crate) fn reject(&self, _agent: &mut Agent, _reason: Value) {
+        todo!()
     }
 }
 
 impl HeapMarkAndSweep for PromiseCapability {
     fn mark_values(&self, queues: &mut WorkQueues) {
-        queues.promise_capability_records.push(*self);
-    }
-
-    fn sweep_values(&mut self, compactions: &CompactionLists) {
-        compactions
-            .promise_capability_records
-            .shift_index(&mut self.0);
-    }
-}
-
-impl HeapMarkAndSweep for PromiseCapabilityRecord {
-    fn mark_values(&self, queues: &mut WorkQueues) {
         self.promise.mark_values(queues);
-        self.reject.mark_values(queues);
-        self.resolve.mark_values(queues);
     }
 
     fn sweep_values(&mut self, compactions: &CompactionLists) {
         self.promise.sweep_values(compactions);
-        self.reject.sweep_values(compactions);
-        self.resolve.sweep_values(compactions);
-    }
-}
-
-impl Index<PromiseCapability> for Agent {
-    type Output = PromiseCapabilityRecord;
-
-    fn index(&self, index: PromiseCapability) -> &Self::Output {
-        &self.heap.promise_capability_records[index]
-    }
-}
-
-impl IndexMut<PromiseCapability> for Agent {
-    fn index_mut(&mut self, index: PromiseCapability) -> &mut Self::Output {
-        &mut self.heap.promise_capability_records[index]
-    }
-}
-
-impl Index<PromiseCapability> for Vec<Option<PromiseCapabilityRecord>> {
-    type Output = PromiseCapabilityRecord;
-
-    fn index(&self, index: PromiseCapability) -> &Self::Output {
-        self.get(index.get_index())
-            .expect("PromiseCapability out of bounds")
-            .as_ref()
-            .expect("PromiseCapability slot empty")
-    }
-}
-
-impl IndexMut<PromiseCapability> for Vec<Option<PromiseCapabilityRecord>> {
-    fn index_mut(&mut self, index: PromiseCapability) -> &mut Self::Output {
-        self.get_mut(index.get_index())
-            .expect("PromiseCapability out of bounds")
-            .as_mut()
-            .expect("PromiseCapability slot empty")
-    }
-}
-
-impl CreateHeapData<PromiseCapabilityRecord, PromiseCapability> for Heap {
-    fn create(&mut self, data: PromiseCapabilityRecord) -> PromiseCapability {
-        self.promise_capability_records.push(Some(data));
-        PromiseCapability(BaseIndex::last(&self.promise_capability_records))
     }
 }
 
@@ -142,19 +90,9 @@ pub(crate) fn if_abrupt_reject_promise<T>(
     capability: PromiseCapability,
 ) -> JsResult<T> {
     value.or_else(|err| {
-        // If abrupt completion, call reject and make caller return the
-        // capability promise
-        let PromiseCapabilityRecord {
-            promise, reject, ..
-        } = agent[capability];
-        call_function(
-            agent,
-            reject,
-            Value::Undefined,
-            Some(ArgumentsList(&[err.value()])),
-        )?;
+        capability.reject(agent, err.value());
         // Note: We return an error here so that caller gets to call this
         // function with the ? operator
-        Err(JsError::new(promise.into_value()))
+        Err(JsError::new(capability.promise().into_value()))
     })
 }

--- a/nova_vm/src/heap.rs
+++ b/nova_vm/src/heap.rs
@@ -30,7 +30,6 @@ use self::{
 use crate::ecmascript::{
     builtins::{
         control_abstraction_objects::promise_objects::promise_abstract_operations::{
-            promise_capability_records::PromiseCapabilityRecord,
             promise_reaction_records::PromiseReactionRecord,
             promise_reject_function::PromiseRejectFunctionHeapData,
         },
@@ -92,7 +91,6 @@ pub struct Heap {
     pub numbers: Vec<Option<NumberHeapData>>,
     pub objects: Vec<Option<ObjectHeapData>>,
     pub primitive_objects: Vec<Option<PrimitiveObjectHeapData>>,
-    pub promise_capability_records: Vec<Option<PromiseCapabilityRecord>>,
     pub promise_reaction_records: Vec<Option<PromiseReactionRecord>>,
     pub promise_reject_functions: Vec<Option<PromiseRejectFunctionHeapData>>,
     pub promises: Vec<Option<PromiseHeapData>>,
@@ -169,7 +167,6 @@ impl Heap {
             numbers: Vec::with_capacity(1024),
             objects: Vec::with_capacity(1024),
             primitive_objects: Vec::with_capacity(0),
-            promise_capability_records: Vec::with_capacity(0),
             promise_reaction_records: Vec::with_capacity(0),
             promise_reject_functions: Vec::with_capacity(0),
             promises: Vec::with_capacity(0),

--- a/nova_vm/src/heap/heap_bits.rs
+++ b/nova_vm/src/heap/heap_bits.rs
@@ -13,7 +13,6 @@ use crate::ecmascript::{
     builtins::{
         bound_function::BoundFunction,
         control_abstraction_objects::promise_objects::promise_abstract_operations::{
-            promise_capability_records::PromiseCapability,
             promise_reaction_records::PromiseReaction,
             promise_reject_function::BuiltinPromiseRejectFunction,
         },
@@ -73,7 +72,6 @@ pub struct HeapBits {
     pub object_environments: Box<[bool]>,
     pub objects: Box<[bool]>,
     pub primitive_objects: Box<[bool]>,
-    pub promise_capability_records: Box<[bool]>,
     pub promise_reaction_records: Box<[bool]>,
     pub promise_reject_functions: Box<[bool]>,
     pub promises: Box<[bool]>,
@@ -122,7 +120,6 @@ pub(crate) struct WorkQueues {
     pub objects: Vec<OrdinaryObject>,
     pub primitive_objects: Vec<PrimitiveObject>,
     pub promises: Vec<Promise>,
-    pub promise_capability_records: Vec<PromiseCapability>,
     pub promise_reaction_records: Vec<PromiseReaction>,
     pub promise_reject_functions: Vec<BuiltinPromiseRejectFunction>,
     pub proxys: Vec<Proxy>,
@@ -169,7 +166,6 @@ impl HeapBits {
         let object_environments = vec![false; heap.environments.object.len()];
         let objects = vec![false; heap.objects.len()];
         let primitive_objects = vec![false; heap.primitive_objects.len()];
-        let promise_capability_records = vec![false; heap.promise_capability_records.len()];
         let promise_reaction_records = vec![false; heap.promise_reaction_records.len()];
         let promise_reject_functions = vec![false; heap.promise_reject_functions.len()];
         let promises = vec![false; heap.promises.len()];
@@ -214,7 +210,6 @@ impl HeapBits {
             object_environments: object_environments.into_boxed_slice(),
             objects: objects.into_boxed_slice(),
             primitive_objects: primitive_objects.into_boxed_slice(),
-            promise_capability_records: promise_capability_records.into_boxed_slice(),
             promise_reaction_records: promise_reaction_records.into_boxed_slice(),
             promise_reject_functions: promise_reject_functions.into_boxed_slice(),
             promises: promises.into_boxed_slice(),
@@ -265,9 +260,6 @@ impl WorkQueues {
             object_environments: Vec::with_capacity(heap.environments.object.len() / 4),
             objects: Vec::with_capacity(heap.objects.len() / 4),
             primitive_objects: Vec::with_capacity(heap.primitive_objects.len() / 4),
-            promise_capability_records: Vec::with_capacity(
-                heap.promise_capability_records.len() / 4,
-            ),
             promise_reaction_records: Vec::with_capacity(heap.promise_reaction_records.len() / 4),
             promise_reject_functions: Vec::with_capacity(heap.promise_reject_functions.len() / 4),
             promises: Vec::with_capacity(heap.promises.len() / 4),
@@ -572,7 +564,6 @@ pub(crate) struct CompactionLists {
     pub numbers: CompactionList,
     pub objects: CompactionList,
     pub primitive_objects: CompactionList,
-    pub promise_capability_records: CompactionList,
     pub promise_reaction_records: CompactionList,
     pub promise_reject_functions: CompactionList,
     pub promises: CompactionList,
@@ -629,9 +620,6 @@ impl CompactionLists {
             maps: CompactionList::from_mark_bits(&bits.maps),
             numbers: CompactionList::from_mark_bits(&bits.numbers),
             objects: CompactionList::from_mark_bits(&bits.objects),
-            promise_capability_records: CompactionList::from_mark_bits(
-                &bits.promise_capability_records,
-            ),
             promise_reaction_records: CompactionList::from_mark_bits(
                 &bits.promise_reaction_records,
             ),

--- a/nova_vm/src/heap/heap_gc.rs
+++ b/nova_vm/src/heap/heap_gc.rs
@@ -18,7 +18,6 @@ use crate::ecmascript::{
     builtins::{
         bound_function::BoundFunction,
         control_abstraction_objects::promise_objects::promise_abstract_operations::{
-            promise_capability_records::PromiseCapability,
             promise_reaction_records::PromiseReaction,
             promise_reject_function::BuiltinPromiseRejectFunction,
         },
@@ -85,7 +84,6 @@ pub fn heap_gc(heap: &mut Heap) {
             numbers,
             objects,
             primitive_objects,
-            promise_capability_records,
             promise_reaction_records,
             promise_reject_functions,
             promises,
@@ -388,22 +386,6 @@ pub fn heap_gc(heap: &mut Heap) {
                 }
                 *marked = true;
                 promises.get(index).mark_values(&mut queues);
-            }
-        });
-        let mut promise_capability_record_marks: Box<[PromiseCapability]> =
-            queues.promise_capability_records.drain(..).collect();
-        promise_capability_record_marks.sort();
-        promise_capability_record_marks.iter().for_each(|&idx| {
-            let index = idx.get_index();
-            if let Some(marked) = bits.promise_capability_records.get_mut(index) {
-                if *marked {
-                    // Already marked, ignore
-                    return;
-                }
-                *marked = true;
-                promise_capability_records
-                    .get(index)
-                    .mark_values(&mut queues);
             }
         });
         let mut promise_reaction_record_marks: Box<[PromiseReaction]> =
@@ -778,7 +760,6 @@ fn sweep(heap: &mut Heap, bits: &HeapBits) {
         numbers,
         objects,
         primitive_objects,
-        promise_capability_records,
         promise_reaction_records,
         promise_reject_functions,
         promises,
@@ -910,13 +891,6 @@ fn sweep(heap: &mut Heap, bits: &HeapBits) {
         });
         s.spawn(|| {
             sweep_heap_vector_values(primitive_objects, &compactions, &bits.primitive_objects);
-        });
-        s.spawn(|| {
-            sweep_heap_vector_values(
-                promise_capability_records,
-                &compactions,
-                &bits.promise_capability_records,
-            );
         });
         s.spawn(|| {
             sweep_heap_vector_values(


### PR DESCRIPTION
In the spec, Promise Capability Records contain a promise-like object as well as its resolve and reject functions. This is needed if you allow promise subclassing, which makes it so the resolve and reject functions might not be the ones the spec defines. However, for Nova's implementation of promises, we're only allowing built-in Promises (as well as thenables).

If we see a promise capability as giving you both a promise and a way to resolve it, we can instead implement that as a wrapper over `Promise` that gives you built-in `resolve` and `reject` methods. The promise resolving functions could then build *on top of* `PromiseCapability`, rather than vice versa. This would also mean that there wouldn't be a heap vector for promise capabilities themselves.

There's one remaining issue: there are up to two times where resolving functions can be created for a promise. One is when it is created (and those resolving functions are fed to the construction callback). Another is when a promise is resolved onto another promise or thenable (and those resolving functions are passed to its `.then()` method).

Each pair of promise resolving functions has a shared invalidation condition, which causes those functions to not work anymore. In the spec, a function pair is invalidated when either function is called. Here, we want to represent this in the promise state instead: the pair created during construction is valid if the promise is pending and unresolved, the pair created during resolve is valid if the promise is pending (and resolved).

To track this difference, we add an extra `must_be_unresolved` boolean to `PromiseCapability`, and we refactor `PromiseState` to add an `is_resolved` boolean to the `Pending` state. While we're at it, we also move the fulfill and rejection reactions from `PromiseHeapData` to the `PromiseState::Pending` state, and the `promise_is_handled` flag to the rejected state.