### PR TITLE
refactor(ecmascript): Add default implementations to `HostHooks`

### DIFF
--- a/nova_vm/src/ecmascript/execution/agent.rs
+++ b/nova_vm/src/ecmascript/execution/agent.rs
@@ -52,8 +52,17 @@ impl JsError {
 // pub struct PreAllocated;
 
 pub trait HostHooks: std::fmt::Debug {
-    fn host_ensure_can_compile_strings(&self, callee_realm: &mut Realm) -> JsResult<()>;
-    fn host_has_source_text_available(&self, func: Function) -> bool;
+    /// ### [19.2.1.2 HostEnsureCanCompileStrings ( calleeRealm )](https://tc39.es/ecma262/#sec-hostensurecancompilestrings)
+    fn host_ensure_can_compile_strings(&self, _callee_realm: &mut Realm) -> JsResult<()> {
+        // The default implementation of HostEnsureCanCompileStrings is to return NormalCompletion(unused).
+        Ok(())
+    }
+
+    /// ### [20.2.5 HostHasSourceTextAvailable ( func )](https://tc39.es/ecma262/#sec-hosthassourcetextavailable)
+    fn host_has_source_text_available(&self, _func: Function) -> bool {
+        // The default implementation of HostHasSourceTextAvailable is to return true.
+        true
+    }
 }
 
 /// ### [9.7 Agents](https://tc39.es/ecma262/#sec-agents)

--- a/nova_vm/src/ecmascript/execution/default_host_hooks.rs
+++ b/nova_vm/src/ecmascript/execution/default_host_hooks.rs
@@ -2,21 +2,27 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::{agent::HostHooks, JsResult, Realm};
-use crate::ecmascript::types::Function;
+use super::agent::HostHooks;
 
+/// A default implementation of host hooks, meant for applications that don't
+/// need an event loop or microtasks.
+///
+/// Most applications are expected to define a custom implementation of the
+/// [`HostHooks`] trait, and customize it further according to their needs.
+/// `HostHooks` already provides the default implementations for the hooks that
+/// are given by the spec, but hooks related to scheduling and module loading
+/// don't have default implementations, since those are for the application to
+/// handle job scheduling.
+///
+/// For those hooks, [`DefaultHostHooks`] provides an implementation that does
+/// nothing, ignoring those jobs. This means that even if a promise is resolved
+/// synchronously, its `.then` reactions will not run, since those are enqueued
+/// as promise jobs. This is only meant for applications expecting to run a
+/// simple synchronous script and get a result from it.
+///
+/// Other users of Nova should use a custom implementation of [`HostHooks`] that
+/// overrides the scheduling hooks.
 #[derive(Debug)]
 pub struct DefaultHostHooks;
 
-impl HostHooks for DefaultHostHooks {
-    /// ### [19.2.1.2 HostEnsureCanCompileStrings ( calleeRealm )](https://tc39.es/ecma262/#sec-hostensurecancompilestrings)
-    fn host_ensure_can_compile_strings(&self, _: &mut Realm) -> JsResult<()> {
-        Ok(())
-    }
-
-    /// ### [20.2.5 HostHasSourceTextAvailable ( func )](https://tc39.es/ecma262/#sec-hosthassourcetextavailable)
-    fn host_has_source_text_available(&self, _: Function) -> bool {
-        // The default implementation of HostHasSourceTextAvailable is to return true.
-        true
-    }
-}
+impl HostHooks for DefaultHostHooks {}


### PR DESCRIPTION
The host hooks defined in the JS spec include multiple disparate things, from letting the host control on-demand code evaluation, to integration with HTML's concept of an incumbent realm, to enqueuing jobs for the host to later run.

Nova's current model only allows an all-or-nothing approach: either you implement `HostHooks` by yourself, in which case you don't have any of the spec-provided default implementations, or you use `DefaultHostHooks`, which does not let you customize them.

This does not work for host hooks such as `HostEnqueuePromiseJob` and other scheduling hooks, since the spec does not give default implementations. This makes sense, since it is up to the host, not to the JS engine, to determine job scheduling.

This patch moves the implementation of `HostHooks` methods from `DefaultHostHooks` into the trait. It also adds documentation to indicate that in the future, scheduling host hooks without a default implementation will be a no-op in `DefaultHostHooks`, and recommends against the usage of `DefaultHostHooks` for anything but the simplest synchronous use cases.