### PR TITLE
fix(cli): Remove workaround for non-TTY color escapes for parse errors

### DIFF
--- a/nova_cli/src/helper.rs
+++ b/nova_cli/src/helper.rs
@@ -3,7 +3,7 @@ use nova_vm::ecmascript::{
     execution::{Agent, JsResult},
     types::{InternalMethods, IntoValue, Object, PropertyDescriptor, PropertyKey, Value},
 };
-use oxc_diagnostics::{GraphicalTheme, OxcDiagnostic};
+use oxc_diagnostics::OxcDiagnostic;
 
 /// Initialize the global object with the built-in functions.
 pub fn initialize_global_object(agent: &mut Agent, global: Object) {
@@ -40,13 +40,7 @@ pub fn exit_with_parse_errors(errors: Vec<OxcDiagnostic>, source_path: &str, sou
 
     // This seems to be needed for color and Unicode output.
     miette::set_hook(Box::new(|_| {
-        use std::io::IsTerminal;
-        let mut handler = oxc_diagnostics::GraphicalReportHandler::new();
-        if !std::io::stdout().is_terminal() || std::io::stderr().is_terminal() {
-            // Fix for https://github.com/oxc-project/oxc/issues/3539
-            handler = handler.with_theme(GraphicalTheme::none());
-        }
-        Box::new(handler)
+        Box::new(oxc_diagnostics::GraphicalReportHandler::new())
     }))
     .unwrap();
 


### PR DESCRIPTION
PR #210 added this workaround for oxc-project/oxc#3539, and it can now be removed.