### PR TITLE
fix: Remove unnecessary dot when settings the binary extension for Windows in the test262 runner

### DIFF
--- a/tests/test262_runner.rs
+++ b/tests/test262_runner.rs
@@ -765,7 +765,7 @@ fn main() {
         assert!(path.pop());
         path.push("nova_cli");
         if cfg!(windows) {
-            path.set_extension(".exe");
+            path.set_extension("exe");
         }
         assert!(path.is_file());
         path


### PR DESCRIPTION
👆 title