### PR TITLE
fix: Canonicalize the base path of tests in test262_runner

### DIFF
--- a/tests/test262_runner.rs
+++ b/tests/test262_runner.rs
@@ -755,7 +755,11 @@ fn main() {
     // We're expecting this binary to always be run in the same machine at
     // the same time as the repo checkout exists.
     let runner_base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let tests_base = runner_base_path.join("test262/test");
+    let tests_base = runner_base_path
+        .join("test262")
+        .join("test")
+        .canonicalize()
+        .unwrap();
     let nova_harness_path = runner_base_path.join("nova-harness.js");
 
     let nova_cli_path = {


### PR DESCRIPTION
This caused some issues on Windows as [`PathBuf::canonicalize`](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.canonicalize) adds a `\\\\` in Windows Paths, causing `starts_with` to fail if the other path isn't canonicalized as well.

Solution? Just canonicalize the base tests path.