### PR TITLE
refactor(cli): Refactor execution & microtasks into `CliRunner` struct

### DIFF
--- a/nova_cli/Cargo.toml
+++ b/nova_cli/Cargo.toml
@@ -10,6 +10,7 @@ cliclack = { workspace = true }
 console = { workspace = true }
 miette = { workspace = true }
 nova_vm = { path = "../nova_vm" }
+oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_parser = { workspace = true }
 oxc_semantic = { workspace = true }

--- a/nova_vm/src/ecmascript/execution.rs
+++ b/nova_vm/src/ecmascript/execution.rs
@@ -17,8 +17,8 @@ pub(crate) use environments::{
     PrivateEnvironmentIndex, ThisBindingStatus,
 };
 pub(crate) use execution_context::*;
+pub(crate) use realm::ProtoIntrinsics;
 pub use realm::{
     create_realm, initialize_default_realm, initialize_host_defined_realm, set_realm_global_object,
-    Realm,
+    Realm, RealmIdentifier,
 };
-pub(crate) use realm::{ProtoIntrinsics, RealmIdentifier};


### PR DESCRIPTION
In order to add a repl to the cli, #323 moved the `initialize_global_object` and `exit_with_parse_errors` functions into a new `helper` module. However, this still left duplicate code between the `eval` and `repl` commands.

This patch moves the isolate and realm initialization, as well as the script execution and microtask checkpoint, to a new `CliRunner` struct that lives in the `helper` module.

Aside from just refactoring, this patch makes two visible changes related to promise jobs:
  - When passing multiple files to `eval`, now promise jobs run after each script execution, rather than at the end.
  - In `repl` mode it used to be that promise jobs were never run. Now, all promise jobs enqueued when running a line of JS are run before the result is printed.