### PR TITLE
feat(tests): Introduce `--update-metrics` flag

### DIFF
--- a/tests/metrics.json
+++ b/tests/metrics.json
@@ -1,0 +1,11 @@
+{
+  "results": {
+    "crash": 23248,
+    "fail": 6021,
+    "pass": 15752,
+    "skip": 30,
+    "timeout": 0,
+    "unresolved": 0
+  },
+  "total": 45051
+}


### PR DESCRIPTION
Introduces a new `--update-metrics` flag which outputs the metrics of the test run. It also introduces a shorthand flag `--update` (`-u`) which sets both `--update-metrics` and `--update-expectations` true. 
