### PR TITLE
refactor: Refactor promise reactions in preparation for `await`

### DIFF
--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_jobs.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_jobs.rs
@@ -97,14 +97,16 @@ impl PromiseReactionJob {
     pub(crate) fn run(self, agent: &mut Agent) -> JsResult<()> {
         // The following are substeps of point 1 in NewPromiseReactionJob.
         let handler_result = match agent[self.reaction].handler {
-            PromiseReactionHandler::Empty(PromiseReactionType::Fulfill) => {
-                // d.i.1. Let handlerResult be NormalCompletion(argument).
-                Ok(self.argument)
-            }
-            PromiseReactionHandler::Empty(PromiseReactionType::Reject) => {
-                // d.ii.1. Let handlerResult be ThrowCompletion(argument).
-                Err(JsError::new(self.argument))
-            }
+            PromiseReactionHandler::Empty => match agent[self.reaction].reaction_type {
+                PromiseReactionType::Fulfill => {
+                    // d.i.1. Let handlerResult be NormalCompletion(argument).
+                    Ok(self.argument)
+                }
+                PromiseReactionType::Reject => {
+                    // d.ii.1. Let handlerResult be ThrowCompletion(argument).
+                    Err(JsError::new(self.argument))
+                }
+            },
             // e.1. Let handlerResult be Completion(HostCallJobCallback(handler, undefined, « argument »)).
             // TODO: Add the HostCallJobCallback host hook. For now we're using its default
             // implementation, which is calling the thenable, since only browsers should use a
@@ -159,7 +161,7 @@ pub(crate) fn new_promise_reaction_job(
             }
         }
         // 2. Let handlerRealm be null.
-        PromiseReactionHandler::Empty(_) => None,
+        PromiseReactionHandler::Empty => None,
     };
 
     // 4. Return the Record { [[Job]]: job, [[Realm]]: handlerRealm }.

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_reaction_records.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_reaction_records.rs
@@ -33,8 +33,8 @@ pub(crate) enum PromiseReactionType {
 /// \[\[Type\]\] will be used instead.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum PromiseReactionHandler {
-    Empty(PromiseReactionType),
     JobCallback(Function),
+    Empty,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -46,6 +46,8 @@ pub struct PromiseReactionRecord {
     /// The capabilities of the promise for which this record provides a
     /// reaction handler.
     pub(crate) capability: Option<PromiseCapability>,
+    /// \[\[Type\]\]
+    pub(crate) reaction_type: PromiseReactionType,
     /// \[\[Handler\]\]
     ///
     /// a JobCallback Record or empty


### PR DESCRIPTION
In the spec, there are only two types of promise reaction handlers: callback handlers and empty handlers. The internal behavior of `await` and of other spec-internal machinery that depends on promise reactions simply creates JS functions backed by a spec-internal abstract closure and uses them as callback handlers.

These JS functions, however, should not be observable from JS code, and in fact they should only ever be handled by the engine code that deals with promise reactions. Therefore, our implementation of `await` will instead use a new variant of the `PromiseReactionHandler` enum.

To support this, however, there should be a way to invoke PerformPromiseThen with the `on_fulfilled` and `on_rejected` arguments being `PromiseReactionHandler`. To this end, `perform_promise_then` is made closer to the spec, taking those arguments as `Value`s, and a new `inner_promise_then` function is added.

This patch also refactors `PromiseReactionRecord` to store the reaction type (whether it is a reaction to a promise fulfillment or rejection), rather than storing it in `PromiseReactionHandler` only in the empty case. This was not implemented this way initially, even though it matches the spec better, because in the spec only empty reaction handlers depend on the reaction type. However, this will no longer be true if we add `await` continuations as a reaction handler.