### PR TITLE
refactor: Allow storing VM and execution state in GC'd types

### DIFF
--- a/nova_vm/src/ecmascript/abstract_operations/operations_on_iterator_objects.rs
+++ b/nova_vm/src/ecmascript/abstract_operations/operations_on_iterator_objects.rs
@@ -17,7 +17,7 @@ use crate::{
         execution::{agent::ExceptionType, Agent, JsResult, ProtoIntrinsics},
         types::{Function, Object, PropertyKey, Value, BUILTIN_STRING_MEMORY},
     },
-    heap::WellKnownSymbolIndexes,
+    heap::{CompactionLists, HeapMarkAndSweep, WellKnownSymbolIndexes, WorkQueues},
 };
 
 /// ### [7.4.1 Iterator Records](https://tc39.es/ecma262/#sec-iterator-records)
@@ -447,4 +447,16 @@ pub(crate) fn iterator_to_list(
 
     // 4. Return values.
     Ok(values)
+}
+
+impl HeapMarkAndSweep for IteratorRecord {
+    fn mark_values(&self, queues: &mut WorkQueues) {
+        self.iterator.mark_values(queues);
+        self.next_method.mark_values(queues);
+    }
+
+    fn sweep_values(&mut self, compactions: &CompactionLists) {
+        self.iterator.sweep_values(compactions);
+        self.next_method.sweep_values(compactions);
+    }
 }

--- a/nova_vm/src/ecmascript/execution/execution_context.rs
+++ b/nova_vm/src/ecmascript/execution/execution_context.rs
@@ -3,9 +3,12 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{Agent, EnvironmentIndex, PrivateEnvironmentIndex, RealmIdentifier};
-use crate::ecmascript::{
-    scripts_and_modules::{source_code::SourceCode, ScriptOrModule},
-    types::*,
+use crate::{
+    ecmascript::{
+        scripts_and_modules::{source_code::SourceCode, ScriptOrModule},
+        types::*,
+    },
+    heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
 };
 
 // TODO: Remove this.
@@ -90,6 +93,36 @@ pub(crate) struct ExecutionContext {
 impl ExecutionContext {
     pub(crate) fn suspend(&self) {
         // TODO: What does this actually mean in the end?
+    }
+}
+
+impl HeapMarkAndSweep for ECMAScriptCodeEvaluationState {
+    fn mark_values(&self, queues: &mut WorkQueues) {
+        self.lexical_environment.mark_values(queues);
+        self.variable_environment.mark_values(queues);
+        self.private_environment.mark_values(queues);
+    }
+
+    fn sweep_values(&mut self, compactions: &CompactionLists) {
+        self.lexical_environment.sweep_values(compactions);
+        self.variable_environment.sweep_values(compactions);
+        self.private_environment.sweep_values(compactions);
+    }
+}
+
+impl HeapMarkAndSweep for ExecutionContext {
+    fn mark_values(&self, queues: &mut WorkQueues) {
+        self.ecmascript_code.mark_values(queues);
+        self.function.mark_values(queues);
+        self.realm.mark_values(queues);
+        self.script_or_module.mark_values(queues);
+    }
+
+    fn sweep_values(&mut self, compactions: &CompactionLists) {
+        self.ecmascript_code.sweep_values(compactions);
+        self.function.sweep_values(compactions);
+        self.realm.sweep_values(compactions);
+        self.script_or_module.sweep_values(compactions);
     }
 }
 

--- a/nova_vm/src/ecmascript/execution/execution_context.rs
+++ b/nova_vm/src/ecmascript/execution/execution_context.rs
@@ -101,12 +101,14 @@ impl HeapMarkAndSweep for ECMAScriptCodeEvaluationState {
         self.lexical_environment.mark_values(queues);
         self.variable_environment.mark_values(queues);
         self.private_environment.mark_values(queues);
+        self.source_code.mark_values(queues);
     }
 
     fn sweep_values(&mut self, compactions: &CompactionLists) {
         self.lexical_environment.sweep_values(compactions);
         self.variable_environment.sweep_values(compactions);
         self.private_environment.sweep_values(compactions);
+        self.source_code.sweep_values(compactions);
     }
 }
 

--- a/nova_vm/src/ecmascript/syntax_directed_operations/function_definitions.rs
+++ b/nova_vm/src/ecmascript/syntax_directed_operations/function_definitions.rs
@@ -109,13 +109,13 @@ pub(crate) fn instantiate_ordinary_function_expression(
             .as_ref()
             .unwrap();
         // 4. Let sourceText be the source text matched by FunctionExpression.
-        let source_text = function.expression.span;
+        let source_text = function.expression.get().span;
         // 5. Let closure be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, NON-LEXICAL-THIS, env, privateEnv).
         let params = OrdinaryFunctionCreateParams {
             function_prototype: None,
             source_text,
-            parameters_list: &function.expression.params,
-            body: function.expression.body.as_ref().unwrap(),
+            parameters_list: &function.expression.get().params,
+            body: function.expression.get().body.as_ref().unwrap(),
             is_concise_arrow_function: false,
             lexical_this: false,
             env: lexical_environment,

--- a/nova_vm/src/ecmascript/types/language/object/property_key.rs
+++ b/nova_vm/src/ecmascript/types/language/object/property_key.rs
@@ -17,6 +17,7 @@ use crate::{
             String, Symbol, Value,
         },
     },
+    heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
     SmallInteger, SmallString,
 };
 
@@ -241,6 +242,26 @@ impl TryFrom<usize> for PropertyKey {
             Self::try_from(i64)
         } else {
             Err(())
+        }
+    }
+}
+
+impl HeapMarkAndSweep for PropertyKey {
+    fn mark_values(&self, queues: &mut WorkQueues) {
+        match self {
+            PropertyKey::Integer(_) => {}
+            PropertyKey::SmallString(_) => {}
+            PropertyKey::String(string) => string.mark_values(queues),
+            PropertyKey::Symbol(symbol) => symbol.mark_values(queues),
+        }
+    }
+
+    fn sweep_values(&mut self, compactions: &CompactionLists) {
+        match self {
+            PropertyKey::Integer(_) => {}
+            PropertyKey::SmallString(_) => {}
+            PropertyKey::String(string) => string.sweep_values(compactions),
+            PropertyKey::Symbol(symbol) => symbol.sweep_values(compactions),
         }
     }
 }

--- a/nova_vm/src/ecmascript/types/spec/reference.rs
+++ b/nova_vm/src/ecmascript/types/spec/reference.rs
@@ -340,7 +340,7 @@ impl HeapMarkAndSweep for Base {
         match self {
             Base::Value(value) => value.sweep_values(compactions),
             Base::Environment(idx) => idx.sweep_values(compactions),
-            Base::Unresolvable => todo!(),
+            Base::Unresolvable => {}
         }
     }
 }


### PR DESCRIPTION
In order to allow `await` and `yield` to work, the execution state of a function at the time of evaluating an `await` or `yield` expression must be stored as part of one of the heap vectors, so it can later be resumed.

This means that `Vm`, `Executable` and `ExecutionContext` must implement `HeapMarkAndSweep`. This patch adds those implementations to those types, as well as many other internal types that did not already support GC tracing.

All such types must also implement `Send` and `Sync`, since the GC is meant to become multi-threaded in the future. This was not the case for `Executable`, since it includes static references into the oxc allocator, which is single-threaded. However, it would be fine to unsafely send those references across threads as long as they're only dereferenced in the main thread. So we add a `SendableRef` type to make this possible.