### PR TITLE
fix(repl): restore terminal cursor on Ctrl-C signal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = ["nova_cli", "nova_vm", "common", "small_string", "tests"]
 [workspace.dependencies]
 clap = { version = "4.5.9", features = ["derive"] }
 cliclack = "0.3.2"
+ctrlc = "3.4.4"
 console = "0.15.8"
 fast-float = "0.2.0"
 miette = { version = "7.2.0", features = ["fancy"] }

--- a/nova_cli/Cargo.toml
+++ b/nova_cli/Cargo.toml
@@ -7,6 +7,7 @@ default-run = "nova_cli"
 [dependencies]
 clap = { workspace = true}
 cliclack = { workspace = true }
+ctrlc = { workspace = true }
 console = { workspace = true }
 miette = { workspace = true }
 nova_vm = { path = "../nova_vm" }

--- a/nova_cli/src/main.rs
+++ b/nova_cli/src/main.rs
@@ -201,6 +201,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("\n\n");
             let mut placeholder = "Enter a line of Javascript".to_string();
 
+            // Register a signal handler for Ctrl+C
+            let _ = ctrlc::set_handler(|| {
+                let _ = console::Term::stderr().show_cursor();
+            });
             loop {
                 intro("Nova Repl (type exit or ctrl+c to exit)")?;
                 let input: String = input("").placeholder(&placeholder).interact()?;


### PR DESCRIPTION
```
cargo r repl
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/nova_cli repl`



┌  Nova Repl (type exit or ctrl+c to exit)
│
└  Operation cancelled.
Error: Kind(Interrupted)
```

