### PR TITLE
chore(ecmascript): Remove unsafe usage in Map and Set constructors and methods, implement rehashing of primitives if needed

### DIFF
--- a/nova_vm/src/ecmascript/abstract_operations/testing_and_comparison.rs
+++ b/nova_vm/src/ecmascript/abstract_operations/testing_and_comparison.rs
@@ -4,10 +4,15 @@
 
 //! ## [7.2 Testing and Comparison Operations](https://tc39.es/ecma262/#sec-testing-and-comparison-operations)
 
-use crate::ecmascript::{
-    abstract_operations::type_conversion::to_numeric,
-    execution::{agent::ExceptionType, Agent, JsResult},
-    types::{bigint::BigInt, Function, InternalMethods, IntoValue, Number, Object, String, Value},
+use crate::{
+    ecmascript::{
+        abstract_operations::type_conversion::to_numeric,
+        execution::{agent::ExceptionType, Agent, JsResult},
+        types::{
+            bigint::BigInt, Function, InternalMethods, IntoValue, Number, Object, String, Value,
+        },
+    },
+    heap::PrimitiveHeapIndexable,
 };
 
 use super::type_conversion::{string_to_big_int, to_number, to_primitive, PreferredType};
@@ -144,7 +149,7 @@ pub(crate) fn is_integral_number(agent: &mut Agent, argument: impl Copy + Into<V
 
 /// ### [7.2.10 SameValue ( x, y )](https://tc39.es/ecma262/#sec-samevalue)
 pub(crate) fn same_value<V1: Copy + Into<Value>, V2: Copy + Into<Value>>(
-    agent: &Agent,
+    agent: &impl PrimitiveHeapIndexable,
     x: V1,
     y: V2,
 ) -> bool {
@@ -173,7 +178,7 @@ pub(crate) fn same_value<V1: Copy + Into<Value>, V2: Copy + Into<Value>>(
 /// the difference between +0𝔽 and -0𝔽). It performs the following steps when
 /// called:
 pub(crate) fn same_value_zero(
-    agent: &Agent,
+    agent: &impl PrimitiveHeapIndexable,
     x: impl Copy + Into<Value>,
     y: impl Copy + Into<Value>,
 ) -> bool {
@@ -197,7 +202,11 @@ pub(crate) fn same_value_zero(
 }
 
 /// ### [7.2.12 SameValueNonNumber ( x, y )](https://tc39.es/ecma262/#sec-samevaluenonnumber)
-pub(crate) fn same_value_non_number<T: Copy + Into<Value>>(agent: &Agent, x: T, y: T) -> bool {
+pub(crate) fn same_value_non_number<T: Copy + Into<Value>>(
+    agent: &impl PrimitiveHeapIndexable,
+    x: T,
+    y: T,
+) -> bool {
     let x: Value = x.into();
     let y: Value = y.into();
 

--- a/nova_vm/src/ecmascript/builtins/array.rs
+++ b/nova_vm/src/ecmascript/builtins/array.rs
@@ -775,6 +775,7 @@ fn ordinary_define_own_property_for_array(
     true
 }
 
+/// A partial view to the Agent's Heap that allows accessing array heap data.
 pub(crate) struct ArrayHeap<'a> {
     elements: &'a ElementArrays,
     arrays: &'a Vec<Option<ArrayHeapData>>,
@@ -803,6 +804,7 @@ impl AsRef<ElementArrays> for ArrayHeap<'_> {
     }
 }
 
+/// Helper trait for array indexing.
 pub(crate) trait ArrayHeapIndexable:
     Index<Array, Output = ArrayHeapData> + AsRef<ElementArrays>
 {

--- a/nova_vm/src/ecmascript/builtins/array.rs
+++ b/nova_vm/src/ecmascript/builtins/array.rs
@@ -24,7 +24,7 @@ use crate::{
         },
     },
     heap::{
-        element_array::{ElementDescriptor, ElementsVector},
+        element_array::{ElementArrays, ElementDescriptor, ElementsVector},
         indexes::ArrayIndex,
         CreateHeapData, Heap, HeapMarkAndSweep, WorkQueues,
     },
@@ -48,25 +48,25 @@ impl Array {
         self.0.into_index()
     }
 
-    pub fn len(&self, agent: &Agent) -> u32 {
+    pub fn len(&self, agent: &impl Index<Array, Output = ArrayHeapData>) -> u32 {
         agent[*self].elements.len()
     }
 
-    pub fn is_empty(&self, agent: &Agent) -> bool {
+    pub fn is_empty(&self, agent: &impl Index<Array, Output = ArrayHeapData>) -> bool {
         agent[*self].elements.len() == 0
     }
 
-    pub fn is_dense(self, agent: &Agent) -> bool {
+    pub(crate) fn is_dense(self, agent: &impl ArrayHeapIndexable) -> bool {
         agent[self].elements.is_dense(agent)
     }
 
     /// An array is simple if it contains no element accessor descriptors.
-    pub(crate) fn is_simple(self, agent: &Agent) -> bool {
+    pub(crate) fn is_simple(self, agent: &impl ArrayHeapIndexable) -> bool {
         agent[self].elements.is_simple(agent)
     }
 
     /// An array is trivial if it contains no element descriptors.
-    pub(crate) fn is_trivial(self, agent: &Agent) -> bool {
+    pub(crate) fn is_trivial(self, agent: &impl ArrayHeapIndexable) -> bool {
         agent[self].elements.is_trivial(agent)
     }
 
@@ -90,9 +90,9 @@ impl Array {
     }
 
     #[inline]
-    pub(crate) fn as_slice(self, agent: &Agent) -> &[Option<Value>] {
-        let elements = agent[self].elements;
-        &agent[elements]
+    pub(crate) fn as_slice(self, arena: &impl ArrayHeapIndexable) -> &[Option<Value>] {
+        let elements = arena[self].elements;
+        &arena.as_ref()[elements]
     }
 
     #[inline]
@@ -774,3 +774,38 @@ fn ordinary_define_own_property_for_array(
 
     true
 }
+
+pub(crate) struct ArrayHeap<'a> {
+    elements: &'a ElementArrays,
+    arrays: &'a Vec<Option<ArrayHeapData>>,
+}
+
+impl ArrayHeap<'_> {
+    pub(crate) fn new<'a>(
+        elements: &'a ElementArrays,
+        arrays: &'a Vec<Option<ArrayHeapData>>,
+    ) -> ArrayHeap<'a> {
+        ArrayHeap { elements, arrays }
+    }
+}
+
+impl Index<Array> for ArrayHeap<'_> {
+    type Output = ArrayHeapData;
+
+    fn index(&self, index: Array) -> &ArrayHeapData {
+        self.arrays.index(index)
+    }
+}
+
+impl AsRef<ElementArrays> for ArrayHeap<'_> {
+    fn as_ref(&self) -> &ElementArrays {
+        self.elements
+    }
+}
+
+pub(crate) trait ArrayHeapIndexable:
+    Index<Array, Output = ArrayHeapData> + AsRef<ElementArrays>
+{
+}
+impl ArrayHeapIndexable for ArrayHeap<'_> {}
+impl ArrayHeapIndexable for Agent {}

--- a/nova_vm/src/ecmascript/builtins/array/data.rs
+++ b/nova_vm/src/ecmascript/builtins/array/data.rs
@@ -3,10 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::{
-    ecmascript::{
-        execution::Agent,
-        types::{OrdinaryObject, Value},
-    },
+    ecmascript::types::{OrdinaryObject, Value},
     heap::{
         element_array::{ElementArrayKey, ElementArrays, ElementDescriptor, ElementsVector},
         indexes::ElementIndex,
@@ -46,18 +43,18 @@ impl SealableElementsVector {
     }
 
     /// A sealable elements vector is simple if it contains no accessor descriptors.
-    pub(crate) fn is_simple(&self, agent: &Agent) -> bool {
+    pub(crate) fn is_simple(&self, agent: &impl AsRef<ElementArrays>) -> bool {
         let elements_vector: ElementsVector = (*self).into();
         elements_vector.is_simple(agent)
     }
 
     /// A sealable elements vector is trivial if it contains no descriptors.
-    pub(crate) fn is_trivial(&self, agent: &Agent) -> bool {
+    pub(crate) fn is_trivial(&self, agent: &impl AsRef<ElementArrays>) -> bool {
         let elements_vector: ElementsVector = (*self).into();
         elements_vector.is_trivial(agent)
     }
 
-    pub(crate) fn is_dense(&self, agent: &Agent) -> bool {
+    pub(crate) fn is_dense(&self, agent: &impl AsRef<ElementArrays>) -> bool {
         let elements_vector: ElementsVector = (*self).into();
         elements_vector.is_dense(agent)
     }

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_constructor.rs
@@ -179,7 +179,7 @@ pub fn add_entries_from_iterable_map_constructor(
                         ..
                     } = &mut agent.heap;
                     let array_heap = ArrayHeap::new(elements, arrays);
-                    let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+                    let primitive_heap = PrimitiveHeap::new(bigints, numbers, strings);
 
                     // Iterable uses the normal Array iterator of this realm.
                     if iterable.len(&array_heap) == 0 {
@@ -204,7 +204,7 @@ pub fn add_entries_from_iterable_map_constructor(
                             values,
                             map_data,
                             ..
-                        } = maps[target].borrow_mut(&primtive_heap);
+                        } = maps[target].borrow_mut(&primitive_heap);
                         let map_data = map_data.get_mut();
 
                         let length = length as usize;
@@ -215,7 +215,7 @@ pub fn add_entries_from_iterable_map_constructor(
                         map_data.reserve(length, |_| 0);
                         let hasher = |value: Value| {
                             let mut hasher = AHasher::default();
-                            value.hash(&primtive_heap, &mut hasher);
+                            value.hash(&primitive_heap, &mut hasher);
                             hasher.finish()
                         };
                         for entry in iterable.as_slice(&array_heap).iter() {

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_constructor.rs
@@ -17,10 +17,11 @@ use crate::{
         },
         builders::builtin_function_builder::BuiltinFunctionBuilder,
         builtins::{
+            array::ArrayHeap,
             keyed_collections::map_objects::map_prototype::{
                 canonicalize_keyed_collection_key, MapPrototypeSet,
             },
-            map::{data::MapHeapData, Map},
+            map::{data::MapData, Map},
             ordinary::ordinary_create_from_constructor,
             ArgumentsList, Behaviour, Builtin, BuiltinGetter, BuiltinIntrinsicConstructor,
         },
@@ -30,7 +31,7 @@ use crate::{
             BUILTIN_STRING_MEMORY,
         },
     },
-    heap::{IntrinsicConstructorIndexes, WellKnownSymbolIndexes},
+    heap::{Heap, IntrinsicConstructorIndexes, PrimitiveHeap, WellKnownSymbolIndexes},
 };
 
 pub(crate) struct MapConstructor;
@@ -168,38 +169,44 @@ pub fn add_entries_from_iterable_map_constructor(
                             .into_function(),
                     )
                 {
+                    let Heap {
+                        elements,
+                        arrays,
+                        bigints,
+                        numbers,
+                        strings,
+                        maps,
+                        ..
+                    } = &mut agent.heap;
+                    let array_heap = ArrayHeap::new(elements, arrays);
+                    let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+
                     // Iterable uses the normal Array iterator of this realm.
-                    if iterable.len(agent) == 0 {
+                    if iterable.len(&array_heap) == 0 {
                         // Array iterator does not iterate empty arrays.
                         return Ok(target);
                     }
-                    if iterable.is_trivial(agent)
-                        && iterable.as_slice(agent).iter().all(|entry| {
+                    if iterable.is_trivial(&array_heap)
+                        && iterable.as_slice(&array_heap).iter().all(|entry| {
                             if let Some(Value::Array(entry)) = *entry {
-                                entry.len(agent) == 2
-                                    && entry.is_trivial(agent)
-                                    && entry.is_dense(agent)
+                                entry.len(&array_heap) == 2
+                                    && entry.is_trivial(&array_heap)
+                                    && entry.is_dense(&array_heap)
                             } else {
                                 false
                             }
                         })
                     {
                         // Trivial, dense array of trivial, dense arrays of two elements.
-                        let length = iterable.len(agent);
-                        // SAFETY: None of the other Agent borrows can
-                        // invalidate the MapHeapData borrow here.
-                        // It's thus safe to keep this borrow alive
-                        // while we iterate the entries.
-                        let MapHeapData {
+                        let length = iterable.len(&array_heap);
+                        let MapData {
                             keys,
                             values,
                             map_data,
                             ..
-                        } = unsafe {
-                            std::mem::transmute::<&mut MapHeapData, &'static mut MapHeapData>(
-                                &mut agent[target],
-                            )
-                        };
+                        } = maps[target].borrow_mut(&primtive_heap);
+                        let map_data = map_data.get_mut();
+
                         let length = length as usize;
                         keys.reserve(length);
                         values.reserve(length);
@@ -208,17 +215,16 @@ pub fn add_entries_from_iterable_map_constructor(
                         map_data.reserve(length, |_| 0);
                         let hasher = |value: Value| {
                             let mut hasher = AHasher::default();
-                            value.hash(agent, &mut hasher);
+                            value.hash(&primtive_heap, &mut hasher);
                             hasher.finish()
                         };
-                        for entry in iterable.as_slice(agent).iter() {
+                        for entry in iterable.as_slice(&array_heap).iter() {
                             let Some(Value::Array(entry)) = *entry else {
                                 unreachable!()
                             };
-                            let slice = entry.as_slice(agent);
-                            let key = canonicalize_keyed_collection_key(agent, slice[0].unwrap());
+                            let slice = entry.as_slice(&array_heap);
+                            let key = canonicalize_keyed_collection_key(numbers, slice[0].unwrap());
                             let key_hash = hasher(key);
-                            println!("Constructor | Key {:?}, Hash {}", key, key_hash);
                             let value = slice[1].unwrap();
                             let next_index = keys.len() as u32;
                             let entry = map_data.entry(

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_prototype.rs
@@ -131,13 +131,13 @@ impl MapPrototype {
             maps,
             ..
         } = &mut agent.heap;
-        let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+        let primitive_heap = PrimitiveHeap::new(bigints, numbers, strings);
 
         // 3. Set key to CanonicalizeKeyedCollectionKey(key).
         let key = canonicalize_keyed_collection_key(numbers, arguments.get(0));
         let key_hash = {
             let mut hasher = AHasher::default();
-            key.hash(&primtive_heap, &mut hasher);
+            key.hash(&primitive_heap, &mut hasher);
             hasher.finish()
         };
         // 4. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
@@ -146,14 +146,14 @@ impl MapPrototype {
             values,
             map_data,
             ..
-        } = maps[m].borrow_mut(&primtive_heap);
+        } = maps[m].borrow_mut(&primitive_heap);
         let map_data = map_data.get_mut();
 
         // a. If p.[[Key]] is not EMPTY and SameValue(p.[[Key]], key) is true, then
         if let Ok(entry) = map_data.find_entry(key_hash, |hash_equal_index| {
             let found_key = keys[*hash_equal_index as usize].unwrap();
             // Quick check: Equal keys have the same value.
-            found_key == key || same_value(&primtive_heap, found_key, key)
+            found_key == key || same_value(&primitive_heap, found_key, key)
         }) {
             let index = *entry.get() as usize;
             let _ = entry.remove();
@@ -256,7 +256,7 @@ impl MapPrototype {
             maps,
             ..
         } = &agent.heap;
-        let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+        let primitive_heap = PrimitiveHeap::new(bigints, numbers, strings);
 
         // 3. Set key to CanonicalizeKeyedCollectionKey(key).
         let key = canonicalize_keyed_collection_key(agent, arguments.get(0));
@@ -271,7 +271,7 @@ impl MapPrototype {
             values,
             map_data,
             ..
-        } = &maps[m].borrow(&primtive_heap);
+        } = &maps[m].borrow(&primitive_heap);
         let map_data = map_data.borrow();
 
         // a. If p.[[Key]] is not EMPTY and SameValue(p.[[Key]], key) is true, return p.[[Value]].
@@ -301,17 +301,17 @@ impl MapPrototype {
             maps,
             ..
         } = &mut agent.heap;
-        let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+        let primitive_heap = PrimitiveHeap::new(bigints, numbers, strings);
 
         // 3. Set key to CanonicalizeKeyedCollectionKey(key).
         let key = canonicalize_keyed_collection_key(numbers, arguments.get(0));
         let key_hash = {
             let mut hasher = AHasher::default();
-            key.hash(&primtive_heap, &mut hasher);
+            key.hash(&primitive_heap, &mut hasher);
             hasher.finish()
         };
         // 4. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
-        let MapData { keys, map_data, .. } = &mut maps[m].borrow_mut(&primtive_heap);
+        let MapData { keys, map_data, .. } = &mut maps[m].borrow_mut(&primitive_heap);
         let map_data = map_data.get_mut();
 
         // a. If p.[[Key]] is not EMPTY and SameValue(p.[[Key]], key) is true, return true.
@@ -320,7 +320,7 @@ impl MapPrototype {
             .find(key_hash, |hash_equal_index| {
                 let found_key = keys[*hash_equal_index as usize].unwrap();
                 // Quick check: Equal keys have the same value.
-                found_key == key || same_value(&primtive_heap, found_key, key)
+                found_key == key || same_value(&primitive_heap, found_key, key)
             })
             .is_some();
         Ok(found.into())
@@ -344,19 +344,19 @@ impl MapPrototype {
             maps,
             ..
         } = &mut agent.heap;
-        let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+        let primitive_heap = PrimitiveHeap::new(bigints, numbers, strings);
 
         let MapData {
             keys,
             values,
             map_data,
             ..
-        } = &mut maps[m].borrow_mut(&primtive_heap);
+        } = &mut maps[m].borrow_mut(&primitive_heap);
         let map_data = map_data.get_mut();
 
         let hasher = |value: Value| {
             let mut hasher = AHasher::default();
-            value.hash(&primtive_heap, &mut hasher);
+            value.hash(&primitive_heap, &mut hasher);
             hasher.finish()
         };
 
@@ -370,7 +370,7 @@ impl MapPrototype {
             |hash_equal_index| {
                 let found_key = keys[*hash_equal_index as usize].unwrap();
                 // Quick check: Equal keys have the same value.
-                found_key == key || same_value(&primtive_heap, found_key, key)
+                found_key == key || same_value(&primitive_heap, found_key, key)
             },
             |index_to_hash| hasher(keys[*index_to_hash as usize].unwrap()),
         );

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_prototype.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::hash::Hasher;
+use std::{hash::Hasher, ops::Index};
 
 use ahash::AHasher;
 
@@ -17,13 +17,13 @@ use crate::{
             ordinary_object_builder::OrdinaryObjectBuilder,
         },
         builtins::{
-            map::{data::MapHeapData, Map},
+            map::{data::MapData, Map},
             ArgumentsList, Behaviour, Builtin, BuiltinGetter, BuiltinIntrinsic,
         },
         execution::{agent::ExceptionType, Agent, JsResult, RealmIdentifier},
-        types::{IntoValue, PropertyKey, String, Value, BUILTIN_STRING_MEMORY},
+        types::{HeapNumber, IntoValue, PropertyKey, String, Value, BUILTIN_STRING_MEMORY},
     },
-    heap::{IntrinsicFunctionIndexes, WellKnownSymbolIndexes},
+    heap::{Heap, IntrinsicFunctionIndexes, PrimitiveHeap, WellKnownSymbolIndexes},
 };
 
 pub(crate) struct MapPrototype;
@@ -106,12 +106,9 @@ impl MapPrototype {
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         let m = require_map_data_internal_slot(agent, this_value)?;
         // 3. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
-        let data = &mut agent[m];
         // a. Set p.[[Key]] to EMPTY.
         // b. Set p.[[Value]] to EMPTY.
-        data.keys.fill(None);
-        data.values.fill(None);
-        data.map_data.clear();
+        agent[m].clear();
         // 4. Return undefined.
         Ok(Value::Undefined)
     }
@@ -126,30 +123,37 @@ impl MapPrototype {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         let m = require_map_data_internal_slot(agent, this_value)?;
+
+        let Heap {
+            bigints,
+            numbers,
+            strings,
+            maps,
+            ..
+        } = &mut agent.heap;
+        let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+
         // 3. Set key to CanonicalizeKeyedCollectionKey(key).
-        let key = canonicalize_keyed_collection_key(agent, arguments.get(0));
+        let key = canonicalize_keyed_collection_key(numbers, arguments.get(0));
         let key_hash = {
             let mut hasher = AHasher::default();
-            key.hash(agent, &mut hasher);
+            key.hash(&primtive_heap, &mut hasher);
             hasher.finish()
         };
         // 4. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
-        // SAFETY: Borrow for same_value checking of a Value only requires
-        // access to string, number, and bigint data. It will never access Map
-        // data.
-        let MapHeapData {
+        let MapData {
             keys,
             values,
             map_data,
             ..
-        } = unsafe {
-            std::mem::transmute::<&mut MapHeapData, &'static mut MapHeapData>(&mut agent[m])
-        };
+        } = maps[m].borrow_mut(&primtive_heap);
+        let map_data = map_data.get_mut();
+
         // a. If p.[[Key]] is not EMPTY and SameValue(p.[[Key]], key) is true, then
         if let Ok(entry) = map_data.find_entry(key_hash, |hash_equal_index| {
             let found_key = keys[*hash_equal_index as usize].unwrap();
             // Quick check: Equal keys have the same value.
-            found_key == key || same_value(agent, found_key, key)
+            found_key == key || same_value(&primtive_heap, found_key, key)
         }) {
             let index = *entry.get() as usize;
             let _ = entry.remove();
@@ -209,7 +213,7 @@ impl MapPrototype {
         };
         // 4. Let entries be M.[[MapData]].
         // 5. Let numEntries be the number of elements in entries.
-        let mut num_entries = agent[m].keys.len();
+        let mut num_entries = agent[m].values().len();
         // 6. Let index be 0.
         let mut index = 0;
         // 7. Repeat, while index < numEntries,
@@ -219,10 +223,10 @@ impl MapPrototype {
             let entry_index = index;
             // b. Set index to index + 1.
             index += 1;
-            let k = data.keys[entry_index];
+            let k = data.keys()[entry_index];
             // c. If e.[[Key]] is not EMPTY, then
             if let Some(k) = k {
-                let v = data.values[entry_index].unwrap();
+                let v = data.values()[entry_index].unwrap();
                 // i. Perform ? Call(callbackfn, thisArg, « e.[[Value]], e.[[Key]], M »).
                 call_function(
                     agent,
@@ -232,7 +236,7 @@ impl MapPrototype {
                 )?;
                 // ii. NOTE: The number of elements in entries may have increased during execution of callbackfn.
                 // iii. Set numEntries to the number of elements in entries.
-                num_entries = agent[m].keys.len();
+                num_entries = agent[m].values().len();
             }
         }
         // 8. Return undefined.
@@ -244,6 +248,16 @@ impl MapPrototype {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         let m = require_map_data_internal_slot(agent, this_value)?;
+
+        let Heap {
+            bigints,
+            numbers,
+            strings,
+            maps,
+            ..
+        } = &agent.heap;
+        let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+
         // 3. Set key to CanonicalizeKeyedCollectionKey(key).
         let key = canonicalize_keyed_collection_key(agent, arguments.get(0));
         let key_hash = {
@@ -252,15 +266,22 @@ impl MapPrototype {
             hasher.finish()
         };
         // 4. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
-        let data = &agent[m];
+        let MapData {
+            keys,
+            values,
+            map_data,
+            ..
+        } = &maps[m].borrow(&primtive_heap);
+        let map_data = map_data.borrow();
+
         // a. If p.[[Key]] is not EMPTY and SameValue(p.[[Key]], key) is true, return p.[[Value]].
-        let found = data.map_data.find(key_hash, |hash_equal_index| {
-            let found_key = data.keys[*hash_equal_index as usize].unwrap();
+        let found = map_data.find(key_hash, |hash_equal_index| {
+            let found_key = keys[*hash_equal_index as usize].unwrap();
             // Quick check: Equal keys have the same value.
             found_key == key || same_value(agent, found_key, key)
         });
         if let Some(index) = found {
-            Ok(data.values[*index as usize].unwrap())
+            Ok(values[*index as usize].unwrap())
         } else {
             // 5. Return undefined.
             Ok(Value::Undefined)
@@ -272,24 +293,34 @@ impl MapPrototype {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         let m = require_map_data_internal_slot(agent, this_value)?;
+
+        let Heap {
+            bigints,
+            numbers,
+            strings,
+            maps,
+            ..
+        } = &mut agent.heap;
+        let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+
         // 3. Set key to CanonicalizeKeyedCollectionKey(key).
-        let key = canonicalize_keyed_collection_key(agent, arguments.get(0));
+        let key = canonicalize_keyed_collection_key(numbers, arguments.get(0));
         let key_hash = {
             let mut hasher = AHasher::default();
-            key.hash(agent, &mut hasher);
+            key.hash(&primtive_heap, &mut hasher);
             hasher.finish()
         };
-        println!("Has | Key {:?}, Hash {}", key, key_hash);
         // 4. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
-        let data = &agent[m];
+        let MapData { keys, map_data, .. } = &mut maps[m].borrow_mut(&primtive_heap);
+        let map_data = map_data.get_mut();
+
         // a. If p.[[Key]] is not EMPTY and SameValue(p.[[Key]], key) is true, return true.
         // 5. Return false.
-        let found = data
-            .map_data
+        let found = map_data
             .find(key_hash, |hash_equal_index| {
-                let found_key = data.keys[*hash_equal_index as usize].unwrap();
+                let found_key = keys[*hash_equal_index as usize].unwrap();
                 // Quick check: Equal keys have the same value.
-                found_key == key || same_value(agent, found_key, key)
+                found_key == key || same_value(&primtive_heap, found_key, key)
             })
             .is_some();
         Ok(found.into())
@@ -306,24 +337,31 @@ impl MapPrototype {
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         let m = require_map_data_internal_slot(agent, this_value)?;
 
-        // SAFETY: Borrow for hashing a Value only requires access to string,
-        // number, and bigint data. It will never access Map data.
-        let MapHeapData {
+        let Heap {
+            bigints,
+            numbers,
+            strings,
+            maps,
+            ..
+        } = &mut agent.heap;
+        let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+
+        let MapData {
             keys,
             values,
             map_data,
             ..
-        } = unsafe {
-            std::mem::transmute::<&mut MapHeapData, &'static mut MapHeapData>(&mut agent[m])
-        };
+        } = &mut maps[m].borrow_mut(&primtive_heap);
+        let map_data = map_data.get_mut();
+
         let hasher = |value: Value| {
             let mut hasher = AHasher::default();
-            value.hash(agent, &mut hasher);
+            value.hash(&primtive_heap, &mut hasher);
             hasher.finish()
         };
 
         // 3. Set key to CanonicalizeKeyedCollectionKey(key).
-        let key = canonicalize_keyed_collection_key(agent, arguments.get(0));
+        let key = canonicalize_keyed_collection_key(numbers, arguments.get(0));
         let key_hash = hasher(key);
         // 4. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
         // a. If p.[[Key]] is not EMPTY and SameValue(p.[[Key]], key) is true, then
@@ -332,7 +370,7 @@ impl MapPrototype {
             |hash_equal_index| {
                 let found_key = keys[*hash_equal_index as usize].unwrap();
                 // Quick check: Equal keys have the same value.
-                found_key == key || same_value(agent, found_key, key)
+                found_key == key || same_value(&primtive_heap, found_key, key)
             },
             |index_to_hash| hasher(keys[*index_to_hash as usize].unwrap()),
         );
@@ -358,7 +396,7 @@ impl MapPrototype {
 
     fn get_size(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
         let m = require_map_data_internal_slot(agent, this_value)?;
-        let count = agent[m].map_data.len() as u32;
+        let count = agent[m].size();
         Ok(count.into())
     }
 
@@ -434,7 +472,10 @@ fn require_map_data_internal_slot(agent: &mut Agent, value: Value) -> JsResult<M
 /// ### [24.5.1 CanonicalizeKeyedCollectionKey ( key )](https://tc39.es/ecma262/#sec-canonicalizekeyedcollectionkey)
 /// The abstract operation CanonicalizeKeyedCollectionKey takes argument key
 /// (an ECMAScript language value) and returns an ECMAScript language value.
-pub(crate) fn canonicalize_keyed_collection_key(agent: &Agent, key: Value) -> Value {
+pub(crate) fn canonicalize_keyed_collection_key(
+    agent: &impl Index<HeapNumber, Output = f64>,
+    key: Value,
+) -> Value {
     // 1. If key is -0𝔽, return +0𝔽.
     if let Value::SmallF64(key) = key {
         // Note: Only f32 should hold -0.

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_constructor.rs
@@ -117,16 +117,16 @@ impl SetConstructor {
                     ..
                 } = &mut agent.heap;
                 let array_heap = ArrayHeap::new(elements, arrays);
-                let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+                let primitive_heap = PrimitiveHeap::new(bigints, numbers, strings);
 
                 let SetData {
                     values, set_data, ..
-                } = &mut sets[set].borrow_mut(&primtive_heap);
+                } = &mut sets[set].borrow_mut(&primitive_heap);
                 let set_data = set_data.get_mut();
 
                 let hasher = |value: Value| {
                     let mut hasher = AHasher::default();
-                    value.hash(&primtive_heap, &mut hasher);
+                    value.hash(&primitive_heap, &mut hasher);
                     hasher.finish()
                 };
 

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_constructor.rs
@@ -5,7 +5,6 @@
 use std::hash::Hasher;
 
 use ahash::AHasher;
-use hashbrown::HashTable;
 
 use crate::{
     ecmascript::{
@@ -14,12 +13,14 @@ use crate::{
                 get_iterator, if_abrupt_close_iterator, iterator_step_value,
             },
             operations_on_objects::{call_function, get, get_method},
-            testing_and_comparison::{is_callable, same_value},
+            testing_and_comparison::is_callable,
         },
         builders::builtin_function_builder::BuiltinFunctionBuilder,
         builtins::{
-            ordinary::ordinary_create_from_constructor, set::Set, ArgumentsList, Behaviour,
-            Builtin, BuiltinGetter, BuiltinIntrinsicConstructor,
+            array::ArrayHeap,
+            ordinary::ordinary_create_from_constructor,
+            set::{data::SetData, Set},
+            ArgumentsList, Behaviour, Builtin, BuiltinGetter, BuiltinIntrinsicConstructor,
         },
         execution::{agent::ExceptionType, Agent, JsResult, ProtoIntrinsics, RealmIdentifier},
         types::{
@@ -27,7 +28,7 @@ use crate::{
             BUILTIN_STRING_MEMORY,
         },
     },
-    heap::{IntrinsicConstructorIndexes, WellKnownSymbolIndexes},
+    heap::{Heap, IntrinsicConstructorIndexes, PrimitiveHeap, WellKnownSymbolIndexes},
 };
 
 pub(crate) struct SetConstructor;
@@ -106,25 +107,57 @@ impl SetConstructor {
                 // Accessorless, holeless array with standard Array values
                 // iterator. We can fast-path this.
 
-                // SAFETY: The array slice borrow cannot be invalidated by our
-                // incoming mutation of the Set data.
-                let mut set_vector = iterable.as_slice(agent).to_vec();
-                set_vector.dedup_by(|a, b| same_value(agent, *a, *b));
-                let mut set_hash_table = HashTable::with_capacity(set_vector.len());
+                let Heap {
+                    elements,
+                    arrays,
+                    bigints,
+                    numbers,
+                    strings,
+                    sets,
+                    ..
+                } = &mut agent.heap;
+                let array_heap = ArrayHeap::new(elements, arrays);
+                let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+
+                let SetData {
+                    values, set_data, ..
+                } = &mut sets[set].borrow_mut(&primtive_heap);
+                let set_data = set_data.get_mut();
+
                 let hasher = |value: Value| {
                     let mut hasher = AHasher::default();
-                    value.hash(agent, &mut hasher);
+                    value.hash(&primtive_heap, &mut hasher);
                     hasher.finish()
                 };
-                set_vector.iter().enumerate().for_each(|(index, value)| {
+
+                let iterable_length = iterable.len(&array_heap) as usize;
+                values.reserve(iterable_length);
+                // Note: There should be no items in the set data. Hence the
+                // hasher function should never be called.
+                assert!(set_data.is_empty());
+                set_data.reserve(iterable_length, |_| unreachable!());
+                iterable.as_slice(&array_heap).iter().for_each(|value| {
                     let value = value.unwrap();
                     let value_hash = hasher(value);
-                    set_hash_table.insert_unique(value_hash, index as u32, |index_to_hash| {
-                        hasher(set_vector[*index_to_hash as usize].unwrap())
-                    });
+                    let next_index = values.len() as u32;
+                    let entry = set_data.entry(
+                        value_hash,
+                        |hash_equal_index| values[*hash_equal_index as usize].unwrap() == value,
+                        |index_to_hash| hasher(values[*index_to_hash as usize].unwrap()),
+                    );
+                    match entry {
+                        hashbrown::hash_table::Entry::Occupied(occupied) => {
+                            // We have duplicates in the array. Latter
+                            // ones overwrite earlier ones.
+                            let index = *occupied.get();
+                            values[index as usize] = Some(value);
+                        }
+                        hashbrown::hash_table::Entry::Vacant(vacant) => {
+                            vacant.insert(next_index);
+                            values.push(Some(value));
+                        }
+                    }
                 });
-                agent[set].values = set_vector;
-                agent[set].set_data = set_hash_table;
                 return Ok(set.into_value());
             }
         }

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_prototype.rs
@@ -103,18 +103,18 @@ impl SetPrototype {
             sets,
             ..
         } = &mut agent.heap;
-        let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+        let primitive_heap = PrimitiveHeap::new(bigints, numbers, strings);
 
         // 3. Set value to CanonicalizeKeyedCollectionKey(value).
         let value = canonicalize_keyed_collection_key(numbers, arguments.get(0));
 
         let SetData {
             values, set_data, ..
-        } = &mut sets[s].borrow_mut(&primtive_heap);
+        } = &mut sets[s].borrow_mut(&primitive_heap);
         let set_data = set_data.get_mut();
         let hasher = |value: Value| {
             let mut hasher = AHasher::default();
-            value.hash(&primtive_heap, &mut hasher);
+            value.hash(&primitive_heap, &mut hasher);
             hasher.finish()
         };
 
@@ -127,7 +127,7 @@ impl SetPrototype {
             |hash_equal_index| {
                 let found_value = values[*hash_equal_index as usize].unwrap();
                 // Quick check: Equal values have the same value.
-                found_value == value || same_value(&primtive_heap, found_value, value)
+                found_value == value || same_value(&primitive_heap, found_value, value)
             },
             |index_to_hash| hasher(values[*index_to_hash as usize].unwrap()),
         ) {
@@ -178,24 +178,24 @@ impl SetPrototype {
             sets,
             ..
         } = &mut agent.heap;
-        let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+        let primitive_heap = PrimitiveHeap::new(bigints, numbers, strings);
 
         // 3. Set value to CanonicalizeKeyedCollectionKey(value).
         let value = canonicalize_keyed_collection_key(numbers, arguments.get(0));
         let mut hasher = AHasher::default();
         let value_hash = {
-            value.hash(&primtive_heap, &mut hasher);
+            value.hash(&primitive_heap, &mut hasher);
             hasher.finish()
         };
         let SetData {
             values, set_data, ..
-        } = &mut sets[s].borrow_mut(&primtive_heap);
+        } = &mut sets[s].borrow_mut(&primitive_heap);
         let set_data = set_data.get_mut();
         // 4. For each element e of S.[[SetData]], do
         if let Ok(entry) = set_data.find_entry(value_hash, |hash_equal_index| {
             let found_value = values[*hash_equal_index as usize].unwrap();
             // Quick check: Equal keys have the same value.
-            found_value == value || same_value(&primtive_heap, found_value, value)
+            found_value == value || same_value(&primitive_heap, found_value, value)
         }) {
             // a. If e is not EMPTY and SameValue(e, value) is true, then
             let index = *entry.get() as usize;
@@ -305,17 +305,17 @@ impl SetPrototype {
             sets,
             ..
         } = &agent.heap;
-        let primtive_heap = PrimitiveHeap::new(bigints, numbers, strings);
+        let primitive_heap = PrimitiveHeap::new(bigints, numbers, strings);
         let SetData {
             values, set_data, ..
-        } = &sets[s].borrow(&primtive_heap);
+        } = &sets[s].borrow(&primitive_heap);
         let set_data = set_data.borrow();
 
         // 3. Set value to CanonicalizeKeyedCollectionKey(value).
-        let value = canonicalize_keyed_collection_key(&primtive_heap, arguments.get(0));
+        let value = canonicalize_keyed_collection_key(&primitive_heap, arguments.get(0));
         let mut hasher = AHasher::default();
         let value_hash = {
-            value.hash(&primtive_heap, &mut hasher);
+            value.hash(&primitive_heap, &mut hasher);
             hasher.finish()
         };
         // 4. For each element e of S.[[SetData]], do
@@ -324,7 +324,7 @@ impl SetPrototype {
             .find(value_hash, |hash_equal_index| {
                 let found_value = values[*hash_equal_index as usize].unwrap();
                 // Quick check: Equal values have the same value.
-                found_value == value || same_value(&primtive_heap, found_value, value)
+                found_value == value || same_value(&primitive_heap, found_value, value)
             })
             .is_some();
         // 5. Return false.

--- a/nova_vm/src/ecmascript/builtins/map/data.rs
+++ b/nova_vm/src/ecmascript/builtins/map/data.rs
@@ -93,6 +93,8 @@ impl MapData {
         }
 
         rehash_map_data(&self.keys, self.map_data.get_mut(), arena);
+        self.needs_primitive_rehashing
+            .store(false, Ordering::Relaxed);
     }
 
     fn rehash_if_needed(&self, arena: &impl PrimitiveHeapIndexable) {
@@ -101,6 +103,8 @@ impl MapData {
         }
 
         rehash_map_data(&self.keys, &mut self.map_data.borrow_mut(), arena);
+        self.needs_primitive_rehashing
+            .store(false, Ordering::Relaxed);
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/map/data.rs
+++ b/nova_vm/src/ecmascript/builtins/map/data.rs
@@ -2,35 +2,176 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::hash::Hasher;
-
-use ahash::AHasher;
-use hashbrown::HashTable;
-
 use crate::{
-    ecmascript::types::{OrdinaryObject, Value},
-    heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
+    ecmascript::types::{
+        bigint::HeapBigInt, HeapNumber, HeapPrimitive, HeapString, OrdinaryObject, Value,
+        BIGINT_DISCRIMINANT, NUMBER_DISCRIMINANT, STRING_DISCRIMINANT,
+    },
+    heap::{CompactionLists, HeapMarkAndSweep, PrimitiveHeapIndexable, WorkQueues},
+};
+use ahash::AHasher;
+use hashbrown::{hash_table::Entry, HashTable};
+use std::{
+    cell::RefCell,
+    hash::{Hash, Hasher},
+    sync::atomic::{AtomicBool, Ordering},
 };
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct MapHeapData {
     pub(crate) object_index: Option<OrdinaryObject>,
-    // TODO: Use a ParallelVec to remove one unnecessary allocation.
-    // pub(crate) key_values: ParallelVec<Option<Value>, Option<Value>>
-    pub(crate) keys: Vec<Option<Value>>,
-    pub(crate) values: Vec<Option<Value>>,
-    /// Low-level hash table pointing to keys-values indexes.
-    pub(crate) map_data: HashTable<u32>,
+    map_data: MapData,
     // TODO: When an non-terminal (start or end) iterator exists for the Map,
     // the items in the map cannot be compacted.
     // pub(crate) observed: bool;
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct MapData {
+    // TODO: Use a ParallelVec to remove one unnecessary allocation.
+    // pub(crate) key_values: ParallelVec<Option<Value>, Option<Value>>
+    pub(crate) keys: Vec<Option<Value>>,
+    pub(crate) values: Vec<Option<Value>>,
+    /// Low-level hash table pointing to keys-values indexes.
+    pub(crate) map_data: RefCell<HashTable<u32>>,
+    /// Flag that lets the Map know if it needs to rehash its primitive keys.
+    ///
+    /// This happens when an object key needs to be moved in the map_data
+    /// during garbage collection, and the move results in a primitive key
+    /// moving as well. The primitive key's hash cannot be calculated during
+    /// garbage collection due to the heap data being concurrently sweeped on
+    /// another thread.
+    pub(crate) needs_primitive_rehashing: AtomicBool,
+}
+
+impl MapHeapData {
+    /// ### [24.2.1.5 MapDataSize ( setData )](https://tc39.es/ecma262/#sec-setdatasize)
+    ///
+    /// The abstract operation MapDataSize takes argument setData (a List of either
+    /// ECMAScript language values or EMPTY) and returns a non-negative integer.
+    #[inline(always)]
+    pub fn size(&self) -> u32 {
+        // 1. Let count be 0.
+        // 2. For each element e of setData, do
+        // a. If e is not EMPTY, set count to count + 1.
+        // 3. Return count.
+        self.map_data.map_data.borrow().len() as u32
+    }
+
+    pub fn keys(&self) -> &[Option<Value>] {
+        &self.map_data.keys
+    }
+
+    pub fn values(&self) -> &[Option<Value>] {
+        &self.map_data.values
+    }
+
+    pub fn clear(&mut self) {
+        // 3. For each Record { [[Key]], [[Value]] } p of M.[[MapData]], do
+        // a. Set p.[[Key]] to EMPTY.
+        // b. Set p.[[Value]] to EMPTY.
+        self.map_data.map_data.get_mut().clear();
+        self.map_data.values.fill(None);
+        self.map_data.keys.fill(None);
+    }
+
+    pub(crate) fn borrow(&self, arena: &impl PrimitiveHeapIndexable) -> &MapData {
+        self.map_data.rehash_if_needed(arena);
+        &self.map_data
+    }
+
+    pub(crate) fn borrow_mut(&mut self, arena: &impl PrimitiveHeapIndexable) -> &mut MapData {
+        self.map_data.rehash_if_needed_mut(arena);
+        &mut self.map_data
+    }
+}
+
+impl MapData {
+    fn rehash_if_needed_mut(&mut self, arena: &impl PrimitiveHeapIndexable) {
+        if !*self.needs_primitive_rehashing.get_mut() {
+            return;
+        }
+
+        rehash_map_data(&self.keys, self.map_data.get_mut(), arena);
+    }
+
+    fn rehash_if_needed(&self, arena: &impl PrimitiveHeapIndexable) {
+        if !self.needs_primitive_rehashing.load(Ordering::Relaxed) {
+            return;
+        }
+
+        rehash_map_data(&self.keys, &mut self.map_data.borrow_mut(), arena);
+    }
+}
+
+fn rehash_map_data(
+    keys: &[Option<Value>],
+    map_data: &mut HashTable<u32>,
+    arena: &impl PrimitiveHeapIndexable,
+) {
+    let hasher = |value: Value| {
+        let mut hasher = AHasher::default();
+        value.hash(arena, &mut hasher);
+        hasher.finish()
+    };
+    let hashes = {
+        let hasher = |discriminant: u8| {
+            let mut hasher = AHasher::default();
+            discriminant.hash(&mut hasher);
+            hasher.finish()
+        };
+        [
+            (0u8, hasher(STRING_DISCRIMINANT)),
+            (1u8, hasher(NUMBER_DISCRIMINANT)),
+            (2u8, hasher(BIGINT_DISCRIMINANT)),
+        ]
+    };
+    for (id, hash) in hashes {
+        let eq = |equal_hash_index: &u32| {
+            let value = keys[*equal_hash_index as usize].unwrap();
+            match id {
+                0 => HeapString::try_from(value).is_ok(),
+                1 => HeapNumber::try_from(value).is_ok(),
+                2 => HeapBigInt::try_from(value).is_ok(),
+                _ => unreachable!(),
+            }
+        };
+        let mut entries = Vec::new();
+        while let Ok(entry) = map_data.find_entry(hash, eq) {
+            entries.push(*entry.get());
+            entry.remove();
+        }
+        entries.iter().for_each(|entry| {
+            let key = keys[*entry as usize].unwrap();
+            let key_hash = hasher(key);
+            let result = map_data.entry(
+                key_hash,
+                |equal_hash_index| {
+                    // It should not be possible for there to be an equal item
+                    // in the Map already.
+                    debug_assert_ne!(keys[*equal_hash_index as usize].unwrap(), key);
+                    false
+                },
+                |index_to_hash| hasher(keys[*index_to_hash as usize].unwrap()),
+            );
+
+            let Entry::Vacant(result) = result else {
+                unreachable!();
+            };
+            result.insert(*entry);
+        });
+    }
+}
+
 impl HeapMarkAndSweep for MapHeapData {
     fn mark_values(&self, queues: &mut WorkQueues) {
         self.object_index.mark_values(queues);
-        self.keys.iter().for_each(|value| value.mark_values(queues));
-        self.values
+        self.map_data
+            .keys
+            .iter()
+            .for_each(|value| value.mark_values(queues));
+        self.map_data
+            .values
             .iter()
             .for_each(|value| value.mark_values(queues));
     }
@@ -38,10 +179,15 @@ impl HeapMarkAndSweep for MapHeapData {
     fn sweep_values(&mut self, compactions: &CompactionLists) {
         let Self {
             object_index,
-            keys,
-            values,
             map_data,
         } = self;
+        let MapData {
+            keys,
+            values,
+            needs_primitive_rehashing,
+            map_data,
+        } = map_data;
+        let map_data = map_data.get_mut();
         object_index.sweep_values(compactions);
 
         let hasher = |value: Value| {
@@ -52,18 +198,18 @@ impl HeapMarkAndSweep for MapHeapData {
                 // vectors for those data points are currently being sweeped on
                 // another thread, so we cannot access them right now even if
                 // we wanted to. This situation should be fairly improbable as
-                // it requires mixing eg. long string and object keys in the
+                // it requires mixing eg. long string and object values in the
                 // same Map, so it's not pressing right now. Still, it must be
-                // handled eventually. Possible solutions are:
-                // 1. Store hash in MapHeapData for heap primitive values. This
-                //    requires eg. an Option<HashMap<u32, u64>>.
-                // 2. Deduplicate heap Number and BigInts as well, and hash
-                //    them based on their identity. This means they need to
-                //    relocate in the HashTable as well which may be worse.
-                // 2. Sweep primitives first or last and provide a
-                //    reference to their data in compactions. The problem is:
-                //    How do you know value has already been sweeped?
-                panic!("Relocating an Object key in Map caused a rehashing of a primitive heap value; their data cannot be accessed during garbage collection. Sorry.");
+                // handled eventually. We essentially mark the heap hash data
+                // as "dirty". Any lookup shall then later check this boolean
+                // and rehash primitive keys if necessary.
+                needs_primitive_rehashing.store(true, Ordering::Relaxed);
+                let value = HeapPrimitive::try_from(value).unwrap();
+                // Return a hash based on the discriminant. This we are likely
+                // to cause hash collisions but we avoid having to rehash all
+                // keys; we can just rehash the primitive keys that match the
+                // discriminant hash.
+                core::mem::discriminant(&value).hash(&mut hasher);
             }
             hasher.finish()
         };
@@ -91,7 +237,7 @@ impl HeapMarkAndSweep for MapHeapData {
                 // changes.
                 continue;
             }
-            // Object changed identity; it must be moved in the set_data.
+            // Object changed identity; it must be moved in the map_data.
             let old_hash = hasher(old_key);
             let new_hash = hasher(new_key);
             if let Ok(old_entry) =

--- a/nova_vm/src/ecmascript/builtins/set/data.rs
+++ b/nova_vm/src/ecmascript/builtins/set/data.rs
@@ -2,31 +2,171 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::hash::Hasher;
-
-use ahash::AHasher;
-use hashbrown::HashTable;
-
 use crate::{
-    ecmascript::types::{OrdinaryObject, Value},
-    heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
+    ecmascript::types::{
+        bigint::HeapBigInt, HeapNumber, HeapString, OrdinaryObject, Value, BIGINT_DISCRIMINANT,
+        NUMBER_DISCRIMINANT, STRING_DISCRIMINANT,
+    },
+    heap::{CompactionLists, HeapMarkAndSweep, PrimitiveHeapIndexable, WorkQueues},
+};
+use ahash::AHasher;
+use hashbrown::{hash_table::Entry, HashTable};
+use std::{
+    cell::RefCell,
+    hash::{Hash, Hasher},
+    sync::atomic::{AtomicBool, Ordering},
 };
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct SetHeapData {
     pub(crate) object_index: Option<OrdinaryObject>,
+    set_data: SetData,
+    // TODO: When an non-terminal (start or end) iterator exists for the Set,
+    // the items in the set cannot be compacted.
+    // pub(crate) observed: bool;
+}
+
+impl SetHeapData {
+    /// ### [24.2.1.5 SetDataSize ( setData )](https://tc39.es/ecma262/#sec-setdatasize)
+    ///
+    /// The abstract operation SetDataSize takes argument setData (a List of either
+    /// ECMAScript language values or EMPTY) and returns a non-negative integer.
+    #[inline(always)]
+    pub fn size(&self) -> u32 {
+        // 1. Let count be 0.
+        // 2. For each element e of setData, do
+        // a. If e is not EMPTY, set count to count + 1.
+        // 3. Return count.
+        self.set_data.set_data.borrow().len() as u32
+    }
+
+    pub fn values(&self) -> &[Option<Value>] {
+        &self.set_data.values
+    }
+
+    pub fn clear(&mut self) {
+        // 3. For each element e of S.[[SetData]], do
+        // a. Replace the element of S.[[SetData]] whose value is e with an
+        // element whose value is EMPTY.
+        self.set_data.set_data.get_mut().clear();
+        self.set_data.values.fill(None);
+    }
+
+    pub(crate) fn borrow(&self, arena: &impl PrimitiveHeapIndexable) -> &SetData {
+        self.set_data.rehash_if_needed(arena);
+        &self.set_data
+    }
+
+    pub(crate) fn borrow_mut(&mut self, arena: &impl PrimitiveHeapIndexable) -> &mut SetData {
+        self.set_data.rehash_if_needed(arena);
+        &mut self.set_data
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SetData {
     pub(crate) values: Vec<Option<Value>>,
     /// Low-level hash table pointing to value indexes.
-    pub(crate) set_data: HashTable<u32>,
-    // TODO: When an non-terminal (start or end) iterator exists for the Set,
-    // the items in the map cannot be compacted.
-    // pub(crate) observed: bool;
+    pub(crate) set_data: RefCell<HashTable<u32>>,
+    /// Flag that lets the Set know if it needs to rehash its primitive keys.
+    ///
+    /// This happens when an object key needs to be moved in the set_data
+    /// during garbage collection, and the move results in a primitive key
+    /// moving as well. The primitive key's hash cannot be calculated during
+    /// garbage collection due to the heap data being concurrently sweeped on
+    /// another thread.
+    pub(crate) needs_primitive_rehashing: AtomicBool,
+}
+
+impl SetData {
+    fn rehash_if_needed(&self, arena: &impl PrimitiveHeapIndexable) {
+        if !self.needs_primitive_rehashing.load(Ordering::Relaxed) {
+            return;
+        }
+        let SetData {
+            values, set_data, ..
+        } = self;
+        let mut set_data = set_data.borrow_mut();
+
+        rehash_set_data(values, &mut set_data, arena);
+    }
+
+    fn rehash_if_needed_mut(&mut self, arena: &impl PrimitiveHeapIndexable) {
+        if !*self.needs_primitive_rehashing.get_mut() {
+            return;
+        }
+        let SetData {
+            values, set_data, ..
+        } = self;
+
+        rehash_set_data(values, set_data.get_mut(), arena);
+    }
+}
+
+fn rehash_set_data(
+    values: &[Option<Value>],
+    set_data: &mut HashTable<u32>,
+    arena: &impl PrimitiveHeapIndexable,
+) {
+    let hasher = |value: Value| {
+        let mut hasher = AHasher::default();
+        value.hash(arena, &mut hasher);
+        hasher.finish()
+    };
+    let hashes = {
+        let hasher = |discriminant: u8| {
+            let mut hasher = AHasher::default();
+            discriminant.hash(&mut hasher);
+            hasher.finish()
+        };
+        [
+            (0u8, hasher(STRING_DISCRIMINANT)),
+            (1u8, hasher(NUMBER_DISCRIMINANT)),
+            (2u8, hasher(BIGINT_DISCRIMINANT)),
+        ]
+    };
+    for (id, hash) in hashes {
+        let eq = |equal_hash_index: &u32| {
+            let value = values[*equal_hash_index as usize].unwrap();
+            match id {
+                0 => HeapString::try_from(value).is_ok(),
+                1 => HeapNumber::try_from(value).is_ok(),
+                2 => HeapBigInt::try_from(value).is_ok(),
+                _ => unreachable!(),
+            }
+        };
+        let mut entries = Vec::new();
+        while let Ok(entry) = set_data.find_entry(hash, eq) {
+            entries.push(*entry.get());
+            entry.remove();
+        }
+        entries.iter().for_each(|entry| {
+            let key = values[*entry as usize].unwrap();
+            let key_hash = hasher(key);
+            let result = set_data.entry(
+                key_hash,
+                |equal_hash_index| {
+                    // It should not be possible for there to be an equal item
+                    // in the Set already.
+                    debug_assert_ne!(values[*equal_hash_index as usize].unwrap(), key);
+                    false
+                },
+                |index_to_hash| hasher(values[*index_to_hash as usize].unwrap()),
+            );
+
+            let Entry::Vacant(result) = result else {
+                unreachable!();
+            };
+            result.insert(*entry);
+        });
+    }
 }
 
 impl HeapMarkAndSweep for SetHeapData {
     fn mark_values(&self, queues: &mut WorkQueues) {
         self.object_index.mark_values(queues);
-        self.values
+        self.set_data
+            .values
             .iter()
             .for_each(|value| value.mark_values(queues));
     }
@@ -34,9 +174,14 @@ impl HeapMarkAndSweep for SetHeapData {
     fn sweep_values(&mut self, compactions: &CompactionLists) {
         let Self {
             object_index,
-            values,
             set_data,
         } = self;
+        let SetData {
+            values,
+            set_data,
+            needs_primitive_rehashing,
+        } = set_data;
+        let set_data = set_data.get_mut();
         object_index.sweep_values(compactions);
 
         let hasher = |value: Value| {
@@ -49,16 +194,15 @@ impl HeapMarkAndSweep for SetHeapData {
                 // we wanted to. This situation should be fairly improbable as
                 // it requires mixing eg. long string and object values in the
                 // same Set, so it's not pressing right now. Still, it must be
-                // handled eventually. Possible solutions are:
-                // 1. Store hash in SetHeapData for heap primitive values. This
-                //    requires eg. an Option<HashMap<u32, u64>>.
-                // 2. Deduplicate heap Number and BigInts as well, and hash
-                //    them based on their identity. This means they need to
-                //    relocate in the HashTable as well which may be worse.
-                // 2. Sweep primitives first or last and provide a
-                //    reference to their data in compactions. The problem is:
-                //    How do you know value has already been sweeped?
-                panic!("Relocating an Object key in Set caused a rehashing of a primitive heap value; their data cannot be accessed during garbage collection. Sorry.");
+                // handled eventually. We essentially mark the heap hash data
+                // as "dirty". Any lookup shall then later check this boolean
+                // and rehash primitive keys if necessary.
+                needs_primitive_rehashing.store(true, Ordering::Relaxed);
+                // Return a hash based on the discriminant. This we are likely
+                // to cause hash collisions but we avoid having to rehash all
+                // keys; we can just rehash the primitive keys that match the
+                // discriminant hash.
+                core::mem::discriminant(&value).hash(&mut hasher);
             }
             hasher.finish()
         };

--- a/nova_vm/src/ecmascript/builtins/set/data.rs
+++ b/nova_vm/src/ecmascript/builtins/set/data.rs
@@ -89,6 +89,8 @@ impl SetData {
         let mut set_data = set_data.borrow_mut();
 
         rehash_set_data(values, &mut set_data, arena);
+        self.needs_primitive_rehashing
+            .store(false, Ordering::Relaxed);
     }
 
     fn rehash_if_needed_mut(&mut self, arena: &impl PrimitiveHeapIndexable) {
@@ -100,6 +102,8 @@ impl SetData {
         } = self;
 
         rehash_set_data(values, set_data.get_mut(), arena);
+        self.needs_primitive_rehashing
+            .store(false, Ordering::Relaxed);
     }
 }
 

--- a/nova_vm/src/ecmascript/execution/agent.rs
+++ b/nova_vm/src/ecmascript/execution/agent.rs
@@ -19,7 +19,7 @@ use crate::{
         scripts_and_modules::ScriptOrModule,
         types::{Function, IntoValue, Object, Reference, String, Symbol, Value},
     },
-    heap::{heap_gc::heap_gc, CreateHeapData},
+    heap::{heap_gc::heap_gc, CreateHeapData, PrimitiveHeapIndexable},
     Heap,
 };
 use std::any::Any;
@@ -462,3 +462,5 @@ pub enum ExceptionType {
     TypeError,
     UriError,
 }
+
+impl PrimitiveHeapIndexable for Agent {}

--- a/nova_vm/src/ecmascript/types/language.rs
+++ b/nova_vm/src/ecmascript/types/language.rs
@@ -30,6 +30,7 @@ pub use numeric::Numeric;
 pub use object::{
     InternalMethods, InternalSlots, IntoObject, Object, ObjectHeapData, OrdinaryObject, PropertyKey,
 };
+pub(crate) use primitive::HeapPrimitive;
 pub use primitive::Primitive;
 pub use string::{HeapString, String, StringHeapData, BUILTIN_STRINGS_LIST, BUILTIN_STRING_MEMORY};
 pub use symbol::{Symbol, SymbolHeapData};

--- a/nova_vm/src/ecmascript/types/language/bigint.rs
+++ b/nova_vm/src/ecmascript/types/language/bigint.rs
@@ -3,9 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod data;
-
-use std::ops::{Index, IndexMut};
-
 use super::{
     into_numeric::IntoNumeric,
     numeric::Numeric,
@@ -15,12 +12,13 @@ use super::{
 use crate::{
     ecmascript::execution::{agent::ExceptionType, Agent, JsResult},
     heap::{
-        indexes::BigIntIndex, CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, WorkQueues,
+        indexes::BigIntIndex, CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep,
+        PrimitiveHeap, WorkQueues,
     },
     SmallInteger,
 };
-
 pub use data::BigIntHeapData;
+use std::ops::{Index, IndexMut};
 
 impl IntoValue for BigInt {
     fn into_value(self) -> Value {
@@ -54,6 +52,42 @@ impl HeapBigInt {
 
     pub(crate) fn get_index(self) -> usize {
         self.0.into_index()
+    }
+}
+
+impl IntoValue for HeapBigInt {
+    fn into_value(self) -> Value {
+        Value::BigInt(self)
+    }
+}
+
+impl IntoPrimitive for HeapBigInt {
+    fn into_primitive(self) -> Primitive {
+        Primitive::BigInt(self)
+    }
+}
+
+impl TryFrom<Value> for HeapBigInt {
+    type Error = ();
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        if let Value::BigInt(x) = value {
+            Ok(x)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl TryFrom<Primitive> for HeapBigInt {
+    type Error = ();
+
+    fn try_from(value: Primitive) -> Result<Self, Self::Error> {
+        if let Primitive::BigInt(x) = value {
+            Ok(x)
+        } else {
+            Err(())
+        }
     }
 }
 
@@ -265,7 +299,11 @@ impl BigInt {
     ///
     /// The abstract operation BigInt::lessThan takes arguments x (a BigInt)
     /// and y (a BigInt) and returns a Boolean.
-    pub(crate) fn less_than(agent: &mut Agent, x: BigInt, y: BigInt) -> bool {
+    pub(crate) fn less_than(
+        agent: &impl Index<HeapBigInt, Output = BigIntHeapData>,
+        x: BigInt,
+        y: BigInt,
+    ) -> bool {
         // 1. If ℝ(x) < ℝ(y), return true; otherwise return false.
         match (x, y) {
             (BigInt::BigInt(_), BigInt::SmallBigInt(_)) => false,
@@ -282,7 +320,11 @@ impl BigInt {
     ///
     /// The abstract operation BigInt::equal takes arguments x (a BigInt) and y
     /// (a BigInt) and returns a Boolean.
-    pub(crate) fn equal(agent: &Agent, x: BigInt, y: BigInt) -> bool {
+    pub(crate) fn equal(
+        agent: &impl Index<HeapBigInt, Output = BigIntHeapData>,
+        x: BigInt,
+        y: BigInt,
+    ) -> bool {
         // 1. If ℝ(x) = ℝ(y), return true; otherwise return false.
         match (x, y) {
             (BigInt::BigInt(x), BigInt::BigInt(y)) => {
@@ -390,6 +432,14 @@ impl_value_from_n!(u16);
 impl_value_from_n!(i16);
 impl_value_from_n!(u32);
 impl_value_from_n!(i32);
+
+impl Index<HeapBigInt> for PrimitiveHeap<'_> {
+    type Output = BigIntHeapData;
+
+    fn index(&self, index: HeapBigInt) -> &Self::Output {
+        &self.bigints[index]
+    }
+}
 
 impl Index<HeapBigInt> for Agent {
     type Output = BigIntHeapData;

--- a/nova_vm/src/ecmascript/types/language/number.rs
+++ b/nova_vm/src/ecmascript/types/language/number.rs
@@ -17,7 +17,8 @@ use crate::{
     },
     engine::small_f64::SmallF64,
     heap::{
-        indexes::NumberIndex, CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, WorkQueues,
+        indexes::NumberIndex, CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep,
+        PrimitiveHeap, WorkQueues,
     },
     SmallInteger,
 };
@@ -77,6 +78,18 @@ impl IntoValue for Number {
 impl IntoNumeric for HeapNumber {
     fn into_numeric(self) -> Numeric {
         Numeric::Number(self)
+    }
+}
+
+impl TryFrom<Value> for HeapNumber {
+    type Error = ();
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        if let Value::Number(x) = value {
+            Ok(x)
+        } else {
+            Err(())
+        }
     }
 }
 
@@ -241,7 +254,7 @@ impl Number {
         Self::from(f32::NEG_INFINITY)
     }
 
-    pub fn is_nan(self, agent: &Agent) -> bool {
+    pub fn is_nan(self, agent: &impl Index<HeapNumber, Output = f64>) -> bool {
         match self {
             Number::Number(n) => agent[n].is_nan(),
             Number::Integer(_) => false,
@@ -249,7 +262,7 @@ impl Number {
         }
     }
 
-    pub fn is_pos_zero(self, agent: &Agent) -> bool {
+    pub fn is_pos_zero(self, agent: &impl Index<HeapNumber, Output = f64>) -> bool {
         match self {
             Number::Number(n) => f64::to_bits(0.0) == f64::to_bits(agent[n]),
             Number::Integer(n) => 0i64 == n.into_i64(),
@@ -257,7 +270,7 @@ impl Number {
         }
     }
 
-    pub fn is_neg_zero(self, agent: &Agent) -> bool {
+    pub fn is_neg_zero(self, agent: &impl Index<HeapNumber, Output = f64>) -> bool {
         match self {
             Number::Number(n) => f64::to_bits(-0.0) == f64::to_bits(agent[n]),
             Number::Integer(_) => false,
@@ -265,7 +278,7 @@ impl Number {
         }
     }
 
-    pub fn is_pos_infinity(self, agent: &Agent) -> bool {
+    pub fn is_pos_infinity(self, agent: &impl Index<HeapNumber, Output = f64>) -> bool {
         match self {
             Number::Number(n) => agent[n] == f64::INFINITY,
             Number::Integer(_) => false,
@@ -273,7 +286,7 @@ impl Number {
         }
     }
 
-    pub fn is_neg_infinity(self, agent: &Agent) -> bool {
+    pub fn is_neg_infinity(self, agent: &impl Index<HeapNumber, Output = f64>) -> bool {
         match self {
             Number::Number(n) => agent[n] == f64::NEG_INFINITY,
             Number::Integer(_) => false,
@@ -281,7 +294,7 @@ impl Number {
         }
     }
 
-    pub fn is_finite(self, agent: &Agent) -> bool {
+    pub fn is_finite(self, agent: &impl Index<HeapNumber, Output = f64>) -> bool {
         match self {
             Number::Number(n) => agent[n].is_finite(),
             Number::Integer(_) => true,
@@ -289,7 +302,7 @@ impl Number {
         }
     }
 
-    pub fn is_nonzero(self, agent: &Agent) -> bool {
+    pub fn is_nonzero(self, agent: &impl Index<HeapNumber, Output = f64>) -> bool {
         match self {
             Number::Number(n) => 0.0 != agent[n],
             Number::Integer(n) => 0i64 != n.into_i64(),
@@ -297,7 +310,7 @@ impl Number {
         }
     }
 
-    pub fn is_pos_one(self, agent: &Agent) -> bool {
+    pub fn is_pos_one(self, agent: &impl Index<HeapNumber, Output = f64>) -> bool {
         // NOTE: Only the integer variant should ever return true, if any other
         // variant returns true, that's a bug as it means that our variants are
         // no longer "sound".
@@ -314,7 +327,7 @@ impl Number {
         }
     }
 
-    pub fn is_neg_one(self, agent: &Agent) -> bool {
+    pub fn is_neg_one(self, agent: &impl Index<HeapNumber, Output = f64>) -> bool {
         match self {
             Number::Integer(n) => -1i64 == n.into_i64(),
             Number::Number(n) => {
@@ -328,7 +341,7 @@ impl Number {
         }
     }
 
-    pub fn is_sign_positive(self, agent: &Agent) -> bool {
+    pub fn is_sign_positive(self, agent: &impl Index<HeapNumber, Output = f64>) -> bool {
         match self {
             Number::Number(n) => agent[n].is_sign_positive(),
             Number::Integer(n) => n.into_i64().is_positive(),
@@ -336,7 +349,7 @@ impl Number {
         }
     }
 
-    pub fn is_sign_negative(self, agent: &Agent) -> bool {
+    pub fn is_sign_negative(self, agent: &impl Index<HeapNumber, Output = f64>) -> bool {
         match self {
             Number::Number(n) => agent[n].is_sign_negative(),
             Number::Integer(n) => n.into_i64().is_negative(),
@@ -356,7 +369,7 @@ impl Number {
         }
     }
 
-    pub fn into_f64(self, agent: &Agent) -> f64 {
+    pub fn into_f64(self, agent: &impl Index<HeapNumber, Output = f64>) -> f64 {
         match self {
             Number::Number(n) => agent[n],
             Number::Integer(n) => Into::<i64>::into(n) as f64,
@@ -364,7 +377,7 @@ impl Number {
         }
     }
 
-    pub fn into_f32(self, agent: &Agent) -> f32 {
+    pub fn into_f32(self, agent: &impl Index<HeapNumber, Output = f64>) -> f32 {
         match self {
             Number::Number(n) => agent[n] as f32,
             Number::Integer(n) => Into::<i64>::into(n) as f32,
@@ -378,7 +391,7 @@ impl Number {
     /// - NaN becomes 0.
     /// - Numbers are clamped between [`i64::MIN`] and [`i64::MAX`].
     /// - All other numbers round towards zero.
-    pub fn into_i64(self, agent: &Agent) -> i64 {
+    pub fn into_i64(self, agent: &impl Index<HeapNumber, Output = f64>) -> i64 {
         match self {
             Number::Number(n) => agent[n] as i64,
             Number::Integer(n) => Into::<i64>::into(n),
@@ -392,7 +405,7 @@ impl Number {
     /// - NaN becomes 0.
     /// - Numbers are clamped between 0 and [`usize::MAX`].
     /// - All other numbers round towards zero.
-    pub fn into_usize(self, agent: &Agent) -> usize {
+    pub fn into_usize(self, agent: &impl Index<HeapNumber, Output = f64>) -> usize {
         match self {
             Number::Number(n) => agent[n] as usize,
             Number::Integer(n) => {
@@ -412,7 +425,7 @@ impl Number {
     /// NaN and non-zero checks, depending on which spec algorithm is being
     /// used.
     #[inline(always)]
-    fn is(agent: &Agent, x: Self, y: Self) -> bool {
+    fn is(agent: &impl Index<HeapNumber, Output = f64>, x: Self, y: Self) -> bool {
         match (x, y) {
             // Optimisation: First compare by-reference; only read from heap if needed.
             (Number::Number(x), Number::Number(y)) => x == y || agent[x] == agent[y],
@@ -1063,7 +1076,7 @@ impl Number {
     }
 
     /// ### [6.1.6.1.13 Number::equal ( x, y )](https://tc39.es/ecma262/#sec-numeric-types-number-equal)
-    pub fn equal(agent: &Agent, x: Self, y: Self) -> bool {
+    pub fn equal(agent: &impl Index<HeapNumber, Output = f64>, x: Self, y: Self) -> bool {
         // 1. If x is NaN, return false.
         if x.is_nan(agent) {
             return false;
@@ -1094,7 +1107,7 @@ impl Number {
     }
 
     /// ### [6.1.6.1.14 Number::sameValue ( x, y )](https://tc39.es/ecma262/#sec-numeric-types-number-sameValue)
-    pub fn same_value(agent: &Agent, x: Self, y: Self) -> bool {
+    pub fn same_value(agent: &impl Index<HeapNumber, Output = f64>, x: Self, y: Self) -> bool {
         // 1. If x is NaN and y is NaN, return true.
         if x.is_nan(agent) && y.is_nan(agent) {
             return true;
@@ -1120,7 +1133,7 @@ impl Number {
     }
 
     /// ### [6.1.6.1.15 Number::sameValueZero ( x, y )](https://tc39.es/ecma262/#sec-numeric-types-number-sameValueZero)
-    pub fn same_value_zero(agent: &Agent, x: Self, y: Self) -> bool {
+    pub fn same_value_zero(agent: &impl Index<HeapNumber, Output = f64>, x: Self, y: Self) -> bool {
         // 1. If x is NaN and y is NaN, return true.
         if x.is_nan(agent) && y.is_nan(agent) {
             return true;
@@ -1220,7 +1233,7 @@ impl Number {
     }
 
     /// ### [ℝ](https://tc39.es/ecma262/#%E2%84%9D)
-    pub(crate) fn to_real(self, agent: &Agent) -> f64 {
+    pub(crate) fn to_real(self, agent: &impl Index<HeapNumber, Output = f64>) -> f64 {
         match self {
             Self::Number(n) => agent[n],
             Self::Integer(i) => i.into_i64() as f64,
@@ -1252,6 +1265,14 @@ impl_value_from_n!(u16);
 impl_value_from_n!(i16);
 impl_value_from_n!(u32);
 impl_value_from_n!(i32);
+
+impl Index<HeapNumber> for PrimitiveHeap<'_> {
+    type Output = f64;
+
+    fn index(&self, index: HeapNumber) -> &Self::Output {
+        &self.numbers[index]
+    }
+}
 
 impl Index<HeapNumber> for Agent {
     type Output = f64;

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -2,11 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::{
-    hash::{Hash, Hasher},
-    mem::size_of,
+use super::{
+    bigint::{HeapBigInt, SmallBigInt},
+    number::HeapNumber,
+    string::HeapString,
+    BigInt, BigIntHeapData, IntoValue, Number, Numeric, OrdinaryObject, String, StringHeapData,
+    Symbol,
 };
-
 use crate::{
     ecmascript::{
         abstract_operations::type_conversion::{
@@ -44,12 +46,10 @@ use crate::{
     heap::{indexes::TypedArrayIndex, CompactionLists, HeapMarkAndSweep, WorkQueues},
     SmallInteger, SmallString,
 };
-
-use super::{
-    bigint::{HeapBigInt, SmallBigInt},
-    number::HeapNumber,
-    string::HeapString,
-    BigInt, IntoValue, Number, Numeric, OrdinaryObject, String, Symbol,
+use std::{
+    hash::{Hash, Hasher},
+    mem::size_of,
+    ops::Index,
 };
 
 /// ### [6.1 ECMAScript Language Types](https://tc39.es/ecma262/#sec-ecmascript-language-types)
@@ -465,31 +465,35 @@ impl Value {
         })
     }
 
-    pub(crate) fn hash<H>(self, agent: &Agent, hasher: &mut H)
+    pub(crate) fn hash<H, A>(self, arena: &A, hasher: &mut H)
     where
         H: Hasher,
+        A: Index<HeapString, Output = StringHeapData>
+            + Index<HeapNumber, Output = f64>
+            + Index<HeapBigInt, Output = BigIntHeapData>,
     {
+        let discriminant = core::mem::discriminant(&self);
         match self {
-            Value::Undefined => UNDEFINED_DISCRIMINANT.hash(hasher),
-            Value::Null => NULL_DISCRIMINANT.hash(hasher),
+            Value::Undefined => discriminant.hash(hasher),
+            Value::Null => discriminant.hash(hasher),
             Value::Boolean(data) => {
-                BOOLEAN_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.hash(hasher);
             }
             Value::String(data) => {
                 // Skip discriminant hashing in strings
-                agent[data].as_str().hash(hasher);
+                arena[data].as_str().hash(hasher);
             }
             Value::SmallString(data) => {
                 data.as_str().hash(hasher);
             }
             Value::Symbol(data) => {
-                SYMBOL_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Number(data) => {
                 // Skip discriminant hashing in numbers
-                agent[data].to_bits().hash(hasher);
+                arena[data].to_bits().hash(hasher);
             }
             Value::Integer(data) => {
                 data.into_i64().hash(hasher);
@@ -499,164 +503,164 @@ impl Value {
             }
             Value::BigInt(data) => {
                 // Skip dsciriminant hashing in bigint numbers
-                agent[data].data.hash(hasher);
+                arena[data].data.hash(hasher);
             }
             Value::SmallBigInt(data) => {
                 data.into_i64().hash(hasher);
             }
             Value::Object(data) => {
-                OBJECT_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::BoundFunction(data) => {
-                BOUND_FUNCTION_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::BuiltinFunction(data) => {
-                BUILTIN_FUNCTION_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::ECMAScriptFunction(data) => {
-                ECMASCRIPT_FUNCTION_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::BuiltinGeneratorFunction => todo!(),
             Value::BuiltinConstructorFunction => todo!(),
             Value::BuiltinPromiseResolvingFunction(data) => {
-                BUILTIN_PROMISE_RESOLVING_FUNCTION_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::BuiltinPromiseCollectorFunction => todo!(),
             Value::BuiltinProxyRevokerFunction => todo!(),
             Value::PrimitiveObject(data) => {
-                PRIMITIVE_OBJECT_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Arguments(data) => {
-                ARGUMENTS_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Array(data) => {
-                ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::ArrayBuffer(data) => {
-                ARRAY_BUFFER_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::DataView(data) => {
-                DATA_VIEW_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Date(data) => {
-                DATE_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Error(data) => {
-                ERROR_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::FinalizationRegistry(data) => {
-                FINALIZATION_REGISTRY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Map(data) => {
-                MAP_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Promise(data) => {
-                PROMISE_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Proxy(data) => {
-                PROXY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::RegExp(data) => {
-                REGEXP_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Set(data) => {
-                SET_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::SharedArrayBuffer(data) => {
-                SHARED_ARRAY_BUFFER_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::WeakMap(data) => {
-                WEAK_MAP_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::WeakRef(data) => {
-                WEAK_REF_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::WeakSet(data) => {
-                WEAK_SET_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Int8Array(data) => {
-                INT_8_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Uint8Array(data) => {
-                UINT_8_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Uint8ClampedArray(data) => {
-                UINT_8_CLAMPED_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Int16Array(data) => {
-                INT_16_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Uint16Array(data) => {
-                UINT_16_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Int32Array(data) => {
-                INT_32_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Uint32Array(data) => {
-                UINT_32_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::BigInt64Array(data) => {
-                BIGINT_64_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::BigUint64Array(data) => {
-                BIGUINT_64_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Float32Array(data) => {
-                FLOAT_32_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Float64Array(data) => {
-                FLOAT_64_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::AsyncFromSyncIterator => todo!(),
             Value::AsyncIterator => todo!(),
             Value::Iterator => todo!(),
             Value::ArrayIterator(data) => {
-                ARRAY_ITERATOR_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Generator(data) => {
-                GENERATOR_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Module(data) => {
-                MODULE_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::EmbedderObject(data) => {
-                EMBEDDER_OBJECT_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
         };
@@ -666,23 +670,24 @@ impl Value {
     where
         H: Hasher,
     {
+        let discriminant = core::mem::discriminant(&self);
         match self {
             Value::String(_) | Value::Number(_) | Value::BigInt(_) => {
                 // These values need Agent access to hash.
                 return Err(());
             }
             // All other types can be hashed on the stack.
-            Value::Undefined => UNDEFINED_DISCRIMINANT.hash(hasher),
-            Value::Null => NULL_DISCRIMINANT.hash(hasher),
+            Value::Undefined => discriminant.hash(hasher),
+            Value::Null => discriminant.hash(hasher),
             Value::Boolean(data) => {
-                BOOLEAN_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.hash(hasher);
             }
             Value::SmallString(data) => {
                 data.as_str().hash(hasher);
             }
             Value::Symbol(data) => {
-                SYMBOL_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Integer(data) => {
@@ -695,158 +700,158 @@ impl Value {
                 data.into_i64().hash(hasher);
             }
             Value::Object(data) => {
-                OBJECT_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::BoundFunction(data) => {
-                BOUND_FUNCTION_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::BuiltinFunction(data) => {
-                BUILTIN_FUNCTION_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::ECMAScriptFunction(data) => {
-                ECMASCRIPT_FUNCTION_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::BuiltinGeneratorFunction => todo!(),
             Value::BuiltinConstructorFunction => todo!(),
             Value::BuiltinPromiseResolvingFunction(data) => {
-                BUILTIN_PROMISE_RESOLVING_FUNCTION_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::BuiltinPromiseCollectorFunction => todo!(),
             Value::BuiltinProxyRevokerFunction => todo!(),
             Value::PrimitiveObject(data) => {
-                PRIMITIVE_OBJECT_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Arguments(data) => {
-                ARGUMENTS_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Array(data) => {
-                ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::ArrayBuffer(data) => {
-                ARRAY_BUFFER_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::DataView(data) => {
-                DATA_VIEW_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Date(data) => {
-                DATE_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Error(data) => {
-                ERROR_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::FinalizationRegistry(data) => {
-                FINALIZATION_REGISTRY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Map(data) => {
-                MAP_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Promise(data) => {
-                PROMISE_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Proxy(data) => {
-                PROXY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::RegExp(data) => {
-                REGEXP_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Set(data) => {
-                SET_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::SharedArrayBuffer(data) => {
-                SHARED_ARRAY_BUFFER_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::WeakMap(data) => {
-                WEAK_MAP_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::WeakRef(data) => {
-                WEAK_REF_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::WeakSet(data) => {
-                WEAK_SET_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Int8Array(data) => {
-                INT_8_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Uint8Array(data) => {
-                UINT_8_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Uint8ClampedArray(data) => {
-                UINT_8_CLAMPED_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Int16Array(data) => {
-                INT_16_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Uint16Array(data) => {
-                UINT_16_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Int32Array(data) => {
-                INT_32_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Uint32Array(data) => {
-                UINT_32_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::BigInt64Array(data) => {
-                BIGINT_64_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::BigUint64Array(data) => {
-                BIGUINT_64_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Float32Array(data) => {
-                FLOAT_32_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::Float64Array(data) => {
-                FLOAT_64_ARRAY_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.into_index().hash(hasher);
             }
             Value::AsyncFromSyncIterator => todo!(),
             Value::AsyncIterator => todo!(),
             Value::Iterator => todo!(),
             Value::ArrayIterator(data) => {
-                ARRAY_ITERATOR_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Generator(data) => {
-                GENERATOR_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::Module(data) => {
-                MODULE_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
             Value::EmbedderObject(data) => {
-                EMBEDDER_OBJECT_DISCRIMINANT.hash(hasher);
+                discriminant.hash(hasher);
                 data.get_index().hash(hasher);
             }
         }

--- a/nova_vm/src/heap.rs
+++ b/nova_vm/src/heap.rs
@@ -9,6 +9,8 @@ pub(crate) mod heap_gc;
 pub mod indexes;
 mod object_entry;
 
+use std::ops::Index;
+
 pub(crate) use self::heap_constants::{
     intrinsic_function_count, intrinsic_object_count, intrinsic_primitive_object_count,
     IntrinsicConstructorIndexes, IntrinsicFunctionIndexes, IntrinsicObjectIndexes,
@@ -57,7 +59,7 @@ use crate::ecmascript::{
         weak_set::data::WeakSetHeapData,
     },
     scripts_and_modules::source_code::SourceCodeHeapData,
-    types::{HeapNumber, HeapString, OrdinaryObject, BUILTIN_STRINGS_LIST},
+    types::{bigint::HeapBigInt, HeapNumber, HeapString, OrdinaryObject, BUILTIN_STRINGS_LIST},
 };
 use crate::ecmascript::{
     builtins::{ArrayBufferHeapData, ArrayHeapData},
@@ -343,6 +345,36 @@ impl Default for Heap {
         Self::new()
     }
 }
+
+/// A reference to the primitive value heap data.
+pub(crate) struct PrimitiveHeap<'a> {
+    pub(crate) bigints: &'a Vec<Option<BigIntHeapData>>,
+    pub(crate) numbers: &'a Vec<Option<NumberHeapData>>,
+    pub(crate) strings: &'a Vec<Option<StringHeapData>>,
+}
+
+impl PrimitiveHeap<'_> {
+    pub(crate) fn new<'a>(
+        bigints: &'a Vec<Option<BigIntHeapData>>,
+        numbers: &'a Vec<Option<NumberHeapData>>,
+        strings: &'a Vec<Option<StringHeapData>>,
+    ) -> PrimitiveHeap<'a> {
+        PrimitiveHeap {
+            bigints,
+            numbers,
+            strings,
+        }
+    }
+}
+
+pub(crate) trait PrimitiveHeapIndexable:
+    Index<HeapNumber, Output = f64>
+    + Index<HeapString, Output = StringHeapData>
+    + Index<HeapBigInt, Output = BigIntHeapData>
+{
+}
+
+impl PrimitiveHeapIndexable for PrimitiveHeap<'_> {}
 
 #[test]
 fn init_heap() {

--- a/nova_vm/src/heap.rs
+++ b/nova_vm/src/heap.rs
@@ -346,7 +346,8 @@ impl Default for Heap {
     }
 }
 
-/// A reference to the primitive value heap data.
+/// A partial view to the Agent's heap that allows accessing primitive value
+/// heap data.
 pub(crate) struct PrimitiveHeap<'a> {
     pub(crate) bigints: &'a Vec<Option<BigIntHeapData>>,
     pub(crate) numbers: &'a Vec<Option<NumberHeapData>>,
@@ -367,6 +368,7 @@ impl PrimitiveHeap<'_> {
     }
 }
 
+/// Helper trait for primitive heap data indexing.
 pub(crate) trait PrimitiveHeapIndexable:
     Index<HeapNumber, Output = f64>
     + Index<HeapString, Output = StringHeapData>

--- a/nova_vm/src/heap/element_array.rs
+++ b/nova_vm/src/heap/element_array.rs
@@ -130,8 +130,8 @@ impl ElementsVector {
     }
 
     /// An elements vector is simple if it contains no accessor descriptors.
-    pub(crate) fn is_simple(&self, agent: &Agent) -> bool {
-        let backing_store = agent.heap.elements.get_descriptors_and_slice(*self);
+    pub(crate) fn is_simple(&self, arena: &impl AsRef<ElementArrays>) -> bool {
+        let backing_store = arena.as_ref().get_descriptors_and_slice(*self);
         backing_store.0.map_or(true, |hashmap| {
             !hashmap
                 .iter()
@@ -140,13 +140,13 @@ impl ElementsVector {
     }
 
     /// An elements vector is trivial if it contains no descriptors.
-    pub(crate) fn is_trivial(&self, agent: &Agent) -> bool {
-        let backing_store = agent.heap.elements.get_descriptors_and_slice(*self);
+    pub(crate) fn is_trivial(&self, arena: &impl AsRef<ElementArrays>) -> bool {
+        let backing_store = arena.as_ref().get_descriptors_and_slice(*self);
         backing_store.0.is_none()
     }
 
-    pub(crate) fn is_dense(&self, agent: &Agent) -> bool {
-        let (descriptors, elements) = agent.heap.elements.get_descriptors_and_slice(*self);
+    pub(crate) fn is_dense(&self, arena: &impl AsRef<ElementArrays>) -> bool {
+        let (descriptors, elements) = arena.as_ref().get_descriptors_and_slice(*self);
         if let Some(descriptors) = descriptors {
             for (index, ele) in elements.iter().enumerate() {
                 let index = index as u32;
@@ -2369,5 +2369,11 @@ impl HeapMarkAndSweep for ElementDescriptor {
                 set.sweep_values(compactions);
             }
         }
+    }
+}
+
+impl AsRef<ElementArrays> for Agent {
+    fn as_ref(&self) -> &ElementArrays {
+        &self.heap.elements
     }
 }


### PR DESCRIPTION
Yesterday I made Map and Set be actual hashmaps. There were two issues with this:
1. It contained a lot of unsafe blocks to skirt around borrow rules.
2. It did not fully handle mixed primitive and object hashmaps during garbage collection.

This PR fixes both issues. The first issue is fixed by introducing some intermediate types that can be used to index into primitive value heap data without holding the entire Agent hostage. This makes it possible to hold eg. a mutable borrow on a MapHeapData while still accessing data for heap strings, numbers, and bigints for hashing purposes.

The second point is fixed by adding a single (atomic) boolean into the MapHeapData and SetHeapData; if the boolean is true, then the internal hashtable is re-examined for and all primitive keys that had to be rehashed during garbage collection are rehashed at the first subsequent hash lookup time.