### PR TITLE
feat(vm): Reduce Executable bytecode memory footprint

### DIFF
--- a/nova_vm/src/engine/bytecode/executable.rs
+++ b/nova_vm/src/engine/bytecode/executable.rs
@@ -44,7 +44,14 @@ pub(crate) enum NamedEvaluationParameter {
 
 pub(crate) struct CompileContext<'agent> {
     pub(crate) agent: &'agent mut Agent,
-    pub(crate) exe: Executable,
+    /// Instructions being built
+    instructions: Vec<u8>,
+    /// Constants being built
+    constants: Vec<Value>,
+    /// Function expressions being built
+    function_expressions: Vec<FunctionExpression>,
+    /// Arrow function expressions being built
+    arrow_function_expressions: Vec<ArrowFunctionExpression>,
     /// NamedEvaluation name parameter
     name_identifier: Option<NamedEvaluationParameter>,
     /// If true, indicates that all bindings being created are lexical.
@@ -66,13 +73,10 @@ impl CompileContext<'_> {
     fn new(agent: &'_ mut Agent) -> CompileContext<'_> {
         CompileContext {
             agent,
-            exe: Executable {
-                instructions: Vec::new(),
-                constants: Vec::new(),
-                identifiers: Vec::new(),
-                function_expressions: Vec::new(),
-                arrow_function_expressions: Vec::new(),
-            },
+            instructions: Vec::new(),
+            constants: Vec::new(),
+            function_expressions: Vec::new(),
+            arrow_function_expressions: Vec::new(),
             name_identifier: None,
             lexical_binding_state: false,
             current_continue: None,
@@ -83,112 +87,22 @@ impl CompileContext<'_> {
     }
 
     pub(crate) fn create_identifier(&mut self, atom: &Atom<'_>) -> String {
-        let existing =
-            self.exe.identifiers.iter().find(|existing_identifier| {
-                existing_identifier.as_str(self.agent) == atom.as_str()
-            });
-        if let Some(&existing) = existing {
+        let existing = self.constants.iter().find_map(|constant| {
+            if let Ok(existing_identifier) = String::try_from(*constant) {
+                if existing_identifier.as_str(self.agent) == atom.as_str() {
+                    Some(existing_identifier)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        });
+        if let Some(existing) = existing {
             existing
         } else {
             String::from_str(self.agent, atom.as_str())
         }
-    }
-}
-
-#[derive(Debug)]
-/// A `Send` and `Sync` wrapper over a `&'static T` where `T` might not itself
-/// be `Sync`. This is safe because the reference can only be obtained from the
-/// same thread in which the `SendableRef` was created.
-pub(crate) struct SendableRef<T: ?Sized + 'static> {
-    reference: &'static T,
-    thread_id: std::thread::ThreadId,
-}
-
-impl<T: ?Sized> SendableRef<T> {
-    /// Creates a new [`SendableRef`] from a reference with a static lifetime.
-    pub(crate) fn new(reference: &'static T) -> Self {
-        Self {
-            reference,
-            thread_id: std::thread::current().id(),
-        }
-    }
-
-    /// Unsafely creates a new [`SendableRef`] from a non-static reference.
-    ///
-    /// # Safety
-    ///
-    /// The safety conditions for this constructor are the same as for
-    /// transmuting `reference` into a static lifetime.
-    pub(crate) unsafe fn new_as_static(reference: &T) -> Self {
-        Self::new(unsafe { std::mem::transmute::<&T, &'static T>(reference) })
-    }
-
-    pub(crate) fn get(&self) -> &'static T {
-        assert_eq!(std::thread::current().id(), self.thread_id);
-        self.reference
-    }
-}
-
-// SAFETY: The reference will only be dereferenced in a thread in which the
-// reference is valid, so it's fine to send or use this type from other threads.
-unsafe impl<T: ?Sized> Send for SendableRef<T> {}
-unsafe impl<T: ?Sized> Sync for SendableRef<T> {}
-
-#[derive(Debug)]
-pub(crate) struct FunctionExpression {
-    pub(crate) expression: SendableRef<ast::Function<'static>>,
-    pub(crate) identifier: Option<NamedEvaluationParameter>,
-}
-
-#[derive(Debug)]
-pub(crate) struct ArrowFunctionExpression {
-    pub(crate) expression: SendableRef<ast::ArrowFunctionExpression<'static>>,
-    pub(crate) identifier: Option<NamedEvaluationParameter>,
-    pub(crate) home_object: Option<usize>,
-}
-
-/// ## Notes
-///
-/// - This is inspired by and/or copied from Kiesel engine:
-///   Copyright (c) 2023-2024 Linus Groh
-#[derive(Debug)]
-pub(crate) struct Executable {
-    pub instructions: Vec<u8>,
-    pub(crate) constants: Vec<Value>,
-    pub(crate) identifiers: Vec<String>,
-    pub(crate) function_expressions: Vec<FunctionExpression>,
-    pub(crate) arrow_function_expressions: Vec<ArrowFunctionExpression>,
-}
-
-impl Executable {
-    pub(super) fn get_instruction(&self, ip: &mut usize) -> Option<Instr> {
-        if *ip >= self.instructions.len() {
-            return None;
-        }
-
-        let kind: Instruction =
-            unsafe { std::mem::transmute::<u8, Instruction>(self.instructions[*ip]) };
-        *ip += 1;
-
-        let mut args: [Option<IndexType>; 2] = [None, None];
-
-        for item in args.iter_mut().take(kind.argument_count() as usize) {
-            let length = self.instructions[*ip..].len();
-            if length >= 2 {
-                let bytes = IndexType::from_ne_bytes(unsafe {
-                    *std::mem::transmute::<*const u8, *const [u8; 2]>(
-                        self.instructions[*ip..].as_ptr(),
-                    )
-                });
-                *ip += 2;
-                *item = Some(bytes);
-            } else {
-                *ip += 1;
-                *item = None;
-            }
-        }
-
-        Some(Instr { kind, args })
     }
 
     fn peek_last_instruction(&self) -> Option<u8> {
@@ -200,77 +114,6 @@ impl Executable {
             return Some(*ele);
         }
         None
-    }
-
-    pub(crate) fn compile_script(agent: &mut Agent, script: ScriptIdentifier) -> Executable {
-        if agent.options.print_internals {
-            eprintln!();
-            eprintln!("=== Compiling Script ===");
-            eprintln!();
-        }
-        // SAFETY: Script uniquely owns the Program and the body buffer does
-        // not move under any circumstances during heap operations.
-        let body: &[Statement] =
-            unsafe { std::mem::transmute(agent[script].ecmascript_code.body.as_slice()) };
-
-        Self::_compile_statements(CompileContext::new(agent), body, true)
-    }
-
-    pub(crate) fn compile_function_body(
-        agent: &mut Agent,
-        data: CompileFunctionBodyData<'_>,
-    ) -> Executable {
-        if agent.options.print_internals {
-            eprintln!();
-            eprintln!("=== Compiling Function ===");
-            eprintln!();
-        }
-
-        let mut ctx = CompileContext::new(agent);
-
-        function_declaration_instantiation::instantiation(
-            &mut ctx,
-            data.params,
-            data.body,
-            data.is_strict,
-            data.is_lexical,
-        );
-
-        // SAFETY: Script referred by the Function uniquely owns the Program
-        // and the body buffer does not move under any circumstances during
-        // heap operations.
-        let body: &[Statement] = unsafe { std::mem::transmute(data.body.statements.as_slice()) };
-
-        Self::_compile_statements(ctx, body, data.is_concise_body)
-    }
-
-    pub(crate) fn compile_eval_body(agent: &mut Agent, body: &[Statement]) -> Executable {
-        if agent.options.print_internals {
-            eprintln!();
-            eprintln!("=== Compiling Eval Body ===");
-            eprintln!();
-        }
-
-        Self::_compile_statements(CompileContext::new(agent), body, true)
-    }
-
-    fn _compile_statements(
-        mut ctx: CompileContext,
-        body: &[Statement],
-        implicit_return: bool,
-    ) -> Executable {
-        let iter = body.iter();
-
-        for stmt in iter {
-            stmt.compile(&mut ctx);
-        }
-
-        if implicit_return && ctx.exe.instructions.last() != Some(&Instruction::Return.as_u8()) {
-            // If code did not end with a return statement, add it manually
-            ctx.exe.add_instruction(Instruction::Return);
-        }
-
-        ctx.exe
     }
 
     fn _push_instruction(&mut self, instruction: Instruction) {
@@ -325,15 +168,15 @@ impl Executable {
 
     fn add_identifier(&mut self, identifier: String) -> usize {
         let duplicate = self
-            .identifiers
+            .constants
             .iter()
             .enumerate()
-            .find(|item| *item.1 == identifier)
+            .find(|item| String::try_from(*item.1) == Ok(identifier))
             .map(|(idx, _)| idx);
 
         duplicate.unwrap_or_else(|| {
-            let index = self.identifiers.len();
-            self.identifiers.push(identifier);
+            let index = self.constants.len();
+            self.constants.push(identifier.into_value());
             index
         })
     }
@@ -463,6 +306,177 @@ impl Executable {
     }
 }
 
+#[derive(Debug)]
+/// A `Send` and `Sync` wrapper over a `&'static T` where `T` might not itself
+/// be `Sync`. This is safe because the reference can only be obtained from the
+/// same thread in which the `SendableRef` was created.
+pub(crate) struct SendableRef<T: ?Sized + 'static> {
+    reference: &'static T,
+    thread_id: std::thread::ThreadId,
+}
+
+impl<T: ?Sized> SendableRef<T> {
+    /// Creates a new [`SendableRef`] from a reference with a static lifetime.
+    pub(crate) fn new(reference: &'static T) -> Self {
+        Self {
+            reference,
+            thread_id: std::thread::current().id(),
+        }
+    }
+
+    /// Unsafely creates a new [`SendableRef`] from a non-static reference.
+    ///
+    /// # Safety
+    ///
+    /// The safety conditions for this constructor are the same as for
+    /// transmuting `reference` into a static lifetime.
+    pub(crate) unsafe fn new_as_static(reference: &T) -> Self {
+        Self::new(unsafe { std::mem::transmute::<&T, &'static T>(reference) })
+    }
+
+    pub(crate) fn get(&self) -> &'static T {
+        assert_eq!(std::thread::current().id(), self.thread_id);
+        self.reference
+    }
+}
+
+// SAFETY: The reference will only be dereferenced in a thread in which the
+// reference is valid, so it's fine to send or use this type from other threads.
+unsafe impl<T: ?Sized> Send for SendableRef<T> {}
+unsafe impl<T: ?Sized> Sync for SendableRef<T> {}
+
+#[derive(Debug)]
+pub(crate) struct FunctionExpression {
+    pub(crate) expression: SendableRef<ast::Function<'static>>,
+    pub(crate) identifier: Option<NamedEvaluationParameter>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ArrowFunctionExpression {
+    pub(crate) expression: SendableRef<ast::ArrowFunctionExpression<'static>>,
+    pub(crate) identifier: Option<NamedEvaluationParameter>,
+}
+
+/// ## Notes
+///
+/// - This is inspired by and/or copied from Kiesel engine:
+///   Copyright (c) 2023-2024 Linus Groh
+#[derive(Debug)]
+pub(crate) struct Executable {
+    pub instructions: Box<[u8]>,
+    pub(crate) constants: Box<[Value]>,
+    pub(crate) function_expressions: Box<[FunctionExpression]>,
+    pub(crate) arrow_function_expressions: Box<[ArrowFunctionExpression]>,
+}
+
+impl Executable {
+    pub(super) fn get_instruction(&self, ip: &mut usize) -> Option<Instr> {
+        if *ip >= self.instructions.len() {
+            return None;
+        }
+
+        let kind: Instruction =
+            unsafe { std::mem::transmute::<u8, Instruction>(self.instructions[*ip]) };
+        *ip += 1;
+
+        let mut args: [Option<IndexType>; 2] = [None, None];
+
+        for item in args.iter_mut().take(kind.argument_count() as usize) {
+            let length = self.instructions[*ip..].len();
+            if length >= 2 {
+                let bytes = IndexType::from_ne_bytes(unsafe {
+                    *std::mem::transmute::<*const u8, *const [u8; 2]>(
+                        self.instructions[*ip..].as_ptr(),
+                    )
+                });
+                *ip += 2;
+                *item = Some(bytes);
+            } else {
+                *ip += 1;
+                *item = None;
+            }
+        }
+
+        Some(Instr { kind, args })
+    }
+
+    pub(crate) fn compile_script(agent: &mut Agent, script: ScriptIdentifier) -> Executable {
+        if agent.options.print_internals {
+            eprintln!();
+            eprintln!("=== Compiling Script ===");
+            eprintln!();
+        }
+        // SAFETY: Script uniquely owns the Program and the body buffer does
+        // not move under any circumstances during heap operations.
+        let body: &[Statement] =
+            unsafe { std::mem::transmute(agent[script].ecmascript_code.body.as_slice()) };
+
+        Self::_compile_statements(CompileContext::new(agent), body, true)
+    }
+
+    pub(crate) fn compile_function_body(
+        agent: &mut Agent,
+        data: CompileFunctionBodyData<'_>,
+    ) -> Executable {
+        if agent.options.print_internals {
+            eprintln!();
+            eprintln!("=== Compiling Function ===");
+            eprintln!();
+        }
+
+        let mut ctx = CompileContext::new(agent);
+
+        function_declaration_instantiation::instantiation(
+            &mut ctx,
+            data.params,
+            data.body,
+            data.is_strict,
+            data.is_lexical,
+        );
+
+        // SAFETY: Script referred by the Function uniquely owns the Program
+        // and the body buffer does not move under any circumstances during
+        // heap operations.
+        let body: &[Statement] = unsafe { std::mem::transmute(data.body.statements.as_slice()) };
+
+        Self::_compile_statements(ctx, body, data.is_concise_body)
+    }
+
+    pub(crate) fn compile_eval_body(agent: &mut Agent, body: &[Statement]) -> Executable {
+        if agent.options.print_internals {
+            eprintln!();
+            eprintln!("=== Compiling Eval Body ===");
+            eprintln!();
+        }
+
+        Self::_compile_statements(CompileContext::new(agent), body, true)
+    }
+
+    fn _compile_statements(
+        mut ctx: CompileContext,
+        body: &[Statement],
+        implicit_return: bool,
+    ) -> Executable {
+        let iter = body.iter();
+
+        for stmt in iter {
+            stmt.compile(&mut ctx);
+        }
+
+        if implicit_return && ctx.instructions.last() != Some(&Instruction::Return.as_u8()) {
+            // If code did not end with a return statement, add it manually
+            ctx.add_instruction(Instruction::Return);
+        }
+
+        Executable {
+            instructions: ctx.instructions.into_boxed_slice(),
+            constants: ctx.constants.into_boxed_slice(),
+            function_expressions: ctx.function_expressions.into_boxed_slice(),
+            arrow_function_expressions: ctx.arrow_function_expressions.into_boxed_slice(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 #[repr(transparent)]
 pub(crate) struct JumpIndex {
@@ -500,15 +514,13 @@ fn is_chain_expression(expression: &ast::Expression) -> bool {
 impl CompileEvaluation for ast::NumericLiteral<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
         let constant = ctx.agent.heap.create(self.value);
-        ctx.exe
-            .add_instruction_with_constant(Instruction::StoreConstant, constant);
+        ctx.add_instruction_with_constant(Instruction::StoreConstant, constant);
     }
 }
 
 impl CompileEvaluation for ast::BooleanLiteral {
     fn compile(&self, ctx: &mut CompileContext) {
-        ctx.exe
-            .add_instruction_with_constant(Instruction::StoreConstant, self.value);
+        ctx.add_instruction_with_constant(Instruction::StoreConstant, self.value);
     }
 }
 
@@ -526,39 +538,34 @@ impl CompileEvaluation for ast::BigIntLiteral<'_> {
             ctx.agent,
             num_bigint::BigInt::from_str_radix(big_int_str, radix).unwrap(),
         );
-        ctx.exe
-            .add_instruction_with_constant(Instruction::StoreConstant, constant);
+        ctx.add_instruction_with_constant(Instruction::StoreConstant, constant);
     }
 }
 
 impl CompileEvaluation for ast::NullLiteral {
     fn compile(&self, ctx: &mut CompileContext) {
-        ctx.exe
-            .add_instruction_with_constant(Instruction::StoreConstant, Value::Null);
+        ctx.add_instruction_with_constant(Instruction::StoreConstant, Value::Null);
     }
 }
 
 impl CompileEvaluation for ast::StringLiteral<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
         let constant = String::from_str(ctx.agent, self.value.as_str());
-        ctx.exe
-            .add_instruction_with_constant(Instruction::StoreConstant, constant);
+        ctx.add_instruction_with_constant(Instruction::StoreConstant, constant);
     }
 }
 
 impl CompileEvaluation for ast::IdentifierReference<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
         let identifier = String::from_str(ctx.agent, self.name.as_str());
-        ctx.exe
-            .add_instruction_with_identifier(Instruction::ResolveBinding, identifier);
+        ctx.add_instruction_with_identifier(Instruction::ResolveBinding, identifier);
     }
 }
 
 impl CompileEvaluation for ast::BindingIdentifier<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
         let identifier = String::from_str(ctx.agent, self.name.as_str());
-        ctx.exe
-            .add_instruction_with_identifier(Instruction::ResolveBinding, identifier);
+        ctx.add_instruction_with_identifier(Instruction::ResolveBinding, identifier);
     }
 }
 
@@ -575,16 +582,16 @@ impl CompileEvaluation for ast::UnaryExpression<'_> {
 
                 // 2. Let oldValue be ? ToNumeric(? GetValue(expr)).
                 if is_reference(&self.argument) {
-                    ctx.exe.add_instruction(Instruction::GetValue);
+                    ctx.add_instruction(Instruction::GetValue);
                 }
-                ctx.exe.add_instruction(Instruction::ToNumeric);
+                ctx.add_instruction(Instruction::ToNumeric);
 
                 // 3. If oldValue is a Number, then
                 //    a. Return Number::unaryMinus(oldValue).
                 // 4. Else,
                 //    a. Assert: oldValue is a BigInt.
                 //    b. Return BigInt::unaryMinus(oldValue).
-                ctx.exe.add_instruction(Instruction::UnaryMinus);
+                ctx.add_instruction(Instruction::UnaryMinus);
             }
             // 13.5.4 Unary + Operator
             // https://tc39.es/ecma262/#sec-unary-plus-operator
@@ -595,9 +602,9 @@ impl CompileEvaluation for ast::UnaryExpression<'_> {
 
                 // 2. Return ? ToNumber(? GetValue(expr)).
                 if is_reference(&self.argument) {
-                    ctx.exe.add_instruction(Instruction::GetValue);
+                    ctx.add_instruction(Instruction::GetValue);
                 }
-                ctx.exe.add_instruction(Instruction::ToNumber);
+                ctx.add_instruction(Instruction::ToNumber);
             }
             // 13.5.6 Unary ! Operator
             // https://tc39.es/ecma262/#sec-logical-not-operator-runtime-semantics-evaluation
@@ -610,9 +617,9 @@ impl CompileEvaluation for ast::UnaryExpression<'_> {
                 // 3. If oldValue is true, return false.
                 // 4. Return true.
                 if is_reference(&self.argument) {
-                    ctx.exe.add_instruction(Instruction::GetValue);
+                    ctx.add_instruction(Instruction::GetValue);
                 }
-                ctx.exe.add_instruction(Instruction::LogicalNot);
+                ctx.add_instruction(Instruction::LogicalNot);
             }
             // 13.5.7 Unary ~ Operator
             // https://tc39.es/ecma262/#sec-bitwise-not-operator-runtime-semantics-evaluation
@@ -628,9 +635,9 @@ impl CompileEvaluation for ast::UnaryExpression<'_> {
                 //    a. Assert: oldValue is a BigInt.
                 //    b. Return BigInt::bitwiseNOT(oldValue).
                 if is_reference(&self.argument) {
-                    ctx.exe.add_instruction(Instruction::GetValue);
+                    ctx.add_instruction(Instruction::GetValue);
                 }
-                ctx.exe.add_instruction(Instruction::BitwiseNot);
+                ctx.add_instruction(Instruction::BitwiseNot);
             }
             // 13.5.3 The typeof Operator
             // UnaryExpression : typeof UnaryExpression
@@ -638,7 +645,7 @@ impl CompileEvaluation for ast::UnaryExpression<'_> {
                 // 1. Let val be ? Evaluation of UnaryExpression.
                 self.argument.compile(ctx);
                 // 3. Set val to ? GetValue(val).
-                ctx.exe.add_instruction(Instruction::Typeof);
+                ctx.add_instruction(Instruction::Typeof);
             }
             // 13.5.2 The void operator
             // UnaryExpression : void UnaryExpression
@@ -648,11 +655,10 @@ impl CompileEvaluation for ast::UnaryExpression<'_> {
                 // NOTE: GetValue must be called even though its value is not used because it may have observable side-effects.
                 // 2. Perform ? GetValue(expr).
                 if is_reference(&self.argument) {
-                    ctx.exe.add_instruction(Instruction::GetValue);
+                    ctx.add_instruction(Instruction::GetValue);
                 }
                 // 3. Return undefined.
-                ctx.exe
-                    .add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
+                ctx.add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
             }
             // 13.5.1 The delete operator
             // https://tc39.es/ecma262/#sec-delete-operator-runtime-semantics-evaluation
@@ -662,11 +668,10 @@ impl CompileEvaluation for ast::UnaryExpression<'_> {
                 self.argument.compile(ctx);
                 // 2. If ref is not a Reference Record, return true.
                 if !is_reference(&self.argument) {
-                    ctx.exe
-                        .add_instruction_with_constant(Instruction::StoreConstant, true);
+                    ctx.add_instruction_with_constant(Instruction::StoreConstant, true);
                     return;
                 }
-                ctx.exe.add_instruction(Instruction::Delete);
+                ctx.add_instruction(Instruction::Delete);
             }
         }
     }
@@ -679,57 +684,56 @@ impl CompileEvaluation for ast::BinaryExpression<'_> {
 
         // 2. Let lval be ? GetValue(lref).
         if is_reference(&self.left) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
-        ctx.exe.add_instruction(Instruction::Load);
+        ctx.add_instruction(Instruction::Load);
 
         // 3. Let rref be ? Evaluation of rightOperand.
         self.right.compile(ctx);
 
         // 4. Let rval be ? GetValue(rref).
         if is_reference(&self.right) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
 
         match self.operator {
             BinaryOperator::LessThan => {
-                ctx.exe.add_instruction(Instruction::LessThan);
+                ctx.add_instruction(Instruction::LessThan);
             }
             BinaryOperator::LessEqualThan => {
-                ctx.exe.add_instruction(Instruction::LessThanEquals);
+                ctx.add_instruction(Instruction::LessThanEquals);
             }
             BinaryOperator::GreaterThan => {
-                ctx.exe.add_instruction(Instruction::GreaterThan);
+                ctx.add_instruction(Instruction::GreaterThan);
             }
             BinaryOperator::GreaterEqualThan => {
-                ctx.exe.add_instruction(Instruction::GreaterThanEquals);
+                ctx.add_instruction(Instruction::GreaterThanEquals);
             }
             BinaryOperator::StrictEquality => {
-                ctx.exe.add_instruction(Instruction::IsStrictlyEqual);
+                ctx.add_instruction(Instruction::IsStrictlyEqual);
             }
             BinaryOperator::StrictInequality => {
-                ctx.exe.add_instruction(Instruction::IsStrictlyEqual);
-                ctx.exe.add_instruction(Instruction::LogicalNot);
+                ctx.add_instruction(Instruction::IsStrictlyEqual);
+                ctx.add_instruction(Instruction::LogicalNot);
             }
             BinaryOperator::Equality => {
-                ctx.exe.add_instruction(Instruction::IsLooselyEqual);
+                ctx.add_instruction(Instruction::IsLooselyEqual);
             }
             BinaryOperator::Inequality => {
-                ctx.exe.add_instruction(Instruction::IsLooselyEqual);
-                ctx.exe.add_instruction(Instruction::LogicalNot);
+                ctx.add_instruction(Instruction::IsLooselyEqual);
+                ctx.add_instruction(Instruction::LogicalNot);
             }
             BinaryOperator::In => {
-                ctx.exe.add_instruction(Instruction::HasProperty);
+                ctx.add_instruction(Instruction::HasProperty);
             }
             BinaryOperator::Instanceof => {
-                ctx.exe.add_instruction(Instruction::InstanceofOperator);
+                ctx.add_instruction(Instruction::InstanceofOperator);
             }
             _ => {
                 // 5. Return ? ApplyStringOrNumericBinaryOperator(lval, opText, rval).
-                ctx.exe
-                    .add_instruction(Instruction::ApplyStringOrNumericBinaryOperator(
-                        self.operator,
-                    ));
+                ctx.add_instruction(Instruction::ApplyStringOrNumericBinaryOperator(
+                    self.operator,
+                ));
             }
         }
     }
@@ -739,39 +743,37 @@ impl CompileEvaluation for ast::LogicalExpression<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
         self.left.compile(ctx);
         if is_reference(&self.left) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
         // We store the left value on the stack, because we'll need to restore
         // it later.
-        ctx.exe.add_instruction(Instruction::LoadCopy);
+        ctx.add_instruction(Instruction::LoadCopy);
 
         match self.operator {
             oxc_syntax::operator::LogicalOperator::Or => {
-                ctx.exe.add_instruction(Instruction::LogicalNot);
+                ctx.add_instruction(Instruction::LogicalNot);
             }
             oxc_syntax::operator::LogicalOperator::And => {}
             oxc_syntax::operator::LogicalOperator::Coalesce => {
-                ctx.exe.add_instruction(Instruction::IsNullOrUndefined);
+                ctx.add_instruction(Instruction::IsNullOrUndefined);
             }
         }
-        let jump_to_return_left = ctx
-            .exe
-            .add_instruction_with_jump_slot(Instruction::JumpIfNot);
+        let jump_to_return_left = ctx.add_instruction_with_jump_slot(Instruction::JumpIfNot);
 
         // We're returning the right expression, so we discard the left value
         // at the top of the stack.
-        ctx.exe.add_instruction(Instruction::Store);
+        ctx.add_instruction(Instruction::Store);
 
         self.right.compile(ctx);
         if is_reference(&self.right) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
-        let jump_to_end = ctx.exe.add_instruction_with_jump_slot(Instruction::Jump);
+        let jump_to_end = ctx.add_instruction_with_jump_slot(Instruction::Jump);
 
-        ctx.exe.set_jump_target_here(jump_to_return_left);
+        ctx.set_jump_target_here(jump_to_return_left);
         // Return the result of the left expression.
-        ctx.exe.add_instruction(Instruction::Store);
-        ctx.exe.set_jump_target_here(jump_to_end);
+        ctx.add_instruction(Instruction::Store);
+        ctx.set_jump_target_here(jump_to_end);
     }
 }
 
@@ -802,19 +804,19 @@ impl CompileEvaluation for ast::AssignmentExpression<'_> {
         };
 
         if self.operator == oxc_syntax::operator::AssignmentOperator::Assign {
-            ctx.exe.add_instruction(Instruction::PushReference);
+            ctx.add_instruction(Instruction::PushReference);
             self.right.compile(ctx);
 
             if is_reference(&self.right) {
-                ctx.exe.add_instruction(Instruction::GetValue);
+                ctx.add_instruction(Instruction::GetValue);
             }
 
-            ctx.exe.add_instruction(Instruction::LoadCopy);
-            ctx.exe.add_instruction(Instruction::PopReference);
-            ctx.exe.add_instruction(Instruction::PutValue);
+            ctx.add_instruction(Instruction::LoadCopy);
+            ctx.add_instruction(Instruction::PopReference);
+            ctx.add_instruction(Instruction::PutValue);
 
             // ... Return rval.
-            ctx.exe.add_instruction(Instruction::Store);
+            ctx.add_instruction(Instruction::Store);
         } else if matches!(
             self.operator,
             oxc_syntax::operator::AssignmentOperator::LogicalAnd
@@ -822,11 +824,11 @@ impl CompileEvaluation for ast::AssignmentExpression<'_> {
                 | oxc_syntax::operator::AssignmentOperator::LogicalOr
         ) {
             // 2. Let lval be ? GetValue(lref).
-            ctx.exe.add_instruction(Instruction::GetValueKeepReference);
-            ctx.exe.add_instruction(Instruction::PushReference);
+            ctx.add_instruction(Instruction::GetValueKeepReference);
+            ctx.add_instruction(Instruction::PushReference);
             // We store the left value on the stack, because we'll need to
             // restore it later.
-            ctx.exe.add_instruction(Instruction::LoadCopy);
+            ctx.add_instruction(Instruction::LoadCopy);
 
             match self.operator {
                 oxc_syntax::operator::AssignmentOperator::LogicalAnd => {
@@ -838,22 +840,20 @@ impl CompileEvaluation for ast::AssignmentExpression<'_> {
                     // 3. Let lbool be ToBoolean(lval).
                     // Note: We do not directly call ToBoolean: JumpIfNot does.
                     // 4. If lbool is true, return lval.
-                    ctx.exe.add_instruction(Instruction::LogicalNot);
+                    ctx.add_instruction(Instruction::LogicalNot);
                 }
                 oxc_syntax::operator::AssignmentOperator::LogicalNullish => {
                     // 3. If lval is neither undefined nor null, return lval.
-                    ctx.exe.add_instruction(Instruction::IsNullOrUndefined);
+                    ctx.add_instruction(Instruction::IsNullOrUndefined);
                 }
                 _ => unreachable!(),
             }
 
-            let jump_to_end = ctx
-                .exe
-                .add_instruction_with_jump_slot(Instruction::JumpIfNot);
+            let jump_to_end = ctx.add_instruction_with_jump_slot(Instruction::JumpIfNot);
 
             // We're returning the right expression, so we discard the left
             // value at the top of the stack.
-            ctx.exe.add_instruction(Instruction::Store);
+            ctx.add_instruction(Instruction::Store);
 
             // 5. If IsAnonymousFunctionDefinition(AssignmentExpression)
             // is true and IsIdentifierRef of LeftHandSideExpression is true,
@@ -869,29 +869,29 @@ impl CompileEvaluation for ast::AssignmentExpression<'_> {
                 self.right.compile(ctx);
                 // b. Let rval be ? GetValue(rref).
                 if is_reference(&self.right) {
-                    ctx.exe.add_instruction(Instruction::GetValue);
+                    ctx.add_instruction(Instruction::GetValue);
                 }
             }
 
             // 7. Perform ? PutValue(lref, rval).
-            ctx.exe.add_instruction(Instruction::LoadCopy);
-            ctx.exe.add_instruction(Instruction::PopReference);
-            ctx.exe.add_instruction(Instruction::PutValue);
+            ctx.add_instruction(Instruction::LoadCopy);
+            ctx.add_instruction(Instruction::PopReference);
+            ctx.add_instruction(Instruction::PutValue);
 
             // 4. ... return lval.
-            ctx.exe.set_jump_target_here(jump_to_end);
-            ctx.exe.add_instruction(Instruction::Store);
+            ctx.set_jump_target_here(jump_to_end);
+            ctx.add_instruction(Instruction::Store);
         } else {
             // 2. let lval be ? GetValue(lref).
-            ctx.exe.add_instruction(Instruction::GetValueKeepReference);
-            ctx.exe.add_instruction(Instruction::Load);
-            ctx.exe.add_instruction(Instruction::PushReference);
+            ctx.add_instruction(Instruction::GetValueKeepReference);
+            ctx.add_instruction(Instruction::Load);
+            ctx.add_instruction(Instruction::PushReference);
             // 3. Let rref be ? Evaluation of AssignmentExpression.
             self.right.compile(ctx);
 
             // 4. Let rval be ? GetValue(rref).
             if is_reference(&self.right) {
-                ctx.exe.add_instruction(Instruction::GetValue);
+                ctx.add_instruction(Instruction::GetValue);
             }
 
             // 5. Let assignmentOpText be the source text matched by AssignmentOperator.
@@ -920,14 +920,13 @@ impl CompileEvaluation for ast::AssignmentExpression<'_> {
                 _ => unreachable!(),
             };
             // 7. Let r be ? ApplyStringOrNumericBinaryOperator(lval, opText, rval).
-            ctx.exe
-                .add_instruction(Instruction::ApplyStringOrNumericBinaryOperator(op_text));
-            ctx.exe.add_instruction(Instruction::LoadCopy);
+            ctx.add_instruction(Instruction::ApplyStringOrNumericBinaryOperator(op_text));
+            ctx.add_instruction(Instruction::LoadCopy);
             // 8. Perform ? PutValue(lref, r).
-            ctx.exe.add_instruction(Instruction::PopReference);
-            ctx.exe.add_instruction(Instruction::PutValue);
+            ctx.add_instruction(Instruction::PopReference);
+            ctx.add_instruction(Instruction::PutValue);
             // 9. Return r.
-            ctx.exe.add_instruction(Instruction::Store);
+            ctx.add_instruction(Instruction::Store);
         }
     }
 }
@@ -940,31 +939,31 @@ impl CompileEvaluation for ast::ParenthesizedExpression<'_> {
 
 impl CompileEvaluation for ast::ArrowFunctionExpression<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
-        ctx.exe
-            .add_arrow_function_expression(ArrowFunctionExpression {
-                expression: SendableRef::new(unsafe {
-                    std::mem::transmute::<
-                        &ast::ArrowFunctionExpression<'_>,
-                        &'static ast::ArrowFunctionExpression<'static>,
-                    >(self)
-                }),
-                // CompileContext holds a name identifier for us if this is NamedEvaluation.
-                identifier: ctx.name_identifier.take(),
-                home_object: None,
-            });
+        // CompileContext holds a name identifier for us if this is NamedEvaluation.
+        let identifier = ctx.name_identifier.take();
+        ctx.add_arrow_function_expression(ArrowFunctionExpression {
+            expression: SendableRef::new(unsafe {
+                std::mem::transmute::<
+                    &ast::ArrowFunctionExpression<'_>,
+                    &'static ast::ArrowFunctionExpression<'static>,
+                >(self)
+            }),
+            identifier,
+        });
     }
 }
 
 impl CompileEvaluation for ast::Function<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
-        ctx.exe.add_instruction_with_function_expression(
+        // CompileContext holds a name identifier for us if this is NamedEvaluation.
+        let identifier = ctx.name_identifier.take();
+        ctx.add_instruction_with_function_expression(
             Instruction::InstantiateOrdinaryFunctionExpression,
             FunctionExpression {
                 expression: SendableRef::new(unsafe {
                     std::mem::transmute::<&ast::Function<'_>, &'static ast::Function<'static>>(self)
                 }),
-                // CompileContext holds a name identifier for us if this is NamedEvaluation.
-                identifier: ctx.name_identifier.take(),
+                identifier,
             },
         );
     }
@@ -974,7 +973,7 @@ impl CompileEvaluation for ast::ObjectExpression<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
         // TODO: Consider preparing the properties onto the stack and creating
         // the object with a known size.
-        ctx.exe.add_instruction(Instruction::ObjectCreate);
+        ctx.add_instruction(Instruction::ObjectCreate);
         for property in self.properties.iter() {
             match property {
                 ast::ObjectPropertyKind::ObjectProperty(prop) => {
@@ -1014,14 +1013,14 @@ impl CompileEvaluation for ast::ObjectExpression<'_> {
                                     // should dispatch a SetPrototype instruction.
                                     is_proto_setter = true;
                                 } else {
-                                    ctx.exe.add_instruction_with_constant(
+                                    ctx.add_instruction_with_constant(
                                         Instruction::StoreConstant,
                                         BUILTIN_STRING_MEMORY.__proto__,
                                     );
                                 }
                             } else {
                                 let identifier = PropertyKey::from_str(ctx.agent, &id.name);
-                                ctx.exe.add_instruction_with_constant(
+                                ctx.add_instruction_with_constant(
                                     Instruction::StoreConstant,
                                     identifier,
                                 );
@@ -1030,7 +1029,7 @@ impl CompileEvaluation for ast::ObjectExpression<'_> {
                         ast::PropertyKey::StaticMemberExpression(init) => init.compile(ctx),
                         ast::PropertyKey::StringLiteral(init) => {
                             let identifier = PropertyKey::from_str(ctx.agent, &init.value);
-                            ctx.exe.add_instruction_with_constant(
+                            ctx.add_instruction_with_constant(
                                 Instruction::StoreConstant,
                                 identifier,
                             );
@@ -1053,12 +1052,12 @@ impl CompileEvaluation for ast::ObjectExpression<'_> {
                     if let Some(prop_key_expression) = prop.key.as_expression() {
                         if is_reference(prop_key_expression) {
                             assert!(!is_proto_setter);
-                            ctx.exe.add_instruction(Instruction::GetValue);
+                            ctx.add_instruction(Instruction::GetValue);
                         }
                     }
                     if !is_proto_setter {
                         // Prototype setter doesn't need the key.
-                        ctx.exe.add_instruction(Instruction::Load);
+                        ctx.add_instruction(Instruction::Load);
                     }
                     match prop.kind {
                         ast::PropertyKind::Init => {
@@ -1067,16 +1066,16 @@ impl CompileEvaluation for ast::ObjectExpression<'_> {
                             }
                             prop.value.compile(ctx);
                             if is_reference(&prop.value) {
-                                ctx.exe.add_instruction(Instruction::GetValue);
+                                ctx.add_instruction(Instruction::GetValue);
                             }
                             // 7. If isProtoSetter is true, then
                             if is_proto_setter {
                                 // a. If propValue is an Object or propValue is null, then
                                 //     i. Perform ! object.[[SetPrototypeOf]](propValue).
                                 // b. Return unused.
-                                ctx.exe.add_instruction(Instruction::ObjectSetPrototype);
+                                ctx.add_instruction(Instruction::ObjectSetPrototype);
                             } else {
-                                ctx.exe.add_instruction(Instruction::ObjectDefineProperty);
+                                ctx.add_instruction(Instruction::ObjectDefineProperty);
                             }
                         }
                         ast::PropertyKind::Get | ast::PropertyKind::Set => {
@@ -1086,81 +1085,77 @@ impl CompileEvaluation for ast::ObjectExpression<'_> {
                             else {
                                 unreachable!()
                             };
-                            ctx.exe
-                                .add_instruction_with_function_expression_and_immediate(
-                                    if is_get {
-                                        Instruction::ObjectDefineGetter
-                                    } else {
-                                        Instruction::ObjectDefineSetter
-                                    },
-                                    FunctionExpression {
-                                        expression: SendableRef::new(unsafe {
-                                            std::mem::transmute::<
-                                                &ast::Function<'_>,
-                                                &'static ast::Function<'static>,
-                                            >(
-                                                function_expression
-                                            )
-                                        }),
-                                        identifier: None,
-                                    },
-                                    // enumerable: true,
-                                    true.into(),
-                                );
+                            ctx.add_instruction_with_function_expression_and_immediate(
+                                if is_get {
+                                    Instruction::ObjectDefineGetter
+                                } else {
+                                    Instruction::ObjectDefineSetter
+                                },
+                                FunctionExpression {
+                                    expression: SendableRef::new(unsafe {
+                                        std::mem::transmute::<
+                                            &ast::Function<'_>,
+                                            &'static ast::Function<'static>,
+                                        >(
+                                            function_expression
+                                        )
+                                    }),
+                                    identifier: None,
+                                },
+                                // enumerable: true,
+                                true.into(),
+                            );
                         }
                     }
                 }
                 ast::ObjectPropertyKind::SpreadProperty(spread) => {
                     spread.argument.compile(ctx);
                     if is_reference(&spread.argument) {
-                        ctx.exe.add_instruction(Instruction::GetValue);
+                        ctx.add_instruction(Instruction::GetValue);
                     }
-                    ctx.exe.add_instruction(Instruction::CopyDataProperties);
+                    ctx.add_instruction(Instruction::CopyDataProperties);
                 }
             }
         }
         // 3. Return obj
-        ctx.exe.add_instruction(Instruction::Store);
+        ctx.add_instruction(Instruction::Store);
     }
 }
 
 impl CompileEvaluation for ast::ArrayExpression<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
         let elements_min_count = self.elements.len();
-        ctx.exe
-            .add_instruction_with_immediate(Instruction::ArrayCreate, elements_min_count);
+        ctx.add_instruction_with_immediate(Instruction::ArrayCreate, elements_min_count);
         for ele in &self.elements {
             match ele {
                 ast::ArrayExpressionElement::SpreadElement(spread) => {
                     spread.argument.compile(ctx);
                     if is_reference(&spread.argument) {
-                        ctx.exe.add_instruction(Instruction::GetValue);
+                        ctx.add_instruction(Instruction::GetValue);
                     }
-                    ctx.exe.add_instruction(Instruction::GetIteratorSync);
+                    ctx.add_instruction(Instruction::GetIteratorSync);
 
-                    let iteration_start = ctx.exe.get_jump_index_to_here();
-                    let iteration_end = ctx
-                        .exe
-                        .add_instruction_with_jump_slot(Instruction::IteratorStepValue);
-                    ctx.exe.add_instruction(Instruction::ArrayPush);
-                    ctx.exe
-                        .add_jump_instruction_to_index(Instruction::Jump, iteration_start);
-                    ctx.exe.set_jump_target_here(iteration_end);
+                    let iteration_start = ctx.get_jump_index_to_here();
+                    let iteration_end =
+                        ctx.add_instruction_with_jump_slot(Instruction::IteratorStepValue);
+                    ctx.add_instruction(Instruction::ArrayPush);
+                    ctx.add_jump_instruction_to_index(Instruction::Jump, iteration_start);
+                    ctx.set_jump_target_here(iteration_end);
                 }
                 ast::ArrayExpressionElement::Elision(_) => {
-                    ctx.exe.add_instruction(Instruction::ArrayElision);
+                    ctx.add_instruction(Instruction::ArrayElision);
                 }
                 _ => {
                     let expression = ele.to_expression();
                     expression.compile(ctx);
                     if is_reference(expression) {
-                        ctx.exe.add_instruction(Instruction::GetValue);
+                        ctx.add_instruction(Instruction::GetValue);
                     }
-                    ctx.exe.add_instruction(Instruction::ArrayPush);
+                    ctx.add_instruction(Instruction::ArrayPush);
                 }
             }
         }
-        ctx.exe.add_instruction(Instruction::Store);
+        ctx.add_instruction(Instruction::Store);
     }
 }
 
@@ -1178,38 +1173,34 @@ fn compile_arguments(arguments: &[ast::Argument], ctx: &mut CompileContext) -> u
         // arguments, followed by the arguments.
         if let ast::Argument::SpreadElement(spread) = argument {
             if let Some(num_arguments) = known_num_arguments.take() {
-                ctx.exe
-                    .add_instruction_with_constant(Instruction::LoadConstant, num_arguments);
+                ctx.add_instruction_with_constant(Instruction::LoadConstant, num_arguments);
             }
 
             spread.argument.compile(ctx);
             if is_reference(&spread.argument) {
-                ctx.exe.add_instruction(Instruction::GetValue);
+                ctx.add_instruction(Instruction::GetValue);
             }
-            ctx.exe.add_instruction(Instruction::GetIteratorSync);
+            ctx.add_instruction(Instruction::GetIteratorSync);
 
-            let iteration_start = ctx.exe.get_jump_index_to_here();
-            let iteration_end = ctx
-                .exe
-                .add_instruction_with_jump_slot(Instruction::IteratorStepValue);
+            let iteration_start = ctx.get_jump_index_to_here();
+            let iteration_end = ctx.add_instruction_with_jump_slot(Instruction::IteratorStepValue);
             // result: value; stack: [num, ...args]
-            ctx.exe.add_instruction(Instruction::LoadStoreSwap);
+            ctx.add_instruction(Instruction::LoadStoreSwap);
             // result: num; stack: [value, ...args]
-            ctx.exe.add_instruction(Instruction::Increment);
+            ctx.add_instruction(Instruction::Increment);
             // result: num + 1; stack: [value, ...args]
-            ctx.exe.add_instruction(Instruction::Load);
+            ctx.add_instruction(Instruction::Load);
             // stack: [num + 1, value, ...args]
-            ctx.exe
-                .add_jump_instruction_to_index(Instruction::Jump, iteration_start);
-            ctx.exe.set_jump_target_here(iteration_end);
+            ctx.add_jump_instruction_to_index(Instruction::Jump, iteration_start);
+            ctx.set_jump_target_here(iteration_end);
         } else {
             let expression = argument.to_expression();
             expression.compile(ctx);
             if is_reference(expression) {
-                ctx.exe.add_instruction(Instruction::GetValue);
+                ctx.add_instruction(Instruction::GetValue);
             }
             if let Some(num_arguments) = known_num_arguments.as_mut() {
-                ctx.exe.add_instruction(Instruction::Load);
+                ctx.add_instruction(Instruction::Load);
                 // stack: [value, ...args]
 
                 if *num_arguments < IndexType::MAX - 1 {
@@ -1219,7 +1210,7 @@ fn compile_arguments(arguments: &[ast::Argument], ctx: &mut CompileContext) -> u
                     // result value.
                     debug_assert_eq!(*num_arguments, IndexType::MAX - 1);
                     known_num_arguments = None;
-                    ctx.exe.add_instruction_with_constant(
+                    ctx.add_instruction_with_constant(
                         Instruction::LoadConstant,
                         Value::from(IndexType::MAX),
                     );
@@ -1227,11 +1218,11 @@ fn compile_arguments(arguments: &[ast::Argument], ctx: &mut CompileContext) -> u
                 }
             } else {
                 // result: value; stack: [num, ...args]
-                ctx.exe.add_instruction(Instruction::LoadStoreSwap);
+                ctx.add_instruction(Instruction::LoadStoreSwap);
                 // result: num; stack: [value, ...args]
-                ctx.exe.add_instruction(Instruction::Increment);
+                ctx.add_instruction(Instruction::Increment);
                 // result: num + 1; stack: [value, ...args]
-                ctx.exe.add_instruction(Instruction::Load);
+                ctx.add_instruction(Instruction::Load);
                 // stack: [num + 1, value, ...args]
             }
         }
@@ -1242,7 +1233,7 @@ fn compile_arguments(arguments: &[ast::Argument], ctx: &mut CompileContext) -> u
         num_arguments as usize
     } else {
         // stack: [num, ...args]
-        ctx.exe.add_instruction(Instruction::Store);
+        ctx.add_instruction(Instruction::Store);
         // result: num; stack: [...args]
         IndexType::MAX as usize
     }
@@ -1255,8 +1246,7 @@ impl CompileEvaluation for CallExpression<'_> {
             if let ast::Expression::Identifier(ident) = &self.callee {
                 if ident.name == "eval" {
                     let num_arguments = compile_arguments(&self.arguments, ctx);
-                    ctx.exe
-                        .add_instruction_with_immediate(Instruction::DirectEvalCall, num_arguments);
+                    ctx.add_instruction_with_immediate(Instruction::DirectEvalCall, num_arguments);
                     return;
                 }
             }
@@ -1267,12 +1257,12 @@ impl CompileEvaluation for CallExpression<'_> {
         self.callee.compile(ctx);
         // 2. Let func be ? GetValue(ref).
         let need_pop_reference = if is_reference(&self.callee) {
-            ctx.exe.add_instruction(Instruction::GetValueKeepReference);
+            ctx.add_instruction(Instruction::GetValueKeepReference);
             // Optimization: If we know arguments is empty, we don't need to
             // worry about arguments evaluation clobbering our function's this
             // reference.
             if !self.arguments.is_empty() {
-                ctx.exe.add_instruction(Instruction::PushReference);
+                ctx.add_instruction(Instruction::PushReference);
                 true
             } else {
                 false
@@ -1285,9 +1275,9 @@ impl CompileEvaluation for CallExpression<'_> {
             // Optional Chains
 
             // Load copy of func to stack.
-            ctx.exe.add_instruction(Instruction::LoadCopy);
+            ctx.add_instruction(Instruction::LoadCopy);
             // 3. If func is either undefined or null, then
-            ctx.exe.add_instruction(Instruction::IsNullOrUndefined);
+            ctx.add_instruction(Instruction::IsNullOrUndefined);
             // a. Return undefined
 
             // To return undefined we jump over the rest of the call handling.
@@ -1295,25 +1285,22 @@ impl CompileEvaluation for CallExpression<'_> {
                 // If we need to pop the reference stack, then we must do it
                 // here before we go to the nullish case handling.
                 // Note the inverted jump condition here!
-                let jump_to_call = ctx
-                    .exe
-                    .add_instruction_with_jump_slot(Instruction::JumpIfNot);
+                let jump_to_call = ctx.add_instruction_with_jump_slot(Instruction::JumpIfNot);
                 // Now we're in our local nullish case handling.
                 // First we pop our reference.
-                ctx.exe.add_instruction(Instruction::PopReference);
+                ctx.add_instruction(Instruction::PopReference);
                 // And now we're ready to jump over the call.
-                let jump_over_call = ctx.exe.add_instruction_with_jump_slot(Instruction::Jump);
+                let jump_over_call = ctx.add_instruction_with_jump_slot(Instruction::Jump);
                 // But if we're jumping to call then we need to land here.
-                ctx.exe.set_jump_target_here(jump_to_call);
+                ctx.set_jump_target_here(jump_to_call);
                 jump_over_call
             } else {
-                ctx.exe
-                    .add_instruction_with_jump_slot(Instruction::JumpIfTrue)
+                ctx.add_instruction_with_jump_slot(Instruction::JumpIfTrue)
             };
             // Register our jump slot to the chain nullish case handling.
             ctx.optional_chains.as_mut().unwrap().push(jump_over_call);
         } else {
-            ctx.exe.add_instruction(Instruction::Load);
+            ctx.add_instruction(Instruction::Load);
         }
         // If we're in an optional chain, we need to pluck it out while we're
         // compiling the parameters: They do not join our chain.
@@ -1325,10 +1312,9 @@ impl CompileEvaluation for CallExpression<'_> {
         }
 
         if need_pop_reference {
-            ctx.exe.add_instruction(Instruction::PopReference);
+            ctx.add_instruction(Instruction::PopReference);
         }
-        ctx.exe
-            .add_instruction_with_immediate(Instruction::EvaluateCall, num_arguments);
+        ctx.add_instruction_with_immediate(Instruction::EvaluateCall, num_arguments);
     }
 }
 
@@ -1336,13 +1322,12 @@ impl CompileEvaluation for NewExpression<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
         self.callee.compile(ctx);
         if is_reference(&self.callee) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
-        ctx.exe.add_instruction(Instruction::Load);
+        ctx.add_instruction(Instruction::Load);
 
         let num_arguments = compile_arguments(&self.arguments, ctx);
-        ctx.exe
-            .add_instruction_with_immediate(Instruction::EvaluateNew, num_arguments);
+        ctx.add_instruction_with_immediate(Instruction::EvaluateNew, num_arguments);
     }
 }
 
@@ -1364,22 +1349,21 @@ impl CompileEvaluation for ast::ComputedMemberExpression<'_> {
 
         // 2. Let baseValue be ? GetValue(baseReference).
         if is_reference(&self.object) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
 
         if self.optional {
             // Optional Chains
 
             // Load copy of baseValue to stack.
-            ctx.exe.add_instruction(Instruction::LoadCopy);
+            ctx.add_instruction(Instruction::LoadCopy);
             // 3. If baseValue is either undefined or null, then
-            ctx.exe.add_instruction(Instruction::IsNullOrUndefined);
+            ctx.add_instruction(Instruction::IsNullOrUndefined);
             // a. Return undefined
 
             // To return undefined we jump over the property access.
-            let jump_over_property_access = ctx
-                .exe
-                .add_instruction_with_jump_slot(Instruction::JumpIfTrue);
+            let jump_over_property_access =
+                ctx.add_instruction_with_jump_slot(Instruction::JumpIfTrue);
 
             // Register our jump slot to the chain nullish case handling.
             ctx.optional_chains
@@ -1387,7 +1371,7 @@ impl CompileEvaluation for ast::ComputedMemberExpression<'_> {
                 .unwrap()
                 .push(jump_over_property_access);
         } else {
-            ctx.exe.add_instruction(Instruction::Load);
+            ctx.add_instruction(Instruction::Load);
         }
 
         // If we're in an optional chain, we need to pluck it out while we're
@@ -1396,7 +1380,7 @@ impl CompileEvaluation for ast::ComputedMemberExpression<'_> {
         // 4. Return ? EvaluatePropertyAccessWithExpressionKey(baseValue, Expression, strict).
         self.expression.compile(ctx);
         if is_reference(&self.expression) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
         // After we're done with compiling the member expression we go back
         // into the chain.
@@ -1404,8 +1388,7 @@ impl CompileEvaluation for ast::ComputedMemberExpression<'_> {
             ctx.optional_chains.replace(optional_chain);
         }
 
-        ctx.exe
-            .add_instruction(Instruction::EvaluatePropertyAccessWithExpressionKey);
+        ctx.add_instruction(Instruction::EvaluatePropertyAccessWithExpressionKey);
     }
 }
 
@@ -1416,22 +1399,21 @@ impl CompileEvaluation for ast::StaticMemberExpression<'_> {
 
         // 2. Let baseValue be ? GetValue(baseReference).
         if is_reference(&self.object) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
 
         if self.optional {
             // Optional Chains
 
             // Load copy of baseValue to stack.
-            ctx.exe.add_instruction(Instruction::LoadCopy);
+            ctx.add_instruction(Instruction::LoadCopy);
             // 3. If baseValue is either undefined or null, then
-            ctx.exe.add_instruction(Instruction::IsNullOrUndefined);
+            ctx.add_instruction(Instruction::IsNullOrUndefined);
             // a. Return undefined
 
             // To return undefined we jump over the property access.
-            let jump_over_property_access = ctx
-                .exe
-                .add_instruction_with_jump_slot(Instruction::JumpIfTrue);
+            let jump_over_property_access =
+                ctx.add_instruction_with_jump_slot(Instruction::JumpIfTrue);
 
             // Register our jump slot to the chain nullish case handling.
             ctx.optional_chains
@@ -1440,12 +1422,12 @@ impl CompileEvaluation for ast::StaticMemberExpression<'_> {
                 .push(jump_over_property_access);
 
             // Return copy of baseValue from stack if it is not.
-            ctx.exe.add_instruction(Instruction::Store);
+            ctx.add_instruction(Instruction::Store);
         }
 
         // 4. Return EvaluatePropertyAccessWithIdentifierKey(baseValue, IdentifierName, strict).
         let identifier = String::from_str(ctx.agent, self.property.name.as_str());
-        ctx.exe.add_instruction_with_identifier(
+        ctx.add_instruction_with_identifier(
             Instruction::EvaluatePropertyAccessWithIdentifierKey,
             identifier,
         );
@@ -1464,10 +1446,10 @@ impl CompileEvaluation for ast::AwaitExpression<'_> {
         self.argument.compile(ctx);
         // 2. Let value be ? GetValue(exprRef).
         if is_reference(&self.argument) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
         // 3. Return ? Await(value).
-        ctx.exe.add_instruction(Instruction::Await);
+        ctx.add_instruction(Instruction::Await);
     }
 }
 
@@ -1512,25 +1494,23 @@ impl CompileEvaluation for ast::ChainExpression<'_> {
             // both its value and its reference.
             if ctx.is_call_optional_chain_this {
                 ctx.is_call_optional_chain_this = false;
-                ctx.exe.add_instruction(Instruction::GetValueKeepReference);
+                ctx.add_instruction(Instruction::GetValueKeepReference);
             } else {
-                ctx.exe.add_instruction(Instruction::GetValue);
+                ctx.add_instruction(Instruction::GetValue);
             }
         }
         if installed_own_chains {
-            let jump_over_return_undefined =
-                ctx.exe.add_instruction_with_jump_slot(Instruction::Jump);
+            let jump_over_return_undefined = ctx.add_instruction_with_jump_slot(Instruction::Jump);
             let own_chains = ctx.optional_chains.take().unwrap();
             for jump_to_return_undefined in own_chains {
-                ctx.exe.set_jump_target_here(jump_to_return_undefined);
+                ctx.set_jump_target_here(jump_to_return_undefined);
             }
             // All optional chains come here with a copy of their null or
             // undefined baseValue on the stack. Pop it off.
-            ctx.exe.add_instruction(Instruction::Store);
+            ctx.add_instruction(Instruction::Store);
             // Replace any possible null with undefined.
-            ctx.exe
-                .add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
-            ctx.exe.set_jump_target_here(jump_over_return_undefined);
+            ctx.add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
+            ctx.set_jump_target_here(jump_over_return_undefined);
         }
     }
 }
@@ -1543,31 +1523,29 @@ impl CompileEvaluation for ast::ConditionalExpression<'_> {
         self.test.compile(ctx);
         // 2. Let lval be ToBoolean(? GetValue(lref)).
         if is_reference(&self.test) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
         // Jump over first AssignmentExpression (consequent) if test fails.
         // Note: JumpIfNot performs ToBoolean from above step.
-        let jump_to_second = ctx
-            .exe
-            .add_instruction_with_jump_slot(Instruction::JumpIfNot);
+        let jump_to_second = ctx.add_instruction_with_jump_slot(Instruction::JumpIfNot);
         // 3. If lval is true, then
         // a. Let trueRef be ? Evaluation of the first AssignmentExpression.
         self.consequent.compile(ctx);
         // b. Return ? GetValue(trueRef).
         if is_reference(&self.consequent) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
         // Jump over second AssignmentExpression (alternate).
-        let jump_over_second = ctx.exe.add_instruction_with_jump_slot(Instruction::Jump);
+        let jump_over_second = ctx.add_instruction_with_jump_slot(Instruction::Jump);
         // 4. Else,
-        ctx.exe.set_jump_target_here(jump_to_second);
+        ctx.set_jump_target_here(jump_to_second);
         // a. Let falseRef be ? Evaluation of the second AssignmentExpression.
         self.alternate.compile(ctx);
         // b. Return ? GetValue(falseRef).
         if is_reference(&self.alternate) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
-        ctx.exe.set_jump_target_here(jump_over_second);
+        ctx.set_jump_target_here(jump_over_second);
     }
 }
 
@@ -1594,8 +1572,7 @@ impl CompileEvaluation for ast::RegExpLiteral<'_> {
         let pattern = String::from_str(ctx.agent, self.regex.pattern.as_str());
         let regexp =
             reg_exp_create(ctx.agent, pattern.into_value(), Some(self.regex.flags)).unwrap();
-        ctx.exe
-            .add_instruction_with_constant(Instruction::StoreConstant, regexp);
+        ctx.add_instruction_with_constant(Instruction::StoreConstant, regexp);
     }
 }
 
@@ -1629,8 +1606,7 @@ impl CompileEvaluation for ast::TemplateLiteral<'_> {
                     .expect("Invalid escape sequence in template literal")
                     .as_str(),
             );
-            ctx.exe
-                .add_instruction_with_constant(Instruction::StoreConstant, constant);
+            ctx.add_instruction_with_constant(Instruction::StoreConstant, constant);
         } else {
             let mut count = 0;
             let mut quasis = self.quasis.as_slice();
@@ -1640,8 +1616,7 @@ impl CompileEvaluation for ast::TemplateLiteral<'_> {
                 // 1. Let head be the TV of TemplateHead as defined in 12.9.6.
                 let head =
                     String::from_str(ctx.agent, head.value.cooked.as_ref().unwrap().as_str());
-                ctx.exe
-                    .add_instruction_with_constant(Instruction::LoadConstant, head);
+                ctx.add_instruction_with_constant(Instruction::LoadConstant, head);
                 count += 1;
                 if let Some((expression, rest)) = expressions.split_first() {
                     expressions = rest;
@@ -1649,25 +1624,24 @@ impl CompileEvaluation for ast::TemplateLiteral<'_> {
                     expression.compile(ctx);
                     if is_reference(expression) {
                         // 3. Let sub be ? GetValue(subRef).
-                        ctx.exe.add_instruction(Instruction::GetValue);
+                        ctx.add_instruction(Instruction::GetValue);
                     }
                     // 4. Let middle be ? ToString(sub).
                     // Note: This is done by StringConcat.
-                    ctx.exe.add_instruction(Instruction::Load);
+                    ctx.add_instruction(Instruction::Load);
                     count += 1;
                 }
                 // 5. Let tail be ? Evaluation of TemplateSpans.
             }
             // 6. Return the string-concatenation of head, middle, and tail.
-            ctx.exe
-                .add_instruction_with_immediate(Instruction::StringConcat, count);
+            ctx.add_instruction_with_immediate(Instruction::StringConcat, count);
         }
     }
 }
 
 impl CompileEvaluation for ast::ThisExpression {
     fn compile(&self, ctx: &mut CompileContext) {
-        ctx.exe.add_instruction(Instruction::ResolveThisBinding);
+        ctx.add_instruction(Instruction::ResolveThisBinding);
     }
 }
 
@@ -1688,16 +1662,15 @@ impl CompileEvaluation for ast::YieldExpression<'_> {
             arg.compile(ctx);
             // 2. Let value be ? GetValue(exprRef).
             if is_reference(arg) {
-                ctx.exe.add_instruction(Instruction::GetValue);
+                ctx.add_instruction(Instruction::GetValue);
             }
         } else {
             // YieldExpression : yield
             // 1. Return ? Yield(undefined).
-            ctx.exe
-                .add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
+            ctx.add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
         }
         // 3. Return ? Yield(value).
-        ctx.exe.add_instruction(Instruction::Yield);
+        ctx.add_instruction(Instruction::Yield);
     }
 }
 
@@ -1763,26 +1736,26 @@ impl CompileEvaluation for ast::UpdateExpression<'_> {
             | ast::SimpleAssignmentTarget::TSSatisfiesExpression(_)
             | ast::SimpleAssignmentTarget::TSTypeAssertion(_) => unreachable!(),
         }
-        ctx.exe.add_instruction(Instruction::GetValueKeepReference);
+        ctx.add_instruction(Instruction::GetValueKeepReference);
         if !self.prefix {
             // The return value of postfix increment/decrement is the value
             // after ToNumeric.
-            ctx.exe.add_instruction(Instruction::ToNumeric);
-            ctx.exe.add_instruction(Instruction::LoadCopy);
+            ctx.add_instruction(Instruction::ToNumeric);
+            ctx.add_instruction(Instruction::LoadCopy);
         }
         match self.operator {
             oxc_syntax::operator::UpdateOperator::Increment => {
-                ctx.exe.add_instruction(Instruction::Increment);
+                ctx.add_instruction(Instruction::Increment);
             }
             oxc_syntax::operator::UpdateOperator::Decrement => {
-                ctx.exe.add_instruction(Instruction::Decrement);
+                ctx.add_instruction(Instruction::Decrement);
             }
         }
         if self.prefix {
-            ctx.exe.add_instruction(Instruction::LoadCopy);
+            ctx.add_instruction(Instruction::LoadCopy);
         }
-        ctx.exe.add_instruction(Instruction::PutValue);
-        ctx.exe.add_instruction(Instruction::Store);
+        ctx.add_instruction(Instruction::PutValue);
+        ctx.add_instruction(Instruction::Store);
     }
 }
 
@@ -1794,7 +1767,7 @@ impl CompileEvaluation for ast::ExpressionStatement<'_> {
         self.expression.compile(ctx);
         if is_reference(&self.expression) {
             // 2. Return ? GetValue(exprRef).
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
     }
 }
@@ -1804,13 +1777,12 @@ impl CompileEvaluation for ast::ReturnStatement<'_> {
         if let Some(expr) = &self.argument {
             expr.compile(ctx);
             if is_reference(expr) {
-                ctx.exe.add_instruction(Instruction::GetValue);
+                ctx.add_instruction(Instruction::GetValue);
             }
         } else {
-            ctx.exe
-                .add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
+            ctx.add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
         }
-        ctx.exe.add_instruction(Instruction::Return);
+        ctx.add_instruction(Instruction::Return);
     }
 }
 
@@ -1819,34 +1791,32 @@ impl CompileEvaluation for ast::IfStatement<'_> {
         // if (test) consequent
         self.test.compile(ctx);
         if is_reference(&self.test) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
         // jump over consequent if test fails
-        let jump_to_else = ctx
-            .exe
-            .add_instruction_with_jump_slot(Instruction::JumpIfNot);
+        let jump_to_else = ctx.add_instruction_with_jump_slot(Instruction::JumpIfNot);
         self.consequent.compile(ctx);
         let mut jump_over_else: Option<JumpIndex> = None;
         if let Some(alternate) = &self.alternate {
             // Optimisation: If the an else branch exists, the consequent
             // branch needs to end in a jump over it. But if the consequent
             // branch ends in a return statement that jump becomes unnecessary.
-            if ctx.exe.peek_last_instruction() != Some(Instruction::Return.as_u8()) {
-                jump_over_else = Some(ctx.exe.add_instruction_with_jump_slot(Instruction::Jump));
+            if ctx.peek_last_instruction() != Some(Instruction::Return.as_u8()) {
+                jump_over_else = Some(ctx.add_instruction_with_jump_slot(Instruction::Jump));
             }
 
             // Jump to else-branch when if test fails.
-            ctx.exe.set_jump_target_here(jump_to_else);
+            ctx.set_jump_target_here(jump_to_else);
             alternate.compile(ctx);
         } else {
             // Jump over if-branch when if test fails.
-            ctx.exe.set_jump_target_here(jump_to_else);
+            ctx.set_jump_target_here(jump_to_else);
         }
 
         // Jump over else-branch at the end of if-branch if necessary.
         // (See optimisation above for when it is not needed.)
         if let Some(jump_over_else) = jump_over_else {
-            ctx.exe.set_jump_target_here(jump_over_else);
+            ctx.set_jump_target_here(jump_over_else);
         }
     }
 }
@@ -1857,8 +1827,8 @@ impl CompileEvaluation for ast::ArrayPattern<'_> {
             return;
         }
 
-        ctx.exe.add_instruction(Instruction::Store);
-        ctx.exe.add_instruction(Instruction::GetIteratorSync);
+        ctx.add_instruction(Instruction::Store);
+        ctx.add_instruction(Instruction::GetIteratorSync);
 
         if !self.contains_expression() {
             simple_array_pattern(
@@ -1889,7 +1859,7 @@ fn simple_array_pattern<'a, 'b, I>(
     'b: 'a,
     I: Iterator<Item = Option<&'a BindingPattern<'b>>>,
 {
-    ctx.exe.add_instruction_with_immediate_and_immediate(
+    ctx.add_instruction_with_immediate_and_immediate(
         Instruction::BeginSimpleArrayBindingPattern,
         num_elements,
         has_environment.into(),
@@ -1897,23 +1867,23 @@ fn simple_array_pattern<'a, 'b, I>(
 
     for ele in elements {
         let Some(ele) = ele else {
-            ctx.exe.add_instruction(Instruction::BindingPatternSkip);
+            ctx.add_instruction(Instruction::BindingPatternSkip);
             continue;
         };
         match &ele.kind {
             ast::BindingPatternKind::BindingIdentifier(identifier) => {
                 let identifier_string = ctx.create_identifier(&identifier.name);
-                ctx.exe.add_instruction_with_identifier(
+                ctx.add_instruction_with_identifier(
                     Instruction::BindingPatternBind,
                     identifier_string,
                 )
             }
             ast::BindingPatternKind::ObjectPattern(pattern) => {
-                ctx.exe.add_instruction(Instruction::BindingPatternGetValue);
+                ctx.add_instruction(Instruction::BindingPatternGetValue);
                 simple_object_pattern(pattern, ctx, has_environment);
             }
             ast::BindingPatternKind::ArrayPattern(pattern) => {
-                ctx.exe.add_instruction(Instruction::BindingPatternGetValue);
+                ctx.add_instruction(Instruction::BindingPatternGetValue);
                 simple_array_pattern(
                     ctx,
                     pattern.elements.iter().map(Option::as_ref),
@@ -1930,19 +1900,17 @@ fn simple_array_pattern<'a, 'b, I>(
         match &rest.argument.kind {
             ast::BindingPatternKind::BindingIdentifier(identifier) => {
                 let identifier_string = ctx.create_identifier(&identifier.name);
-                ctx.exe.add_instruction_with_identifier(
+                ctx.add_instruction_with_identifier(
                     Instruction::BindingPatternBindRest,
                     identifier_string,
                 );
             }
             ast::BindingPatternKind::ObjectPattern(pattern) => {
-                ctx.exe
-                    .add_instruction(Instruction::BindingPatternGetRestValue);
+                ctx.add_instruction(Instruction::BindingPatternGetRestValue);
                 simple_object_pattern(pattern, ctx, has_environment);
             }
             ast::BindingPatternKind::ArrayPattern(pattern) => {
-                ctx.exe
-                    .add_instruction(Instruction::BindingPatternGetRestValue);
+                ctx.add_instruction(Instruction::BindingPatternGetRestValue);
                 simple_array_pattern(
                     ctx,
                     pattern.elements.iter().map(Option::as_ref),
@@ -1954,7 +1922,7 @@ fn simple_array_pattern<'a, 'b, I>(
             ast::BindingPatternKind::AssignmentPattern(_) => unreachable!(),
         }
     } else {
-        ctx.exe.add_instruction(Instruction::FinishBindingPattern);
+        ctx.add_instruction(Instruction::FinishBindingPattern);
     }
 }
 
@@ -1968,8 +1936,7 @@ fn complex_array_pattern<'a, 'b, I>(
     I: Iterator<Item = Option<&'a BindingPattern<'b>>>,
 {
     for ele in elements {
-        ctx.exe
-            .add_instruction(Instruction::IteratorStepValueOrUndefined);
+        ctx.add_instruction(Instruction::IteratorStepValueOrUndefined);
 
         let Some(ele) = ele else {
             continue;
@@ -1978,18 +1945,16 @@ fn complex_array_pattern<'a, 'b, I>(
         let binding_pattern = match &ele.kind {
             ast::BindingPatternKind::AssignmentPattern(pattern) => {
                 // Run the initializer if the result value is undefined.
-                ctx.exe.add_instruction(Instruction::LoadCopy);
-                ctx.exe.add_instruction(Instruction::IsUndefined);
-                let jump_slot = ctx
-                    .exe
-                    .add_instruction_with_jump_slot(Instruction::JumpIfNot);
-                ctx.exe.add_instruction(Instruction::Store);
+                ctx.add_instruction(Instruction::LoadCopy);
+                ctx.add_instruction(Instruction::IsUndefined);
+                let jump_slot = ctx.add_instruction_with_jump_slot(Instruction::JumpIfNot);
+                ctx.add_instruction(Instruction::Store);
                 if is_anonymous_function_definition(&pattern.right) {
                     if let ast::BindingPatternKind::BindingIdentifier(identifier) =
                         &pattern.left.kind
                     {
                         let identifier_string = ctx.create_identifier(&identifier.name);
-                        ctx.exe.add_instruction_with_constant(
+                        ctx.add_instruction_with_constant(
                             Instruction::StoreConstant,
                             identifier_string,
                         );
@@ -1999,11 +1964,11 @@ fn complex_array_pattern<'a, 'b, I>(
                 pattern.right.compile(ctx);
                 ctx.name_identifier = None;
                 if is_reference(&pattern.right) {
-                    ctx.exe.add_instruction(Instruction::GetValue);
+                    ctx.add_instruction(Instruction::GetValue);
                 }
-                ctx.exe.add_instruction(Instruction::Load);
-                ctx.exe.set_jump_target_here(jump_slot);
-                ctx.exe.add_instruction(Instruction::Store);
+                ctx.add_instruction(Instruction::Load);
+                ctx.set_jump_target_here(jump_slot);
+                ctx.add_instruction(Instruction::Store);
 
                 &pattern.left.kind
             }
@@ -2013,23 +1978,19 @@ fn complex_array_pattern<'a, 'b, I>(
         match binding_pattern {
             ast::BindingPatternKind::BindingIdentifier(identifier) => {
                 let identifier_string = ctx.create_identifier(&identifier.name);
-                ctx.exe.add_instruction_with_identifier(
-                    Instruction::ResolveBinding,
-                    identifier_string,
-                );
+                ctx.add_instruction_with_identifier(Instruction::ResolveBinding, identifier_string);
                 if !has_environment {
-                    ctx.exe.add_instruction(Instruction::PutValue);
+                    ctx.add_instruction(Instruction::PutValue);
                 } else {
-                    ctx.exe
-                        .add_instruction(Instruction::InitializeReferencedBinding);
+                    ctx.add_instruction(Instruction::InitializeReferencedBinding);
                 }
             }
             ast::BindingPatternKind::ObjectPattern(pattern) => {
-                ctx.exe.add_instruction(Instruction::Load);
+                ctx.add_instruction(Instruction::Load);
                 pattern.compile(ctx);
             }
             ast::BindingPatternKind::ArrayPattern(pattern) => {
-                ctx.exe.add_instruction(Instruction::Load);
+                ctx.add_instruction(Instruction::Load);
                 pattern.compile(ctx);
             }
             ast::BindingPatternKind::AssignmentPattern(_) => unreachable!(),
@@ -2037,33 +1998,29 @@ fn complex_array_pattern<'a, 'b, I>(
     }
 
     if let Some(rest) = rest {
-        ctx.exe.add_instruction(Instruction::IteratorRestIntoArray);
+        ctx.add_instruction(Instruction::IteratorRestIntoArray);
         match &rest.argument.kind {
             ast::BindingPatternKind::BindingIdentifier(identifier) => {
                 let identifier_string = ctx.create_identifier(&identifier.name);
-                ctx.exe.add_instruction_with_identifier(
-                    Instruction::ResolveBinding,
-                    identifier_string,
-                );
+                ctx.add_instruction_with_identifier(Instruction::ResolveBinding, identifier_string);
                 if !has_environment {
-                    ctx.exe.add_instruction(Instruction::PutValue);
+                    ctx.add_instruction(Instruction::PutValue);
                 } else {
-                    ctx.exe
-                        .add_instruction(Instruction::InitializeReferencedBinding);
+                    ctx.add_instruction(Instruction::InitializeReferencedBinding);
                 }
             }
             ast::BindingPatternKind::ObjectPattern(pattern) => {
-                ctx.exe.add_instruction(Instruction::Load);
+                ctx.add_instruction(Instruction::Load);
                 pattern.compile(ctx);
             }
             ast::BindingPatternKind::ArrayPattern(pattern) => {
-                ctx.exe.add_instruction(Instruction::Load);
+                ctx.add_instruction(Instruction::Load);
                 pattern.compile(ctx);
             }
             ast::BindingPatternKind::AssignmentPattern(_) => unreachable!(),
         }
     } else {
-        ctx.exe.add_instruction(Instruction::IteratorClose);
+        ctx.add_instruction(Instruction::IteratorClose);
     }
 }
 
@@ -2082,7 +2039,7 @@ fn simple_object_pattern(
     ctx: &mut CompileContext,
     has_environment: bool,
 ) {
-    ctx.exe.add_instruction_with_immediate(
+    ctx.add_instruction_with_immediate(
         Instruction::BeginSimpleObjectBindingPattern,
         has_environment.into(),
     );
@@ -2097,10 +2054,7 @@ fn simple_object_pattern(
                 ast::BindingPatternKind::BindingIdentifier(_)
             ));
             let identifier_string = ctx.create_identifier(&identifier.name);
-            ctx.exe.add_instruction_with_identifier(
-                Instruction::BindingPatternBind,
-                identifier_string,
-            );
+            ctx.add_instruction_with_identifier(Instruction::BindingPatternBind, identifier_string);
         } else {
             let key_string = match &ele.key {
                 ast::PropertyKey::StaticIdentifier(identifier) => {
@@ -2123,21 +2077,21 @@ fn simple_object_pattern(
             match &ele.value.kind {
                 ast::BindingPatternKind::BindingIdentifier(identifier) => {
                     let value_identifier_string = ctx.create_identifier(&identifier.name);
-                    ctx.exe.add_instruction_with_identifier_and_constant(
+                    ctx.add_instruction_with_identifier_and_constant(
                         Instruction::BindingPatternBindNamed,
                         value_identifier_string,
                         key_string,
                     )
                 }
                 ast::BindingPatternKind::ObjectPattern(pattern) => {
-                    ctx.exe.add_instruction_with_constant(
+                    ctx.add_instruction_with_constant(
                         Instruction::BindingPatternGetValueNamed,
                         key_string,
                     );
                     simple_object_pattern(pattern, ctx, has_environment);
                 }
                 ast::BindingPatternKind::ArrayPattern(pattern) => {
-                    ctx.exe.add_instruction_with_constant(
+                    ctx.add_instruction_with_constant(
                         Instruction::BindingPatternGetValueNamed,
                         key_string,
                     );
@@ -2158,7 +2112,7 @@ fn simple_object_pattern(
         match &rest.argument.kind {
             ast::BindingPatternKind::BindingIdentifier(identifier) => {
                 let identifier_string = ctx.create_identifier(&identifier.name);
-                ctx.exe.add_instruction_with_identifier(
+                ctx.add_instruction_with_identifier(
                     Instruction::BindingPatternBindRest,
                     identifier_string,
                 );
@@ -2166,7 +2120,7 @@ fn simple_object_pattern(
             _ => unreachable!(),
         }
     } else {
-        ctx.exe.add_instruction(Instruction::FinishBindingPattern);
+        ctx.add_instruction(Instruction::FinishBindingPattern);
     }
 }
 
@@ -2180,17 +2134,17 @@ fn complex_object_pattern(
     // 1. Perform ? RequireObjectCoercible(value).
     // NOTE: RequireObjectCoercible throws in the same cases as ToObject, and other operations
     // later on (such as GetV) also perform ToObject, so we convert to an object early.
-    ctx.exe.add_instruction(Instruction::Store);
-    ctx.exe.add_instruction(Instruction::ToObject);
-    ctx.exe.add_instruction(Instruction::Load);
+    ctx.add_instruction(Instruction::Store);
+    ctx.add_instruction(Instruction::ToObject);
+    ctx.add_instruction(Instruction::Load);
 
     for property in &object_pattern.properties {
         match &property.key {
             ast::PropertyKey::StaticIdentifier(identifier) => {
-                ctx.exe.add_instruction(Instruction::Store);
-                ctx.exe.add_instruction(Instruction::LoadCopy);
+                ctx.add_instruction(Instruction::Store);
+                ctx.add_instruction(Instruction::LoadCopy);
                 let identifier_string = ctx.create_identifier(&identifier.name);
-                ctx.exe.add_instruction_with_identifier(
+                ctx.add_instruction_with_identifier(
                     Instruction::EvaluatePropertyAccessWithIdentifierKey,
                     identifier_string,
                 );
@@ -2198,32 +2152,29 @@ fn complex_object_pattern(
             ast::PropertyKey::PrivateIdentifier(_) => todo!(),
             _ => {
                 property.key.to_expression().compile(ctx);
-                ctx.exe
-                    .add_instruction(Instruction::EvaluatePropertyAccessWithExpressionKey);
+                ctx.add_instruction(Instruction::EvaluatePropertyAccessWithExpressionKey);
             }
         }
         if object_pattern.rest.is_some() {
-            ctx.exe.add_instruction(Instruction::GetValueKeepReference);
-            ctx.exe.add_instruction(Instruction::PushReference);
+            ctx.add_instruction(Instruction::GetValueKeepReference);
+            ctx.add_instruction(Instruction::PushReference);
         } else {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
 
         let binding_pattern = match &property.value.kind {
             ast::BindingPatternKind::AssignmentPattern(pattern) => {
                 // Run the initializer if the result value is undefined.
-                ctx.exe.add_instruction(Instruction::LoadCopy);
-                ctx.exe.add_instruction(Instruction::IsUndefined);
-                let jump_slot = ctx
-                    .exe
-                    .add_instruction_with_jump_slot(Instruction::JumpIfNot);
-                ctx.exe.add_instruction(Instruction::Store);
+                ctx.add_instruction(Instruction::LoadCopy);
+                ctx.add_instruction(Instruction::IsUndefined);
+                let jump_slot = ctx.add_instruction_with_jump_slot(Instruction::JumpIfNot);
+                ctx.add_instruction(Instruction::Store);
                 if is_anonymous_function_definition(&pattern.right) {
                     if let ast::BindingPatternKind::BindingIdentifier(identifier) =
                         &pattern.left.kind
                     {
                         let identifier_string = ctx.create_identifier(&identifier.name);
-                        ctx.exe.add_instruction_with_constant(
+                        ctx.add_instruction_with_constant(
                             Instruction::StoreConstant,
                             identifier_string,
                         );
@@ -2233,11 +2184,11 @@ fn complex_object_pattern(
                 pattern.right.compile(ctx);
                 ctx.name_identifier = None;
                 if is_reference(&pattern.right) {
-                    ctx.exe.add_instruction(Instruction::GetValue);
+                    ctx.add_instruction(Instruction::GetValue);
                 }
-                ctx.exe.add_instruction(Instruction::Load);
-                ctx.exe.set_jump_target_here(jump_slot);
-                ctx.exe.add_instruction(Instruction::Store);
+                ctx.add_instruction(Instruction::Load);
+                ctx.set_jump_target_here(jump_slot);
+                ctx.add_instruction(Instruction::Store);
 
                 &pattern.left.kind
             }
@@ -2247,23 +2198,19 @@ fn complex_object_pattern(
         match binding_pattern {
             ast::BindingPatternKind::BindingIdentifier(identifier) => {
                 let identifier_string = ctx.create_identifier(&identifier.name);
-                ctx.exe.add_instruction_with_identifier(
-                    Instruction::ResolveBinding,
-                    identifier_string,
-                );
+                ctx.add_instruction_with_identifier(Instruction::ResolveBinding, identifier_string);
                 if !has_environment {
-                    ctx.exe.add_instruction(Instruction::PutValue);
+                    ctx.add_instruction(Instruction::PutValue);
                 } else {
-                    ctx.exe
-                        .add_instruction(Instruction::InitializeReferencedBinding);
+                    ctx.add_instruction(Instruction::InitializeReferencedBinding);
                 }
             }
             ast::BindingPatternKind::ObjectPattern(pattern) => {
-                ctx.exe.add_instruction(Instruction::Load);
+                ctx.add_instruction(Instruction::Load);
                 pattern.compile(ctx);
             }
             ast::BindingPatternKind::ArrayPattern(pattern) => {
-                ctx.exe.add_instruction(Instruction::Load);
+                ctx.add_instruction(Instruction::Load);
                 pattern.compile(ctx);
             }
             ast::BindingPatternKind::AssignmentPattern(_) => unreachable!(),
@@ -2277,23 +2224,21 @@ fn complex_object_pattern(
 
         // We have kept the references for all of the properties read in the reference stack, so we
         // can now use them to exclude those properties from the rest object.
-        ctx.exe.add_instruction_with_immediate(
+        ctx.add_instruction_with_immediate(
             Instruction::CopyDataPropertiesIntoObject,
             object_pattern.properties.len(),
         );
 
         let identifier_string = ctx.create_identifier(&identifier.name);
-        ctx.exe
-            .add_instruction_with_identifier(Instruction::ResolveBinding, identifier_string);
+        ctx.add_instruction_with_identifier(Instruction::ResolveBinding, identifier_string);
         if !has_environment {
-            ctx.exe.add_instruction(Instruction::PutValue);
+            ctx.add_instruction(Instruction::PutValue);
         } else {
-            ctx.exe
-                .add_instruction(Instruction::InitializeReferencedBinding);
+            ctx.add_instruction(Instruction::InitializeReferencedBinding);
         }
     } else {
         // Don't keep the object on the stack.
-        ctx.exe.add_instruction(Instruction::Store);
+        ctx.add_instruction(Instruction::Store);
     }
 }
 
@@ -2318,9 +2263,9 @@ impl CompileEvaluation for ast::VariableDeclaration<'_> {
                         init.compile(ctx);
                         // 2. Let rval be ? GetValue(rhs).
                         if is_reference(init) {
-                            ctx.exe.add_instruction(Instruction::GetValue);
+                            ctx.add_instruction(Instruction::GetValue);
                         }
-                        ctx.exe.add_instruction(Instruction::Load);
+                        ctx.add_instruction(Instruction::Load);
                         // 3. Return ? BindingInitialization of BidingPattern with arguments rval and undefined.
                         match &decl.id.kind {
                             ast::BindingPatternKind::BindingIdentifier(_) => unreachable!(),
@@ -2334,11 +2279,11 @@ impl CompileEvaluation for ast::VariableDeclaration<'_> {
                     // 1. Let bindingId be StringValue of BindingIdentifier.
                     // 2. Let lhs be ? ResolveBinding(bindingId).
                     let identifier_string = String::from_str(ctx.agent, identifier.name.as_str());
-                    ctx.exe.add_instruction_with_identifier(
+                    ctx.add_instruction_with_identifier(
                         Instruction::ResolveBinding,
                         identifier_string,
                     );
-                    ctx.exe.add_instruction(Instruction::PushReference);
+                    ctx.add_instruction(Instruction::PushReference);
 
                     // 3. If IsAnonymousFunctionDefinition(Initializer) is true, then
                     if is_anonymous_function_definition(init) {
@@ -2351,19 +2296,16 @@ impl CompileEvaluation for ast::VariableDeclaration<'_> {
                         init.compile(ctx);
                         // b. Let value be ? GetValue(rhs).
                         if is_reference(init) {
-                            ctx.exe.add_instruction(Instruction::GetValue);
+                            ctx.add_instruction(Instruction::GetValue);
                         }
                     }
                     // 5. Perform ? PutValue(lhs, value).
-                    ctx.exe.add_instruction(Instruction::PopReference);
-                    ctx.exe.add_instruction(Instruction::PutValue);
+                    ctx.add_instruction(Instruction::PopReference);
+                    ctx.add_instruction(Instruction::PutValue);
 
                     // 6. Return EMPTY.
                     // Store Undefined as the result value.
-                    ctx.exe.add_instruction_with_constant(
-                        Instruction::StoreConstant,
-                        Value::Undefined,
-                    );
+                    ctx.add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
                 }
             }
             ast::VariableDeclarationKind::Let | ast::VariableDeclarationKind::Const => {
@@ -2378,11 +2320,11 @@ impl CompileEvaluation for ast::VariableDeclaration<'_> {
                         init.compile(ctx);
                         // 2. Let value be ? GetValue(rhs).
                         if is_reference(init) {
-                            ctx.exe.add_instruction(Instruction::GetValue);
+                            ctx.add_instruction(Instruction::GetValue);
                         }
                         // 3. Let env be the running execution context's LexicalEnvironment.
                         // 4. Return ? BindingInitialization of BindingPattern with arguments value and env.
-                        ctx.exe.add_instruction(Instruction::Load);
+                        ctx.add_instruction(Instruction::Load);
                         match &decl.id.kind {
                             ast::BindingPatternKind::BindingIdentifier(_) => unreachable!(),
                             ast::BindingPatternKind::ObjectPattern(pattern) => pattern.compile(ctx),
@@ -2394,7 +2336,7 @@ impl CompileEvaluation for ast::VariableDeclaration<'_> {
 
                     // 1. Let lhs be ! ResolveBinding(StringValue of BindingIdentifier).
                     let identifier_string = String::from_str(ctx.agent, identifier.name.as_str());
-                    ctx.exe.add_instruction_with_identifier(
+                    ctx.add_instruction_with_identifier(
                         Instruction::ResolveBinding,
                         identifier_string,
                     );
@@ -2402,14 +2344,13 @@ impl CompileEvaluation for ast::VariableDeclaration<'_> {
                     let Some(init) = &decl.init else {
                         // LexicalBinding : BindingIdentifier
                         // 2. Perform ! InitializeReferencedBinding(lhs, undefined).
-                        ctx.exe.add_instruction_with_constant(
+                        ctx.add_instruction_with_constant(
                             Instruction::StoreConstant,
                             Value::Undefined,
                         );
-                        ctx.exe
-                            .add_instruction(Instruction::InitializeReferencedBinding);
+                        ctx.add_instruction(Instruction::InitializeReferencedBinding);
                         // 3. Return empty.
-                        ctx.exe.add_instruction_with_constant(
+                        ctx.add_instruction_with_constant(
                             Instruction::StoreConstant,
                             Value::Undefined,
                         );
@@ -2417,7 +2358,7 @@ impl CompileEvaluation for ast::VariableDeclaration<'_> {
                     };
 
                     //  LexicalBinding : BindingIdentifier Initializer
-                    ctx.exe.add_instruction(Instruction::PushReference);
+                    ctx.add_instruction(Instruction::PushReference);
                     // 3. If IsAnonymousFunctionDefinition(Initializer) is true, then
                     if is_anonymous_function_definition(init) {
                         // a. Let value be ? NamedEvaluation of Initializer with argument bindingId.
@@ -2429,19 +2370,15 @@ impl CompileEvaluation for ast::VariableDeclaration<'_> {
                         init.compile(ctx);
                         // b. Let value be ? GetValue(rhs).
                         if is_reference(init) {
-                            ctx.exe.add_instruction(Instruction::GetValue);
+                            ctx.add_instruction(Instruction::GetValue);
                         }
                     }
 
                     // 5. Perform ! InitializeReferencedBinding(lhs, value).
-                    ctx.exe.add_instruction(Instruction::PopReference);
-                    ctx.exe
-                        .add_instruction(Instruction::InitializeReferencedBinding);
+                    ctx.add_instruction(Instruction::PopReference);
+                    ctx.add_instruction(Instruction::InitializeReferencedBinding);
                     // 6. Return empty.
-                    ctx.exe.add_instruction_with_constant(
-                        Instruction::StoreConstant,
-                        Value::Undefined,
-                    );
+                    ctx.add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
                 }
             }
         }
@@ -2465,8 +2402,7 @@ impl CompileEvaluation for ast::BlockStatement<'_> {
             // 1. Return EMPTY.
             return;
         }
-        ctx.exe
-            .add_instruction(Instruction::EnterDeclarativeEnvironment);
+        ctx.add_instruction(Instruction::EnterDeclarativeEnvironment);
         // SAFETY: Stupid lifetime transmute.
         let body = unsafe {
             std::mem::transmute::<
@@ -2480,7 +2416,7 @@ impl CompileEvaluation for ast::BlockStatement<'_> {
                     if decl.kind.is_const() {
                         decl.id.bound_names(&mut |name| {
                             let identifier = String::from_str(ctx.agent, name.name.as_str());
-                            ctx.exe.add_instruction_with_identifier(
+                            ctx.add_instruction_with_identifier(
                                 Instruction::CreateImmutableBinding,
                                 identifier,
                             );
@@ -2488,7 +2424,7 @@ impl CompileEvaluation for ast::BlockStatement<'_> {
                     } else if decl.kind.is_lexical() {
                         decl.id.bound_names(&mut |name| {
                             let identifier = String::from_str(ctx.agent, name.name.as_str());
-                            ctx.exe.add_instruction_with_identifier(
+                            ctx.add_instruction_with_identifier(
                                 Instruction::CreateMutableBinding,
                                 identifier,
                             );
@@ -2499,7 +2435,7 @@ impl CompileEvaluation for ast::BlockStatement<'_> {
                     // TODO: InstantiateFunctionObject and InitializeBinding
                     decl.bound_names(&mut |name| {
                         let identifier = String::from_str(ctx.agent, name.name.as_str());
-                        ctx.exe.add_instruction_with_identifier(
+                        ctx.add_instruction_with_identifier(
                             Instruction::CreateMutableBinding,
                             identifier,
                         );
@@ -2508,7 +2444,7 @@ impl CompileEvaluation for ast::BlockStatement<'_> {
                 LexicallyScopedDeclaration::Class(decl) => {
                     decl.bound_names(&mut |name| {
                         let identifier = String::from_str(ctx.agent, name.name.as_str());
-                        ctx.exe.add_instruction_with_identifier(
+                        ctx.add_instruction_with_identifier(
                             Instruction::CreateMutableBinding,
                             identifier,
                         );
@@ -2520,13 +2456,11 @@ impl CompileEvaluation for ast::BlockStatement<'_> {
         for ele in &self.body {
             ele.compile(ctx);
         }
-        if ctx.exe.peek_last_instruction() != Some(Instruction::Return.as_u8()) {
+        if ctx.peek_last_instruction() != Some(Instruction::Return.as_u8()) {
             // Block did not end in a return so we overwrite the result with undefined.
-            ctx.exe
-                .add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
+            ctx.add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
         }
-        ctx.exe
-            .add_instruction(Instruction::ExitDeclarativeEnvironment);
+        ctx.add_instruction(Instruction::ExitDeclarativeEnvironment);
     }
 }
 
@@ -2580,8 +2514,7 @@ impl CompileEvaluation for ast::ForStatement<'_> {
                     if is_lexical {
                         // 1. Let oldEnv be the running execution context's LexicalEnvironment.
                         // 2. Let loopEnv be NewDeclarativeEnvironment(oldEnv).
-                        ctx.exe
-                            .add_instruction(Instruction::EnterDeclarativeEnvironment);
+                        ctx.add_instruction(Instruction::EnterDeclarativeEnvironment);
                         // 3. Let isConst be IsConstantDeclaration of LexicalDeclaration.
                         let is_const = init.kind.is_const();
                         // 4. Let boundNames be the BoundNames of LexicalDeclaration.
@@ -2591,7 +2524,7 @@ impl CompileEvaluation for ast::ForStatement<'_> {
                             init.bound_names(&mut |dn| {
                                 // i. Perform ! loopEnv.CreateImmutableBinding(dn, true).
                                 let identifier = String::from_str(ctx.agent, dn.name.as_str());
-                                ctx.exe.add_instruction_with_identifier(
+                                ctx.add_instruction_with_identifier(
                                     Instruction::CreateImmutableBinding,
                                     identifier,
                                 )
@@ -2605,7 +2538,7 @@ impl CompileEvaluation for ast::ForStatement<'_> {
                                 // be boundNames; otherwise let perIterationLets
                                 // be a new empty List.
                                 per_iteration_lets.push(identifier);
-                                ctx.exe.add_instruction_with_identifier(
+                                ctx.add_instruction_with_identifier(
                                     Instruction::CreateMutableBinding,
                                     identifier,
                                 )
@@ -2641,44 +2574,28 @@ impl CompileEvaluation for ast::ForStatement<'_> {
 
                     let binding = *per_iteration_lets.first().unwrap();
                     // Get value of binding from lastIterationEnv.
-                    ctx.exe
-                        .add_instruction_with_identifier(Instruction::ResolveBinding, binding);
-                    ctx.exe.add_instruction(Instruction::GetValue);
+                    ctx.add_instruction_with_identifier(Instruction::ResolveBinding, binding);
+                    ctx.add_instruction(Instruction::GetValue);
                     // Current declarative environment is now "outer"
-                    ctx.exe
-                        .add_instruction(Instruction::ExitDeclarativeEnvironment);
+                    ctx.add_instruction(Instruction::ExitDeclarativeEnvironment);
                     // NewDeclarativeEnvironment(outer)
-                    ctx.exe
-                        .add_instruction(Instruction::EnterDeclarativeEnvironment);
-                    ctx.exe.add_instruction_with_identifier(
-                        Instruction::CreateMutableBinding,
-                        binding,
-                    );
-                    ctx.exe
-                        .add_instruction_with_identifier(Instruction::ResolveBinding, binding);
-                    ctx.exe
-                        .add_instruction(Instruction::InitializeReferencedBinding);
+                    ctx.add_instruction(Instruction::EnterDeclarativeEnvironment);
+                    ctx.add_instruction_with_identifier(Instruction::CreateMutableBinding, binding);
+                    ctx.add_instruction_with_identifier(Instruction::ResolveBinding, binding);
+                    ctx.add_instruction(Instruction::InitializeReferencedBinding);
                 } else {
                     for bn in &per_iteration_lets {
-                        ctx.exe
-                            .add_instruction_with_identifier(Instruction::ResolveBinding, *bn);
-                        ctx.exe.add_instruction(Instruction::GetValue);
-                        ctx.exe.add_instruction(Instruction::Load);
+                        ctx.add_instruction_with_identifier(Instruction::ResolveBinding, *bn);
+                        ctx.add_instruction(Instruction::GetValue);
+                        ctx.add_instruction(Instruction::Load);
                     }
-                    ctx.exe
-                        .add_instruction(Instruction::ExitDeclarativeEnvironment);
-                    ctx.exe
-                        .add_instruction(Instruction::EnterDeclarativeEnvironment);
+                    ctx.add_instruction(Instruction::ExitDeclarativeEnvironment);
+                    ctx.add_instruction(Instruction::EnterDeclarativeEnvironment);
                     for bn in per_iteration_lets.iter().rev() {
-                        ctx.exe.add_instruction_with_identifier(
-                            Instruction::CreateMutableBinding,
-                            *bn,
-                        );
-                        ctx.exe
-                            .add_instruction_with_identifier(Instruction::ResolveBinding, *bn);
-                        ctx.exe.add_instruction(Instruction::Store);
-                        ctx.exe
-                            .add_instruction(Instruction::InitializeReferencedBinding);
+                        ctx.add_instruction_with_identifier(Instruction::CreateMutableBinding, *bn);
+                        ctx.add_instruction_with_identifier(Instruction::ResolveBinding, *bn);
+                        ctx.add_instruction(Instruction::Store);
+                        ctx.add_instruction(Instruction::InitializeReferencedBinding);
                     }
                 }
             })
@@ -2690,23 +2607,21 @@ impl CompileEvaluation for ast::ForStatement<'_> {
             create_per_iteration_env(ctx);
         }
 
-        let loop_jump = ctx.exe.get_jump_index_to_here();
+        let loop_jump = ctx.get_jump_index_to_here();
         if let Some(test) = &self.test {
             test.compile(ctx);
             if is_reference(test) {
-                ctx.exe.add_instruction(Instruction::GetValue);
+                ctx.add_instruction(Instruction::GetValue);
             }
         }
         // jump over consequent if test fails
-        let end_jump = ctx
-            .exe
-            .add_instruction_with_jump_slot(Instruction::JumpIfNot);
+        let end_jump = ctx.add_instruction_with_jump_slot(Instruction::JumpIfNot);
 
         self.body.compile(ctx);
 
         let own_continues = ctx.current_continue.take().unwrap();
         for continue_entry in own_continues {
-            ctx.exe.set_jump_target_here(continue_entry);
+            ctx.set_jump_target_here(continue_entry);
         }
 
         if let Some(create_per_iteration_env) = create_per_iteration_env {
@@ -2716,19 +2631,17 @@ impl CompileEvaluation for ast::ForStatement<'_> {
         if let Some(update) = &self.update {
             update.compile(ctx);
         }
-        ctx.exe
-            .add_jump_instruction_to_index(Instruction::Jump, loop_jump);
-        ctx.exe.set_jump_target_here(end_jump);
+        ctx.add_jump_instruction_to_index(Instruction::Jump, loop_jump);
+        ctx.set_jump_target_here(end_jump);
 
         let own_breaks = ctx.current_break.take().unwrap();
         for break_entry in own_breaks {
-            ctx.exe.set_jump_target_here(break_entry);
+            ctx.set_jump_target_here(break_entry);
         }
         if is_lexical {
             // Lexical binding loops have an extra declarative environment that
             // we need to exit from once we exit the loop.
-            ctx.exe
-                .add_instruction(Instruction::ExitDeclarativeEnvironment);
+            ctx.add_instruction(Instruction::ExitDeclarativeEnvironment);
         }
         ctx.current_break = previous_break;
         ctx.current_continue = previous_continue;
@@ -2742,14 +2655,13 @@ impl CompileEvaluation for ast::SwitchStatement<'_> {
         self.discriminant.compile(ctx);
         if is_reference(&self.discriminant) {
             // 2. Let switchValue be ? GetValue(exprRef).
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
-        ctx.exe.add_instruction(Instruction::Load);
+        ctx.add_instruction(Instruction::Load);
         // 3. Let oldEnv be the running execution context's LexicalEnvironment.
         // 4. Let blockEnv be NewDeclarativeEnvironment(oldEnv).
         // 6. Set the running execution context's LexicalEnvironment to blockEnv.
-        ctx.exe
-            .add_instruction(Instruction::EnterDeclarativeEnvironment);
+        ctx.add_instruction(Instruction::EnterDeclarativeEnvironment);
         // 5. Perform BlockDeclarationInstantiation(CaseBlock, blockEnv).
         // TODO: Analyze switch env instantiation.
 
@@ -2767,34 +2679,31 @@ impl CompileEvaluation for ast::SwitchStatement<'_> {
             };
             // Duplicate the switchValue on the stack. One will remain, one is
             // used by the IsStrictlyEqual
-            ctx.exe.add_instruction(Instruction::Store);
-            ctx.exe.add_instruction(Instruction::LoadCopy);
-            ctx.exe.add_instruction(Instruction::Load);
+            ctx.add_instruction(Instruction::Store);
+            ctx.add_instruction(Instruction::LoadCopy);
+            ctx.add_instruction(Instruction::Load);
             // 2. Let exprRef be ? Evaluation of the Expression of C.
             test.compile(ctx);
             // 3. Let clauseSelector be ? GetValue(exprRef).
             if is_reference(test) {
-                ctx.exe.add_instruction(Instruction::GetValue);
+                ctx.add_instruction(Instruction::GetValue);
             }
             // 4. Return IsStrictlyEqual(input, clauseSelector).
-            ctx.exe.add_instruction(Instruction::IsStrictlyEqual);
+            ctx.add_instruction(Instruction::IsStrictlyEqual);
             // b. If found is true then [evaluate case]
-            jump_indexes.push(
-                ctx.exe
-                    .add_instruction_with_jump_slot(Instruction::JumpIfTrue),
-            );
+            jump_indexes.push(ctx.add_instruction_with_jump_slot(Instruction::JumpIfTrue));
         }
 
         if has_default {
             // 10. If foundInB is true, return V.
             // 11. Let defaultR be Completion(Evaluation of DefaultClause).
-            jump_indexes.push(ctx.exe.add_instruction_with_jump_slot(Instruction::Jump));
+            jump_indexes.push(ctx.add_instruction_with_jump_slot(Instruction::Jump));
         }
 
         let mut index = 0;
         for (i, case) in self.cases.iter().enumerate() {
             let fallthrough_jump = if i != 0 {
-                Some(ctx.exe.add_instruction_with_jump_slot(Instruction::Jump))
+                Some(ctx.add_instruction_with_jump_slot(Instruction::Jump))
             } else {
                 None
             };
@@ -2807,16 +2716,15 @@ impl CompileEvaluation for ast::SwitchStatement<'_> {
                 // Default case! The jump index is last in the Vec.
                 jump_indexes.last().unwrap()
             };
-            ctx.exe.set_jump_target_here(jump_index.clone());
+            ctx.set_jump_target_here(jump_index.clone());
 
             // Pop the switchValue from the stack.
-            ctx.exe.add_instruction(Instruction::Store);
+            ctx.add_instruction(Instruction::Store);
             // And override it with undefined
-            ctx.exe
-                .add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
+            ctx.add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
 
             if let Some(fallthrough_jump) = fallthrough_jump {
-                ctx.exe.set_jump_target_here(fallthrough_jump);
+                ctx.set_jump_target_here(fallthrough_jump);
             }
 
             for ele in &case.consequent {
@@ -2826,13 +2734,12 @@ impl CompileEvaluation for ast::SwitchStatement<'_> {
 
         let own_breaks = ctx.current_break.take().unwrap();
         for break_entry in own_breaks {
-            ctx.exe.set_jump_target_here(break_entry);
+            ctx.set_jump_target_here(break_entry);
         }
         ctx.current_break = previous_break;
 
         // 8. Set the running execution context's LexicalEnvironment to oldEnv.
-        ctx.exe
-            .add_instruction(Instruction::ExitDeclarativeEnvironment);
+        ctx.add_instruction(Instruction::ExitDeclarativeEnvironment);
         // 9. Return R.
     }
 }
@@ -2841,9 +2748,9 @@ impl CompileEvaluation for ast::ThrowStatement<'_> {
     fn compile(&self, ctx: &mut CompileContext) {
         self.argument.compile(ctx);
         if is_reference(&self.argument) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
-        ctx.exe.add_instruction(Instruction::Throw)
+        ctx.add_instruction(Instruction::Throw)
     }
 }
 
@@ -2853,35 +2760,29 @@ impl CompileEvaluation for ast::TryStatement<'_> {
             todo!();
         }
 
-        let jump_to_catch = ctx
-            .exe
-            .add_instruction_with_jump_slot(Instruction::PushExceptionJumpTarget);
+        let jump_to_catch =
+            ctx.add_instruction_with_jump_slot(Instruction::PushExceptionJumpTarget);
         self.block.compile(ctx);
-        ctx.exe.add_instruction(Instruction::PopExceptionJumpTarget);
-        let jump_to_end = ctx.exe.add_instruction_with_jump_slot(Instruction::Jump);
+        ctx.add_instruction(Instruction::PopExceptionJumpTarget);
+        let jump_to_end = ctx.add_instruction_with_jump_slot(Instruction::Jump);
 
         let catch_clause = self.handler.as_ref().unwrap();
-        ctx.exe.set_jump_target_here(jump_to_catch);
+        ctx.set_jump_target_here(jump_to_catch);
         if let Some(exception_param) = &catch_clause.param {
             let ast::BindingPatternKind::BindingIdentifier(identifier) =
                 &exception_param.pattern.kind
             else {
                 todo!("{:?}", exception_param.pattern.kind);
             };
-            ctx.exe
-                .add_instruction(Instruction::EnterDeclarativeEnvironment);
+            ctx.add_instruction(Instruction::EnterDeclarativeEnvironment);
             let identifier_string = String::from_str(ctx.agent, identifier.name.as_str());
-            ctx.exe.add_instruction_with_identifier(
-                Instruction::CreateCatchBinding,
-                identifier_string,
-            );
+            ctx.add_instruction_with_identifier(Instruction::CreateCatchBinding, identifier_string);
         }
         catch_clause.body.compile(ctx);
         if catch_clause.param.is_some() {
-            ctx.exe
-                .add_instruction(Instruction::ExitDeclarativeEnvironment);
+            ctx.add_instruction(Instruction::ExitDeclarativeEnvironment);
         }
-        ctx.exe.set_jump_target_here(jump_to_end);
+        ctx.set_jump_target_here(jump_to_end);
     }
 }
 
@@ -2891,38 +2792,35 @@ impl CompileEvaluation for ast::WhileStatement<'_> {
         let previous_break = ctx.current_break.replace(vec![]);
 
         // 2. Repeat
-        let start_jump = ctx.exe.get_jump_index_to_here();
+        let start_jump = ctx.get_jump_index_to_here();
 
         // a. Let exprRef be ? Evaluation of Expression.
 
         self.test.compile(ctx);
         if is_reference(&self.test) {
             // b. Let exprValue be ? GetValue(exprRef).
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
 
         // c. If ToBoolean(exprValue) is false, return V.
         // jump over loop jump if test fails
-        let end_jump = ctx
-            .exe
-            .add_instruction_with_jump_slot(Instruction::JumpIfNot);
+        let end_jump = ctx.add_instruction_with_jump_slot(Instruction::JumpIfNot);
         // d. Let stmtResult be Completion(Evaluation of Statement).
         self.body.compile(ctx);
 
         // e. If LoopContinues(stmtResult, labelSet) is false, return ? UpdateEmpty(stmtResult, V).
         // f. If stmtResult.[[Value]] is not EMPTY, set V to stmtResult.[[Value]].
-        ctx.exe
-            .add_jump_instruction_to_index(Instruction::Jump, start_jump.clone());
+        ctx.add_jump_instruction_to_index(Instruction::Jump, start_jump.clone());
         let own_continues = ctx.current_continue.take().unwrap();
         for continue_entry in own_continues {
-            ctx.exe.set_jump_target(continue_entry, start_jump.clone());
+            ctx.set_jump_target(continue_entry, start_jump.clone());
         }
 
-        ctx.exe.set_jump_target_here(end_jump);
+        ctx.set_jump_target_here(end_jump);
 
         let own_breaks = ctx.current_break.take().unwrap();
         for break_entry in own_breaks {
-            ctx.exe.set_jump_target_here(break_entry);
+            ctx.set_jump_target_here(break_entry);
         }
         ctx.current_break = previous_break;
         ctx.current_continue = previous_continue;
@@ -2934,29 +2832,26 @@ impl CompileEvaluation for ast::DoWhileStatement<'_> {
         let previous_continue = ctx.current_continue.replace(vec![]);
         let previous_break = ctx.current_break.replace(vec![]);
 
-        let start_jump = ctx.exe.get_jump_index_to_here();
+        let start_jump = ctx.get_jump_index_to_here();
         self.body.compile(ctx);
 
         let own_continues = ctx.current_continue.take().unwrap();
         for continue_entry in own_continues {
-            ctx.exe.set_jump_target_here(continue_entry);
+            ctx.set_jump_target_here(continue_entry);
         }
 
         self.test.compile(ctx);
         if is_reference(&self.test) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
         // jump over loop jump if test fails
-        let end_jump = ctx
-            .exe
-            .add_instruction_with_jump_slot(Instruction::JumpIfNot);
-        ctx.exe
-            .add_jump_instruction_to_index(Instruction::Jump, start_jump);
-        ctx.exe.set_jump_target_here(end_jump);
+        let end_jump = ctx.add_instruction_with_jump_slot(Instruction::JumpIfNot);
+        ctx.add_jump_instruction_to_index(Instruction::Jump, start_jump);
+        ctx.set_jump_target_here(end_jump);
 
         let own_breaks = ctx.current_break.take().unwrap();
         for break_entry in own_breaks {
-            ctx.exe.set_jump_target_here(break_entry);
+            ctx.set_jump_target_here(break_entry);
         }
         ctx.current_break = previous_break;
         ctx.current_continue = previous_continue;
@@ -2969,7 +2864,7 @@ impl CompileEvaluation for ast::BreakStatement<'_> {
             let label = label.name.as_str();
             todo!("break {};", label);
         }
-        let break_jump = ctx.exe.add_instruction_with_jump_slot(Instruction::Jump);
+        let break_jump = ctx.add_instruction_with_jump_slot(Instruction::Jump);
         ctx.current_break.as_mut().unwrap().push(break_jump);
     }
 }
@@ -2980,7 +2875,7 @@ impl CompileEvaluation for ast::ContinueStatement<'_> {
             let label = label.name.as_str();
             todo!("continue {};", label);
         }
-        let continue_jump = ctx.exe.add_instruction_with_jump_slot(Instruction::Jump);
+        let continue_jump = ctx.add_instruction_with_jump_slot(Instruction::Jump);
         ctx.current_continue.as_mut().unwrap().push(continue_jump);
     }
 }
@@ -3039,12 +2934,10 @@ fn is_anonymous_function_definition(expression: &ast::Expression) -> bool {
 
 impl HeapMarkAndSweep for Executable {
     fn mark_values(&self, queues: &mut WorkQueues) {
-        self.constants.as_slice().mark_values(queues);
-        self.identifiers.as_slice().mark_values(queues);
+        self.constants.mark_values(queues);
     }
 
     fn sweep_values(&mut self, compactions: &CompactionLists) {
-        self.constants.as_mut_slice().sweep_values(compactions);
-        self.identifiers.as_mut_slice().sweep_values(compactions);
+        self.constants.sweep_values(compactions);
     }
 }

--- a/nova_vm/src/engine/bytecode/executable/class_definition_evaluation.rs
+++ b/nova_vm/src/engine/bytecode/executable/class_definition_evaluation.rs
@@ -32,8 +32,7 @@ impl CompileEvaluation for ast::Class<'_> {
         // 2. Let classEnv be NewDeclarativeEnvironment(env).
         // Note: The specification doesn't enter the declaration here, but
         // no user code is run between here and first enter.
-        ctx.exe
-            .add_instruction(Instruction::EnterDeclarativeEnvironment);
+        ctx.add_instruction(Instruction::EnterDeclarativeEnvironment);
 
         // 3. If classBinding is not undefined, then
         let mut has_class_name_on_stack = false;
@@ -42,23 +41,22 @@ impl CompileEvaluation for ast::Class<'_> {
             // a. Perform ! classEnv.CreateImmutableBinding(classBinding, true).
             let identifier = String::from_str(ctx.agent, class_binding.name.as_str());
             class_identifier = Some(identifier);
-            ctx.exe
-                .add_instruction_with_identifier(Instruction::CreateImmutableBinding, identifier);
+            ctx.add_instruction_with_identifier(Instruction::CreateImmutableBinding, identifier);
         } else if let Some(anonymous_class_name) = anonymous_class_name {
             has_class_name_on_stack = true;
             match anonymous_class_name {
                 NamedEvaluationParameter::Result => {
-                    ctx.exe.add_instruction(Instruction::Load);
+                    ctx.add_instruction(Instruction::Load);
                 }
                 NamedEvaluationParameter::Stack => {}
                 NamedEvaluationParameter::Reference => {
-                    ctx.exe.add_instruction(Instruction::GetValue);
-                    ctx.exe.add_instruction(Instruction::Load);
+                    ctx.add_instruction(Instruction::GetValue);
+                    ctx.add_instruction(Instruction::Load);
                 }
                 NamedEvaluationParameter::ReferenceStack => {
-                    ctx.exe.add_instruction(Instruction::PopReference);
-                    ctx.exe.add_instruction(Instruction::GetValue);
-                    ctx.exe.add_instruction(Instruction::Load);
+                    ctx.add_instruction(Instruction::PopReference);
+                    ctx.add_instruction(Instruction::GetValue);
+                    ctx.add_instruction(Instruction::Load);
                 }
             }
         }
@@ -92,10 +90,9 @@ impl CompileEvaluation for ast::Class<'_> {
                 // Hence we do not need to set has_constructor_parent true.
                 // But we do need to remember that this is still a derived
                 // class.
-                ctx.exe.add_instruction(Instruction::ObjectCreate);
-                ctx.exe
-                    .add_instruction_with_constant(Instruction::StoreConstant, Value::Null);
-                ctx.exe.add_instruction(Instruction::ObjectSetPrototype);
+                ctx.add_instruction(Instruction::ObjectCreate);
+                ctx.add_instruction_with_constant(Instruction::StoreConstant, Value::Null);
+                ctx.add_instruction(Instruction::ObjectSetPrototype);
             } else {
                 // Constructor parent is known only at runtime, so we must
                 // consider it.
@@ -111,116 +108,107 @@ impl CompileEvaluation for ast::Class<'_> {
                 // them in classEnv. Whether there's a difference I don't know.
                 if is_reference(super_class) {
                     // e. Let superclass be ? GetValue(? superclassRef).
-                    ctx.exe.add_instruction(Instruction::GetValue);
+                    ctx.add_instruction(Instruction::GetValue);
                 }
                 // f. If superclass is null, then
-                ctx.exe.add_instruction(Instruction::LoadCopy);
-                ctx.exe.add_instruction(Instruction::IsNull);
-                let jump_to_else = ctx
-                    .exe
-                    .add_instruction_with_jump_slot(Instruction::JumpIfNot);
+                ctx.add_instruction(Instruction::LoadCopy);
+                ctx.add_instruction(Instruction::IsNull);
+                let jump_to_else = ctx.add_instruction_with_jump_slot(Instruction::JumpIfNot);
                 // i. Let protoParent be null.
                 // Note: We already have null on the stack.
                 // 9. Let proto be OrdinaryObjectCreate(protoParent).
-                ctx.exe.add_instruction(Instruction::ObjectCreate);
+                ctx.add_instruction(Instruction::ObjectCreate);
                 // Now we have proto on the stack followed be null (protoParent).
-                ctx.exe.add_instruction(Instruction::Swap);
+                ctx.add_instruction(Instruction::Swap);
                 // Now we have null (protoParent) followed by proto.
-                ctx.exe.add_instruction(Instruction::Load);
+                ctx.add_instruction(Instruction::Load);
                 // Now null is in the result register and proto is at the top of
                 // the stack.
-                ctx.exe.add_instruction(Instruction::ObjectSetPrototype);
+                ctx.add_instruction(Instruction::ObjectSetPrototype);
                 // ii. Let constructorParent be %Function.prototype%.
-                ctx.exe.add_instruction_with_constant(
+                ctx.add_instruction_with_constant(
                     Instruction::LoadConstant,
                     ctx.agent.current_realm().intrinsics().function_prototype(),
                 );
 
                 // Note: constructorParent is now at the top of the stack, and
                 // proto is after it. We can jump to the end.
-                let jump_over_else = ctx.exe.add_instruction_with_jump_slot(Instruction::Jump);
+                let jump_over_else = ctx.add_instruction_with_jump_slot(Instruction::Jump);
 
-                ctx.exe.set_jump_target_here(jump_to_else);
+                ctx.set_jump_target_here(jump_to_else);
                 // g. Else if IsConstructor(superclass) is false, then
-                ctx.exe.add_instruction(Instruction::StoreCopy);
-                ctx.exe.add_instruction(Instruction::IsConstructor);
-                let jump_over_throw = ctx
-                    .exe
-                    .add_instruction_with_jump_slot(Instruction::JumpIfTrue);
+                ctx.add_instruction(Instruction::StoreCopy);
+                ctx.add_instruction(Instruction::IsConstructor);
+                let jump_over_throw = ctx.add_instruction_with_jump_slot(Instruction::JumpIfTrue);
                 // Pop the superclass from the stack.
-                ctx.exe.add_instruction(Instruction::Store);
+                ctx.add_instruction(Instruction::Store);
                 // i. Throw a TypeError exception.
-                ctx.exe.add_instruction_with_constant(
-                    Instruction::StoreConstant,
-                    String::from_static_str(ctx.agent, "class heritage is not a constructor"),
-                );
-                ctx.exe.add_instruction_with_immediate(
+                let error_message =
+                    String::from_static_str(ctx.agent, "class heritage is not a constructor");
+                ctx.add_instruction_with_constant(Instruction::StoreConstant, error_message);
+                ctx.add_instruction_with_immediate(
                     Instruction::ThrowError,
                     ExceptionType::TypeError as usize,
                 );
 
                 // h. Else,
-                ctx.exe.set_jump_target_here(jump_over_throw);
+                ctx.set_jump_target_here(jump_over_throw);
                 // i. Let protoParent be ? Get(superclass, "prototype").
-                ctx.exe.add_instruction(Instruction::StoreCopy);
-                ctx.exe.add_instruction_with_identifier(
+                ctx.add_instruction(Instruction::StoreCopy);
+                ctx.add_instruction_with_identifier(
                     Instruction::EvaluatePropertyAccessWithIdentifierKey,
                     BUILTIN_STRING_MEMORY.prototype,
                 );
-                ctx.exe.add_instruction(Instruction::GetValue);
+                ctx.add_instruction(Instruction::GetValue);
 
                 // Note: superclass is now at the top of the stack, and protoParent
                 // in the result register.
 
                 // ii. If protoParent is not an Object and protoParent is not null,
-                ctx.exe.add_instruction(Instruction::LoadCopy);
-                ctx.exe.add_instruction(Instruction::IsObject);
-                let jump_over_null_check_and_throw = ctx
-                    .exe
-                    .add_instruction_with_jump_slot(Instruction::JumpIfTrue);
+                ctx.add_instruction(Instruction::LoadCopy);
+                ctx.add_instruction(Instruction::IsObject);
+                let jump_over_null_check_and_throw =
+                    ctx.add_instruction_with_jump_slot(Instruction::JumpIfTrue);
 
-                ctx.exe.add_instruction(Instruction::StoreCopy);
-                ctx.exe.add_instruction(Instruction::IsNull);
-                let jump_over_throw = ctx
-                    .exe
-                    .add_instruction_with_jump_slot(Instruction::JumpIfTrue);
+                ctx.add_instruction(Instruction::StoreCopy);
+                ctx.add_instruction(Instruction::IsNull);
+                let jump_over_throw = ctx.add_instruction_with_jump_slot(Instruction::JumpIfTrue);
 
                 // ... throw a TypeError exception.
-                ctx.exe.add_instruction_with_constant(
-                    Instruction::StoreConstant,
-                    String::from_static_str(ctx.agent, "class heritage is not an object or null"),
-                );
-                ctx.exe.add_instruction_with_immediate(
+                let error_message =
+                    String::from_static_str(ctx.agent, "class heritage is not an object or null");
+                ctx.add_instruction_with_constant(Instruction::StoreConstant, error_message);
+                ctx.add_instruction_with_immediate(
                     Instruction::ThrowError,
                     ExceptionType::TypeError as usize,
                 );
-                ctx.exe.set_jump_target_here(jump_over_throw);
-                ctx.exe.set_jump_target_here(jump_over_null_check_and_throw);
+                ctx.set_jump_target_here(jump_over_throw);
+                ctx.set_jump_target_here(jump_over_null_check_and_throw);
 
                 // Note: protoParent is now at the top of the stack, and superclass
                 // is after it.
 
                 // 9. Let proto be OrdinaryObjectCreate(protoParent)
-                ctx.exe.add_instruction(Instruction::ObjectCreate);
-                ctx.exe.add_instruction(Instruction::Swap);
+                ctx.add_instruction(Instruction::ObjectCreate);
+                ctx.add_instruction(Instruction::Swap);
                 // Now protoParent is at the top of the stack, proto is second, and
                 // superclass is third.
-                ctx.exe.add_instruction(Instruction::Store);
-                ctx.exe.add_instruction(Instruction::ObjectSetPrototype);
+                ctx.add_instruction(Instruction::Store);
+                ctx.add_instruction(Instruction::ObjectSetPrototype);
 
                 // Now proto is first and superclass second.
-                ctx.exe.add_instruction(Instruction::Swap);
+                ctx.add_instruction(Instruction::Swap);
                 // Now superclass is first and proto is second.
 
                 // iii. Let constructorParent be superclass.
-                ctx.exe.set_jump_target_here(jump_over_else);
+                ctx.set_jump_target_here(jump_over_else);
                 // Now constructorParent is at the top of the stack, and
                 // proto is after it.
             }
         } else {
             // a. Let protoParent be %Object.prototype%.
             // 9. Let proto be OrdinaryObjectCreate(protoParent).
-            ctx.exe.add_instruction(Instruction::ObjectCreate);
+            ctx.add_instruction(Instruction::ObjectCreate);
             // b. Let constructorParent be %Function.prototype%.
             // We omit constructor parent as we statically know it is
             // uninteresting.
@@ -254,23 +242,23 @@ impl CompileEvaluation for ast::Class<'_> {
         if has_class_name_on_stack {
             if has_constructor_parent {
                 // stack: [constructor_parent, proto, class_name]
-                ctx.exe.add_instruction(Instruction::Store);
+                ctx.add_instruction(Instruction::Store);
                 // stack: [proto, class_name]
-                ctx.exe.add_instruction(Instruction::Swap);
+                ctx.add_instruction(Instruction::Swap);
                 // stack: [class_name, proto]
-                ctx.exe.add_instruction(Instruction::Load);
+                ctx.add_instruction(Instruction::Load);
                 // stack: [constructor_parent, class_name, proto]
-                ctx.exe.add_instruction(Instruction::Swap);
+                ctx.add_instruction(Instruction::Swap);
                 // stack: [class_name, constructor_parent, proto]
             } else {
                 // stack: [proto, class_name]
-                ctx.exe.add_instruction(Instruction::Swap);
+                ctx.add_instruction(Instruction::Swap);
                 // stack: [class_name, proto]
             }
         } else {
             // We don't have the class name on the stack, so we can just
             // push it there.
-            ctx.exe.add_instruction_with_constant(
+            ctx.add_instruction_with_constant(
                 Instruction::LoadConstant,
                 class_identifier.unwrap_or(String::EMPTY_STRING),
             );
@@ -290,7 +278,7 @@ impl CompileEvaluation for ast::Class<'_> {
             // ...
             // b. Let F be CreateBuiltinFunction(defaultConstructor, 0, className, « [[ConstructorKind]], [[SourceText]] », the current Realm Record, constructorParent).
 
-            ctx.exe.add_instruction_with_immediate(
+            ctx.add_instruction_with_immediate(
                 Instruction::ClassDefineDefaultConstructor,
                 has_constructor_parent.into(),
             );
@@ -298,7 +286,7 @@ impl CompileEvaluation for ast::Class<'_> {
 
         // result: F
         // stack: [proto]
-        ctx.exe.add_instruction(Instruction::Load);
+        ctx.add_instruction(Instruction::Load);
         // stack: [constructor, proto]
 
         // Note: These steps have been performed by ClassDefineConstructor or
@@ -313,13 +301,13 @@ impl CompileEvaluation for ast::Class<'_> {
         let mut proto_is_on_top = false;
         let swap_to_proto = |ctx: &mut CompileContext, proto_is_on_top: &mut bool| {
             if !*proto_is_on_top {
-                ctx.exe.add_instruction(Instruction::Swap);
+                ctx.add_instruction(Instruction::Swap);
                 *proto_is_on_top = true;
             }
         };
         let swap_to_constructor = |ctx: &mut CompileContext, proto_is_on_top: &mut bool| {
             if *proto_is_on_top {
-                ctx.exe.add_instruction(Instruction::Swap);
+                ctx.add_instruction(Instruction::Swap);
                 *proto_is_on_top = false;
             }
         };
@@ -394,7 +382,7 @@ impl CompileEvaluation for ast::Class<'_> {
         }
         // Drop proto from stack: It is no longer needed.
         swap_to_proto(ctx, &mut proto_is_on_top);
-        ctx.exe.add_instruction(Instruction::Store);
+        ctx.add_instruction(Instruction::Store);
 
         // stack: [constructor]
 
@@ -410,11 +398,9 @@ impl CompileEvaluation for ast::Class<'_> {
         // class method calls access the classBinding through the classEnv.
         if let Some(class_binding) = class_identifier {
             // a. Perform ! classEnv.InitializeBinding(classBinding, F).
-            ctx.exe.add_instruction(Instruction::StoreCopy);
-            ctx.exe
-                .add_instruction_with_identifier(Instruction::ResolveBinding, class_binding);
-            ctx.exe
-                .add_instruction(Instruction::InitializeReferencedBinding);
+            ctx.add_instruction(Instruction::StoreCopy);
+            ctx.add_instruction_with_identifier(Instruction::ResolveBinding, class_binding);
+            ctx.add_instruction(Instruction::InitializeReferencedBinding);
         }
 
         // 28. Set F.[[PrivateMethods]] to instancePrivateMethods.
@@ -434,8 +420,7 @@ impl CompileEvaluation for ast::Class<'_> {
             //     ii. Return ? result.
         }
         // Note: We finally leave classEnv here. See step 26.
-        ctx.exe
-            .add_instruction(Instruction::ExitDeclarativeEnvironment);
+        ctx.add_instruction(Instruction::ExitDeclarativeEnvironment);
 
         // 32. Set the running execution context's PrivateEnvironment to outerPrivateEnvironment.
         // 33. Return F.
@@ -447,14 +432,12 @@ impl CompileEvaluation for ast::Class<'_> {
             // 4. Let env be the running execution context's LexicalEnvironment.
             // 5. Perform ? InitializeBoundName(className, value, env).
             // => a. Perform ! environment.InitializeBinding(name, value).
-            ctx.exe.add_instruction(Instruction::StoreCopy);
-            ctx.exe
-                .add_instruction_with_identifier(Instruction::ResolveBinding, class_identifier);
-            ctx.exe
-                .add_instruction(Instruction::InitializeReferencedBinding);
+            ctx.add_instruction(Instruction::StoreCopy);
+            ctx.add_instruction_with_identifier(Instruction::ResolveBinding, class_identifier);
+            ctx.add_instruction(Instruction::InitializeReferencedBinding);
         }
 
-        ctx.exe.add_instruction(Instruction::Store);
+        ctx.add_instruction(Instruction::Store);
         // result: constructor
     }
 }
@@ -485,20 +468,19 @@ fn define_constructor_method(
     //     a. Let prototype be %Function.prototype%.
     // 6. Let sourceText be the source text matched by MethodDefinition.
     // 7. Let closure be OrdinaryFunctionCreate(prototype, sourceText, UniqueFormalParameters, FunctionBody, non-lexical-this, env, privateEnv).
-    ctx.exe
-        .add_instruction_with_function_expression_and_immediate(
-            Instruction::ClassDefineConstructor,
-            FunctionExpression {
-                expression: SendableRef::new(unsafe {
-                    std::mem::transmute::<&ast::Function<'_>, &'static ast::Function<'static>>(
-                        &class_element.value,
-                    )
-                }),
-                // CompileContext holds a name identifier for us if this is NamedEvaluation.
-                identifier: None,
-            },
-            has_constructor_parent.into(),
-        );
+    ctx.add_instruction_with_function_expression_and_immediate(
+        Instruction::ClassDefineConstructor,
+        FunctionExpression {
+            expression: SendableRef::new(unsafe {
+                std::mem::transmute::<&ast::Function<'_>, &'static ast::Function<'static>>(
+                    &class_element.value,
+                )
+            }),
+            // CompileContext holds a name identifier for us if this is NamedEvaluation.
+            identifier: None,
+        },
+        has_constructor_parent.into(),
+    );
 
     // result: method
     // stack: [proto]
@@ -517,18 +499,16 @@ fn define_constructor_method(
 fn define_method(class_element: &ast::MethodDefinition, ctx: &mut CompileContext) {
     // 1. Let propKey be ? Evaluation of ClassElementName.
     if let Some(prop_name) = class_element.prop_name() {
-        ctx.exe.add_instruction_with_constant(
-            Instruction::LoadConstant,
-            String::from_str(ctx.agent, prop_name.0),
-        );
+        let prop_name = String::from_str(ctx.agent, prop_name.0);
+        ctx.add_instruction_with_constant(Instruction::LoadConstant, prop_name);
     } else {
         // Computed method name.
         let key = class_element.key.as_expression().unwrap();
         key.compile(ctx);
         if is_reference(key) {
-            ctx.exe.add_instruction(Instruction::GetValue);
+            ctx.add_instruction(Instruction::GetValue);
         }
-        ctx.exe.add_instruction(Instruction::Load);
+        ctx.add_instruction(Instruction::Load);
     };
     // stack: [key, object]
 
@@ -546,21 +526,21 @@ fn define_method(class_element: &ast::MethodDefinition, ctx: &mut CompileContext
         MethodDefinitionKind::Get => Instruction::ObjectDefineGetter,
         MethodDefinitionKind::Set => Instruction::ObjectDefineSetter,
     };
-    ctx.exe
-        .add_instruction_with_function_expression_and_immediate(
-            instruction,
-            FunctionExpression {
-                expression: SendableRef::new(unsafe {
-                    std::mem::transmute::<&ast::Function<'_>, &'static ast::Function<'static>>(
-                        &class_element.value,
-                    )
-                }),
-                // CompileContext holds a name identifier for us if this is NamedEvaluation.
-                identifier: ctx.name_identifier.take(),
-            },
-            // enumerable: false,
-            false.into(),
-        );
+    // CompileContext holds a name identifier for us if this is NamedEvaluation.
+    let identifier = ctx.name_identifier.take();
+    ctx.add_instruction_with_function_expression_and_immediate(
+        instruction,
+        FunctionExpression {
+            expression: SendableRef::new(unsafe {
+                std::mem::transmute::<&ast::Function<'_>, &'static ast::Function<'static>>(
+                    &class_element.value,
+                )
+            }),
+            identifier,
+        },
+        // enumerable: false,
+        false.into(),
+    );
 
     // 8. Perform MakeMethod(closure, object).
     // Note: MakeMethod is performed as part of ObjectDefineMethod.
@@ -597,8 +577,7 @@ impl CompileEvaluation for ast::StaticBlock<'_> {
         // b. Let instantiatedVarNames be a copy of the List parameterBindings.
         let mut instantiated_var_names = AHashSet::new();
         // c. For each element n of varNames, do
-        ctx.exe
-            .add_instruction(Instruction::EnterClassStaticElementEnvironment);
+        ctx.add_instruction(Instruction::EnterClassStaticElementEnvironment);
         for n in class_static_block_var_declared_names(self) {
             // i. If instantiatedVarNames does not contain n, then
             if instantiated_var_names.contains(&n) {
@@ -608,15 +587,11 @@ impl CompileEvaluation for ast::StaticBlock<'_> {
             let n_string = String::from_str(ctx.agent, &n);
             instantiated_var_names.insert(n);
             // 2. Perform ! env.CreateMutableBinding(n, false).
-            ctx.exe
-                .add_instruction_with_identifier(Instruction::CreateMutableBinding, n_string);
+            ctx.add_instruction_with_identifier(Instruction::CreateMutableBinding, n_string);
             // 3. Perform ! env.InitializeBinding(n, undefined).
-            ctx.exe
-                .add_instruction_with_identifier(Instruction::ResolveBinding, n_string);
-            ctx.exe
-                .add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
-            ctx.exe
-                .add_instruction(Instruction::InitializeReferencedBinding);
+            ctx.add_instruction_with_identifier(Instruction::ResolveBinding, n_string);
+            ctx.add_instruction_with_constant(Instruction::StoreConstant, Value::Undefined);
+            ctx.add_instruction(Instruction::InitializeReferencedBinding);
         }
 
         // 34. For each element d of lexDeclarations, do
@@ -630,7 +605,7 @@ impl CompileEvaluation for ast::StaticBlock<'_> {
                         decl.id.bound_names(&mut |identifier| {
                             let dn = String::from_str(ctx.agent, &identifier.name);
                             // 1. Perform ! lexEnv.CreateImmutableBinding(dn, true).
-                            ctx.exe.add_instruction_with_identifier(
+                            ctx.add_instruction_with_identifier(
                                 Instruction::CreateImmutableBinding,
                                 dn,
                             );
@@ -642,24 +617,20 @@ impl CompileEvaluation for ast::StaticBlock<'_> {
                 LexicallyScopedDeclaration::Variable(decl) => {
                     decl.id.bound_names(&mut |identifier| {
                         let dn = String::from_str(ctx.agent, &identifier.name);
-                        ctx.exe
-                            .add_instruction_with_identifier(Instruction::CreateMutableBinding, dn);
+                        ctx.add_instruction_with_identifier(Instruction::CreateMutableBinding, dn);
                     })
                 }
                 LexicallyScopedDeclaration::Function(decl) => {
                     let dn = String::from_str(ctx.agent, &decl.id.as_ref().unwrap().name);
-                    ctx.exe
-                        .add_instruction_with_identifier(Instruction::CreateMutableBinding, dn);
+                    ctx.add_instruction_with_identifier(Instruction::CreateMutableBinding, dn);
                 }
                 LexicallyScopedDeclaration::Class(decl) => {
                     let dn = String::from_str(ctx.agent, &decl.id.as_ref().unwrap().name);
-                    ctx.exe
-                        .add_instruction_with_identifier(Instruction::CreateMutableBinding, dn);
+                    ctx.add_instruction_with_identifier(Instruction::CreateMutableBinding, dn);
                 }
                 LexicallyScopedDeclaration::DefaultExport => {
                     let dn = BUILTIN_STRING_MEMORY._default_;
-                    ctx.exe
-                        .add_instruction_with_identifier(Instruction::CreateMutableBinding, dn);
+                    ctx.add_instruction_with_identifier(Instruction::CreateMutableBinding, dn);
                 }
             }
         }
@@ -672,17 +643,14 @@ impl CompileEvaluation for ast::StaticBlock<'_> {
             let f_name = String::from_str(ctx.agent, &f.id.as_ref().unwrap().name);
             // c. Perform ! varEnv.SetMutableBinding(fn, fo, false).
             // TODO: This compilation is incorrect if !strict, when varEnv != lexEnv.
-            ctx.exe
-                .add_instruction_with_identifier(Instruction::ResolveBinding, f_name);
-            ctx.exe.add_instruction(Instruction::PutValue);
+            ctx.add_instruction_with_identifier(Instruction::ResolveBinding, f_name);
+            ctx.add_instruction(Instruction::PutValue);
         }
 
         for statement in self.body.iter() {
             statement.compile(ctx);
         }
-        ctx.exe
-            .add_instruction(Instruction::ExitDeclarativeEnvironment);
-        ctx.exe
-            .add_instruction(Instruction::ExitVariableEnvironment);
+        ctx.add_instruction(Instruction::ExitDeclarativeEnvironment);
+        ctx.add_instruction(Instruction::ExitVariableEnvironment);
     }
 }

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -130,7 +130,8 @@ impl Vm {
     }
 
     fn fetch_identifier(&self, exe: &Executable, index: usize) -> String {
-        exe.identifiers[index]
+        String::try_from(exe.constants[index])
+            .expect("Invalid identifier index: Value was not a String")
     }
 
     fn fetch_constant(&self, exe: &Executable, index: usize) -> Value {
@@ -157,7 +158,6 @@ impl Vm {
             eprintln!();
             eprintln!("=== Executing Executable ===");
             eprintln!("Constants: {:?}", executable.constants);
-            eprintln!("Identifiers: {:?}", executable.identifiers);
             eprintln!();
 
             eprintln!("Instructions:");

--- a/nova_vm/src/heap/heap_bits.rs
+++ b/nova_vm/src/heap/heap_bits.rs
@@ -757,6 +757,20 @@ where
     }
 }
 
+impl<T> HeapMarkAndSweep for Box<[T]>
+where
+    T: HeapMarkAndSweep,
+{
+    fn mark_values(&self, queues: &mut WorkQueues) {
+        self.iter().for_each(|entry| entry.mark_values(queues));
+    }
+
+    fn sweep_values(&mut self, compactions: &CompactionLists) {
+        self.iter_mut()
+            .for_each(|entry| entry.sweep_values(compactions))
+    }
+}
+
 impl<T> HeapMarkAndSweep for &[T]
 where
     T: HeapMarkAndSweep,


### PR DESCRIPTION
Built ontop of #419, this PR moves the under-construction Executable into `CompileContext` and makes it spit out an `Executable` at the end. This enables `Executable` to only contain boxed slices, reducing its size by one pointer per member. Additionally, the identifiers and constants vectors are combined to a single common boxed slice since both deal with what are effectively `Value`s.

An `Executable` now perfectly fits a cacheline (maybe I should align it to a cacheline as well...?), and it only has the APIs for compiling various ECMAScript sources and getting instructions. Perfect!