### PR TITLE
chore(engine): Move function internal methods into helper fucntions to reduce duplication

### DIFF
--- a/nova_vm/src/ecmascript/builtins/array_buffer.rs
+++ b/nova_vm/src/ecmascript/builtins/array_buffer.rs
@@ -10,8 +10,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData,
-            OrdinaryObject, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
@@ -169,19 +168,8 @@ impl InternalSlots for ArrayBuffer {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -11,9 +11,12 @@ use crate::{
             RealmIdentifier,
         },
         types::{
-            BuiltinFunctionHeapData, Function, InternalMethods, InternalSlots, IntoFunction,
-            IntoObject, IntoValue, Object, ObjectHeapData, PropertyDescriptor, PropertyKey, String,
-            Value, BUILTIN_STRING_MEMORY,
+            function_create_backing_object, function_internal_define_own_property,
+            function_internal_delete, function_internal_get, function_internal_get_own_property,
+            function_internal_has_property, function_internal_own_property_keys,
+            function_internal_set, BuiltinFunctionHeapData, Function, FunctionInternalProperties,
+            InternalMethods, InternalSlots, IntoFunction, IntoObject, IntoValue, Object,
+            OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value, BUILTIN_STRING_MEMORY,
         },
     },
     heap::{
@@ -200,52 +203,30 @@ impl IndexMut<BuiltinFunction> for Vec<Option<BuiltinFunctionHeapData>> {
     }
 }
 
+impl FunctionInternalProperties for BuiltinFunction {
+    fn get_name(self, agent: &Agent) -> String {
+        agent[self].initial_name.unwrap_or(String::EMPTY_STRING)
+    }
+
+    fn get_length(self, agent: &Agent) -> u8 {
+        agent[self].length
+    }
+}
+
 impl InternalSlots for BuiltinFunction {
     const DEFAULT_PROTOTYPE: ProtoIntrinsics = ProtoIntrinsics::Function;
 
     #[inline(always)]
-    fn get_backing_object(self, agent: &Agent) -> Option<crate::ecmascript::types::OrdinaryObject> {
+    fn get_backing_object(self, agent: &Agent) -> Option<OrdinaryObject> {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let length_entry = ObjectEntry {
-            key: PropertyKey::from(BUILTIN_STRING_MEMORY.length),
-            value: ObjectEntryPropertyDescriptor::Data {
-                value: agent[self].length.into(),
-                writable: false,
-                enumerable: false,
-                configurable: true,
-            },
-        };
-        let name_entry = ObjectEntry {
-            key: PropertyKey::from(BUILTIN_STRING_MEMORY.name),
-            value: ObjectEntryPropertyDescriptor::Data {
-                value: agent[self]
-                    .initial_name
-                    .unwrap_or(String::EMPTY_STRING)
-                    .into_value(),
-                writable: false,
-                enumerable: false,
-                configurable: true,
-            },
-        };
-        let (keys, values) = agent
-            .heap
-            .elements
-            .create_object_entries(&[length_entry, name_entry]);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys,
-            values,
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
+    }
+
+    fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject {
+        function_create_backing_object(self, agent)
     }
 }
 
@@ -255,27 +236,7 @@ impl InternalMethods for BuiltinFunction {
         agent: &mut Agent,
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
-        if let Some(object_index) = self.get_backing_object(agent) {
-            object_index.internal_get_own_property(agent, property_key)
-        } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
-            Ok(Some(PropertyDescriptor {
-                value: Some(agent[self].length.into()),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                ..Default::default()
-            }))
-        } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name) {
-            Ok(Some(PropertyDescriptor {
-                value: Some(agent[self].initial_name.into()),
-                writable: Some(false),
-                enumerable: Some(false),
-                configurable: Some(true),
-                ..Default::default()
-            }))
-        } else {
-            Ok(None)
-        }
+        function_internal_get_own_property(self, agent, property_key)
     }
 
     fn internal_define_own_property(
@@ -284,102 +245,11 @@ impl InternalMethods for BuiltinFunction {
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
-        if let Some(object_index) = self.get_backing_object(agent) {
-            object_index.internal_define_own_property(agent, property_key, property_descriptor)
-        } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
-            let prototype = agent
-                .current_realm()
-                .intrinsics()
-                .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-            let length_entry = ObjectEntry {
-                key: property_key,
-                value: ObjectEntryPropertyDescriptor::from(property_descriptor),
-            };
-            let name_entry = ObjectEntry {
-                key: PropertyKey::from(BUILTIN_STRING_MEMORY.name),
-                value: ObjectEntryPropertyDescriptor::Data {
-                    value: agent[self].initial_name.unwrap().into_value(),
-                    writable: false,
-                    enumerable: false,
-                    configurable: true,
-                },
-            };
-            let object_index = agent
-                .heap
-                .create_object_with_prototype(prototype, &[length_entry, name_entry]);
-            agent[self].object_index = Some(object_index);
-            Ok(true)
-        } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name) {
-            let prototype = agent
-                .current_realm()
-                .intrinsics()
-                .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-            let length_entry = ObjectEntry {
-                key: PropertyKey::from(BUILTIN_STRING_MEMORY.length),
-                value: ObjectEntryPropertyDescriptor::Data {
-                    value: agent[self].length.into(),
-                    writable: false,
-                    enumerable: false,
-                    configurable: true,
-                },
-            };
-            let name_entry = ObjectEntry {
-                key: property_key,
-                value: ObjectEntryPropertyDescriptor::from(property_descriptor),
-            };
-            let object_index = agent
-                .heap
-                .create_object_with_prototype(prototype, &[length_entry, name_entry]);
-            agent[self].object_index = Some(object_index);
-            Ok(true)
-        } else {
-            let prototype = agent
-                .current_realm()
-                .intrinsics()
-                .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-            let length_entry = ObjectEntry {
-                key: PropertyKey::from(BUILTIN_STRING_MEMORY.length),
-                value: ObjectEntryPropertyDescriptor::Data {
-                    value: agent[self].length.into(),
-                    writable: false,
-                    enumerable: false,
-                    configurable: true,
-                },
-            };
-            let name_entry = ObjectEntry {
-                key: PropertyKey::from(BUILTIN_STRING_MEMORY.name),
-                value: ObjectEntryPropertyDescriptor::Data {
-                    value: agent[self].initial_name.unwrap().into_value(),
-                    writable: false,
-                    enumerable: false,
-                    configurable: true,
-                },
-            };
-            let other_entry = ObjectEntry {
-                key: property_key,
-                value: ObjectEntryPropertyDescriptor::from(property_descriptor),
-            };
-            let object_index = agent
-                .heap
-                .create_object_with_prototype(prototype, &[length_entry, name_entry, other_entry]);
-            agent[self].object_index = Some(object_index);
-            Ok(true)
-        }
+        function_internal_define_own_property(self, agent, property_key, property_descriptor)
     }
 
     fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
-        if let Some(object_index) = self.get_backing_object(agent) {
-            object_index.internal_has_property(agent, property_key)
-        } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length)
-            || property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name)
-        {
-            Ok(true)
-        } else {
-            let parent = self.internal_get_prototype_of(agent)?;
-            parent.map_or(Ok(false), |parent| {
-                parent.internal_has_property(agent, property_key)
-            })
-        }
+        function_internal_has_property(self, agent, property_key)
     }
 
     fn internal_get(
@@ -388,18 +258,7 @@ impl InternalMethods for BuiltinFunction {
         property_key: PropertyKey,
         receiver: Value,
     ) -> JsResult<Value> {
-        if let Some(object_index) = self.get_backing_object(agent) {
-            object_index.internal_get(agent, property_key, receiver)
-        } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
-            Ok(agent[self].length.into())
-        } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name) {
-            Ok(agent[self].initial_name.into())
-        } else {
-            let parent = self.internal_get_prototype_of(agent)?;
-            parent.map_or(Ok(Value::Undefined), |parent| {
-                parent.internal_get(agent, property_key, receiver)
-            })
-        }
+        function_internal_get(self, agent, property_key, receiver)
     }
 
     fn internal_set(
@@ -409,42 +268,15 @@ impl InternalMethods for BuiltinFunction {
         value: Value,
         receiver: Value,
     ) -> JsResult<bool> {
-        if let Some(backing_object) = self.get_backing_object(agent) {
-            backing_object.internal_set(agent, property_key, value, receiver)
-        } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length)
-            || property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name)
-        {
-            // length and name are not writable
-            Ok(false)
-        } else {
-            self.create_backing_object(agent)
-                .internal_set(agent, property_key, value, receiver)
-        }
+        function_internal_set(self, agent, property_key, value, receiver)
     }
 
     fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
-        if let Some(object_index) = self.get_backing_object(agent) {
-            object_index.internal_delete(agent, property_key)
-        } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length)
-            || property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name)
-        {
-            let object_index = self.create_backing_object(agent);
-            object_index.internal_delete(agent, property_key)
-        } else {
-            // Non-existing property
-            Ok(true)
-        }
+        function_internal_delete(self, agent, property_key)
     }
 
     fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
-        if let Some(object_index) = self.get_backing_object(agent) {
-            object_index.internal_own_property_keys(agent)
-        } else {
-            Ok(vec![
-                PropertyKey::from(BUILTIN_STRING_MEMORY.length),
-                PropertyKey::from(BUILTIN_STRING_MEMORY.name),
-            ])
-        }
+        function_internal_own_property_keys(self, agent)
     }
 
     /// ### [10.3.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist)

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_objects.rs
@@ -12,8 +12,7 @@ use crate::{
             Agent, ExecutionContext, JsResult, ProtoIntrinsics,
         },
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData,
-            OrdinaryObject, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     engine::{Executable, ExecutionResult, Vm},
@@ -272,19 +271,8 @@ impl InternalSlots for Generator {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/data_view.rs
+++ b/nova_vm/src/ecmascript/builtins/data_view.rs
@@ -8,7 +8,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{indexes::DataViewIndex, CreateHeapData, Heap, HeapMarkAndSweep},
@@ -100,23 +100,12 @@ impl InternalSlots for DataView {
     const DEFAULT_PROTOTYPE: ProtoIntrinsics = ProtoIntrinsics::DataView;
 
     #[inline(always)]
-    fn get_backing_object(self, agent: &Agent) -> Option<crate::ecmascript::types::OrdinaryObject> {
+    fn get_backing_object(self, agent: &Agent) -> Option<OrdinaryObject> {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/date.rs
+++ b/nova_vm/src/ecmascript/builtins/date.rs
@@ -10,7 +10,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
@@ -84,23 +84,12 @@ impl InternalSlots for Date {
     const DEFAULT_PROTOTYPE: ProtoIntrinsics = ProtoIntrinsics::Date;
 
     #[inline(always)]
-    fn get_backing_object(self, agent: &Agent) -> Option<crate::ecmascript::types::OrdinaryObject> {
+    fn get_backing_object(self, agent: &Agent) -> Option<OrdinaryObject> {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/embedder_object.rs
+++ b/nova_vm/src/ecmascript/builtins/embedder_object.rs
@@ -8,8 +8,8 @@ use crate::{
     ecmascript::{
         execution::{Agent, JsResult},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, PropertyDescriptor,
-            PropertyKey, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject,
+            PropertyDescriptor, PropertyKey, Value,
         },
     },
     heap::{
@@ -74,14 +74,15 @@ impl From<EmbedderObject> for Object {
 
 impl InternalSlots for EmbedderObject {
     #[inline(always)]
-    fn get_backing_object(
-        self,
-        _agent: &Agent,
-    ) -> Option<crate::ecmascript::types::OrdinaryObject> {
+    fn get_backing_object(self, _agent: &Agent) -> Option<OrdinaryObject> {
         todo!();
     }
 
-    fn create_backing_object(self, _agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
+    fn set_backing_object(self, _agent: &mut Agent, _backing_object: OrdinaryObject) {
+        todo!();
+    }
+
+    fn create_backing_object(self, _agent: &mut Agent) -> OrdinaryObject {
         todo!();
     }
     fn internal_extensible(self, _agent: &Agent) -> bool {

--- a/nova_vm/src/ecmascript/builtins/finalization_registry.rs
+++ b/nova_vm/src/ecmascript/builtins/finalization_registry.rs
@@ -8,7 +8,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
@@ -75,23 +75,12 @@ impl InternalSlots for FinalizationRegistry {
     const DEFAULT_PROTOTYPE: ProtoIntrinsics = ProtoIntrinsics::FinalizationRegistry;
 
     #[inline(always)]
-    fn get_backing_object(self, agent: &Agent) -> Option<crate::ecmascript::types::OrdinaryObject> {
+    fn get_backing_object(self, agent: &Agent) -> Option<OrdinaryObject> {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_iterator_objects/array_iterator.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_iterator_objects/array_iterator.rs
@@ -8,8 +8,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData,
-            OrdinaryObject, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
@@ -105,19 +104,8 @@ impl InternalSlots for ArrayIterator {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_iterator_objects/map_iterator.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_iterator_objects/map_iterator.rs
@@ -12,8 +12,7 @@ use crate::{
         },
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData,
-            OrdinaryObject, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
@@ -105,19 +104,8 @@ impl InternalSlots for MapIterator {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_iterator_objects/set_iterator.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_iterator_objects/set_iterator.rs
@@ -12,8 +12,7 @@ use crate::{
         },
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData,
-            OrdinaryObject, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
@@ -105,19 +104,8 @@ impl InternalSlots for SetIterator {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/map.rs
+++ b/nova_vm/src/ecmascript/builtins/map.rs
@@ -105,6 +105,10 @@ impl InternalSlots for Map {
         agent[self].object_index
     }
 
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
+    }
+
     fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
         let prototype = agent
             .current_realm()
@@ -116,7 +120,7 @@ impl InternalSlots for Map {
             keys: Default::default(),
             values: Default::default(),
         });
-        agent[self].object_index = Some(backing_object);
+        self.set_backing_object(agent, backing_object);
         backing_object
     }
 }

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -11,8 +11,8 @@ use crate::{
         execution::{agent::ExceptionType, Agent, JsResult},
         scripts_and_modules::module::ModuleIdentifier,
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, PropertyDescriptor,
-            PropertyKey, String, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject,
+            PropertyDescriptor, PropertyKey, String, Value,
         },
     },
     heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
@@ -112,11 +112,15 @@ impl Module {
 
 impl InternalSlots for Module {
     #[inline(always)]
-    fn get_backing_object(self, agent: &Agent) -> Option<crate::ecmascript::types::OrdinaryObject> {
+    fn get_backing_object(self, agent: &Agent) -> Option<OrdinaryObject> {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, _: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
+    }
+
+    fn create_backing_object(self, _: &mut Agent) -> OrdinaryObject {
         unreachable!();
     }
 

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -14,11 +14,10 @@ use crate::{
         types::{
             bigint::{HeapBigInt, SmallBigInt},
             BigInt, HeapNumber, HeapString, InternalMethods, InternalSlots, IntoObject, IntoValue,
-            Number, Object, ObjectHeapData, OrdinaryObject, PropertyDescriptor, PropertyKey,
-            String, Symbol, Value, BIGINT_DISCRIMINANT, BOOLEAN_DISCRIMINANT,
-            BUILTIN_STRING_MEMORY, FLOAT_DISCRIMINANT, INTEGER_DISCRIMINANT, NUMBER_DISCRIMINANT,
-            SMALL_BIGINT_DISCRIMINANT, SMALL_STRING_DISCRIMINANT, STRING_DISCRIMINANT,
-            SYMBOL_DISCRIMINANT,
+            Number, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Symbol, Value,
+            BIGINT_DISCRIMINANT, BOOLEAN_DISCRIMINANT, BUILTIN_STRING_MEMORY, FLOAT_DISCRIMINANT,
+            INTEGER_DISCRIMINANT, NUMBER_DISCRIMINANT, SMALL_BIGINT_DISCRIMINANT,
+            SMALL_STRING_DISCRIMINANT, STRING_DISCRIMINANT, SYMBOL_DISCRIMINANT,
         },
     },
     engine::small_f64::SmallF64,
@@ -165,6 +164,10 @@ impl InternalSlots for PrimitiveObject {
         agent[self].object_index
     }
 
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
+    }
+
     fn internal_prototype(
         self,
         agent: &crate::ecmascript::execution::Agent,
@@ -195,19 +198,6 @@ impl InternalSlots for PrimitiveObject {
                 )
             }
         }
-    }
-
-    fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject {
-        debug_assert!(self.get_backing_object(agent).is_none());
-        let prototype = self.internal_prototype(agent).unwrap();
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/promise.rs
+++ b/nova_vm/src/ecmascript/builtins/promise.rs
@@ -8,7 +8,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
@@ -95,23 +95,12 @@ impl InternalSlots for Promise {
     const DEFAULT_PROTOTYPE: ProtoIntrinsics = ProtoIntrinsics::Promise;
 
     #[inline(always)]
-    fn get_backing_object(self, agent: &Agent) -> Option<crate::ecmascript::types::OrdinaryObject> {
+    fn get_backing_object(self, agent: &Agent) -> Option<OrdinaryObject> {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -8,8 +8,8 @@ use crate::{
     ecmascript::{
         execution::{Agent, JsResult},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, PropertyDescriptor,
-            PropertyKey, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject,
+            PropertyDescriptor, PropertyKey, Value,
         },
     },
     heap::{
@@ -74,14 +74,15 @@ impl From<Proxy> for Object {
 
 impl InternalSlots for Proxy {
     #[inline(always)]
-    fn get_backing_object(
-        self,
-        _agent: &Agent,
-    ) -> Option<crate::ecmascript::types::OrdinaryObject> {
+    fn get_backing_object(self, _agent: &Agent) -> Option<OrdinaryObject> {
         todo!()
     }
 
-    fn create_backing_object(self, _agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
+    fn set_backing_object(self, _agent: &mut Agent, _backing_object: OrdinaryObject) {
+        todo!()
+    }
+
+    fn create_backing_object(self, _agent: &mut Agent) -> OrdinaryObject {
         todo!()
     }
 

--- a/nova_vm/src/ecmascript/builtins/regexp.rs
+++ b/nova_vm/src/ecmascript/builtins/regexp.rs
@@ -11,8 +11,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData,
-            OrdinaryObject, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
@@ -90,19 +89,8 @@ impl InternalSlots for RegExp {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/set.rs
+++ b/nova_vm/src/ecmascript/builtins/set.rs
@@ -119,6 +119,10 @@ impl InternalSlots for Set {
         agent[self].object_index
     }
 
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
+    }
+
     fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
         let prototype = agent
             .current_realm()
@@ -130,7 +134,7 @@ impl InternalSlots for Set {
             keys: Default::default(),
             values: Default::default(),
         });
-        agent[self].object_index = Some(backing_object);
+        self.set_backing_object(agent, backing_object);
         backing_object
     }
 }

--- a/nova_vm/src/ecmascript/builtins/shared_array_buffer.rs
+++ b/nova_vm/src/ecmascript/builtins/shared_array_buffer.rs
@@ -8,7 +8,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
@@ -109,24 +109,12 @@ impl InternalSlots for SharedArrayBuffer {
     const DEFAULT_PROTOTYPE: ProtoIntrinsics = ProtoIntrinsics::SharedArrayBuffer;
 
     #[inline(always)]
-    fn get_backing_object(self, agent: &Agent) -> Option<crate::ecmascript::types::OrdinaryObject> {
+    fn get_backing_object(self, agent: &Agent) -> Option<OrdinaryObject> {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
-        debug_assert!(self.get_backing_object(agent).is_none());
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/weak_map.rs
+++ b/nova_vm/src/ecmascript/builtins/weak_map.rs
@@ -8,7 +8,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
@@ -76,24 +76,12 @@ impl InternalSlots for WeakMap {
     const DEFAULT_PROTOTYPE: ProtoIntrinsics = ProtoIntrinsics::WeakMap;
 
     #[inline(always)]
-    fn get_backing_object(self, agent: &Agent) -> Option<crate::ecmascript::types::OrdinaryObject> {
+    fn get_backing_object(self, agent: &Agent) -> Option<OrdinaryObject> {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
-        debug_assert!(self.get_backing_object(agent).is_none());
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/weak_ref.rs
+++ b/nova_vm/src/ecmascript/builtins/weak_ref.rs
@@ -8,7 +8,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
@@ -75,24 +75,12 @@ impl InternalSlots for WeakRef {
     const DEFAULT_PROTOTYPE: ProtoIntrinsics = ProtoIntrinsics::WeakRef;
 
     #[inline(always)]
-    fn get_backing_object(self, agent: &Agent) -> Option<crate::ecmascript::types::OrdinaryObject> {
+    fn get_backing_object(self, agent: &Agent) -> Option<OrdinaryObject> {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
-        debug_assert!(self.get_backing_object(agent).is_none());
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/weak_set.rs
+++ b/nova_vm/src/ecmascript/builtins/weak_set.rs
@@ -8,7 +8,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
@@ -76,24 +76,12 @@ impl InternalSlots for WeakSet {
     const DEFAULT_PROTOTYPE: ProtoIntrinsics = ProtoIntrinsics::WeakSet;
 
     #[inline(always)]
-    fn get_backing_object(self, agent: &Agent) -> Option<crate::ecmascript::types::OrdinaryObject> {
+    fn get_backing_object(self, agent: &Agent) -> Option<OrdinaryObject> {
         agent[self].object_index
     }
 
-    fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
-        debug_assert!(self.get_backing_object(agent).is_none());
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        agent[self].object_index = Some(backing_object);
-        backing_object
+    fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
+        assert!(agent[self].object_index.replace(backing_object).is_none());
     }
 }
 

--- a/nova_vm/src/ecmascript/types/language.rs
+++ b/nova_vm/src/ecmascript/types/language.rs
@@ -18,7 +18,11 @@ mod value;
 
 pub use bigint::{BigInt, BigIntHeapData};
 pub(crate) use function::{
+    function_create_backing_object, function_internal_define_own_property,
+    function_internal_delete, function_internal_get, function_internal_get_own_property,
+    function_internal_has_property, function_internal_own_property_keys, function_internal_set,
     BoundFunctionHeapData, BuiltinFunctionHeapData, ECMAScriptFunctionHeapData,
+    FunctionInternalProperties,
 };
 pub use function::{Function, IntoFunction};
 pub use global_value::Global;

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -27,6 +27,12 @@ use crate::{
 
 pub(crate) use data::*;
 pub use into_function::IntoFunction;
+pub(crate) use into_function::{
+    function_create_backing_object, function_internal_define_own_property,
+    function_internal_delete, function_internal_get, function_internal_get_own_property,
+    function_internal_has_property, function_internal_own_property_keys, function_internal_set,
+    FunctionInternalProperties,
+};
 
 /// https://tc39.es/ecma262/#function-object
 #[derive(Clone, Copy, PartialEq)]
@@ -183,6 +189,10 @@ impl InternalSlots for Function {
 
     fn create_backing_object(self, _: &mut Agent) -> OrdinaryObject {
         unreachable!("Function should not try to create backing object");
+    }
+
+    fn set_backing_object(self, _agent: &mut Agent, _backing_object: OrdinaryObject) {
+        unreachable!("Function should not try to set backing object");
     }
 
     #[inline(always)]

--- a/nova_vm/src/ecmascript/types/language/function/into_function.rs
+++ b/nova_vm/src/ecmascript/types/language/function/into_function.rs
@@ -3,11 +3,202 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::Function;
-use crate::ecmascript::types::language::IntoObject;
+use crate::{
+    ecmascript::{
+        execution::{Agent, JsResult},
+        types::{
+            language::IntoObject, InternalMethods, InternalSlots, ObjectHeapData, OrdinaryObject,
+            PropertyDescriptor, PropertyKey, String, Value, BUILTIN_STRING_MEMORY,
+        },
+    },
+    heap::{CreateHeapData, ObjectEntry, ObjectEntryPropertyDescriptor},
+};
 
 pub trait IntoFunction
 where
     Self: Sized + Copy + IntoObject,
 {
     fn into_function(self) -> Function;
+}
+
+/// Implements getters for the properties normally present on most objects.
+/// These are used when the function hasn't had a backing object created.
+pub(crate) trait FunctionInternalProperties
+where
+    Self: IntoObject + IntoFunction + InternalSlots + InternalMethods,
+{
+    /// Value of the 'name' property.
+    fn get_name(self, agent: &Agent) -> String;
+
+    /// Value of the 'length' property.
+    fn get_length(self, agent: &Agent) -> u8;
+}
+
+pub(crate) fn function_create_backing_object(
+    func: impl FunctionInternalProperties,
+    agent: &mut Agent,
+) -> OrdinaryObject {
+    assert!(func.get_backing_object(agent).is_none());
+    let prototype = func.internal_prototype(agent);
+    let length_entry = ObjectEntry {
+        key: PropertyKey::from(BUILTIN_STRING_MEMORY.length),
+        value: ObjectEntryPropertyDescriptor::Data {
+            value: func.get_length(agent).into(),
+            writable: false,
+            enumerable: false,
+            configurable: true,
+        },
+    };
+    let name_entry = ObjectEntry {
+        key: PropertyKey::from(BUILTIN_STRING_MEMORY.name),
+        value: ObjectEntryPropertyDescriptor::Data {
+            value: func.get_name(agent).into_value(),
+            writable: false,
+            enumerable: false,
+            configurable: true,
+        },
+    };
+    let (keys, values) = agent
+        .heap
+        .elements
+        .create_object_entries(&[length_entry, name_entry]);
+    let backing_object = agent.heap.create(ObjectHeapData {
+        extensible: true,
+        prototype,
+        keys,
+        values,
+    });
+    func.set_backing_object(agent, backing_object);
+    backing_object
+}
+
+pub(crate) fn function_internal_get_own_property(
+    func: impl FunctionInternalProperties,
+    agent: &mut Agent,
+    property_key: PropertyKey,
+) -> JsResult<Option<PropertyDescriptor>> {
+    if let Some(backing_object) = func.get_backing_object(agent) {
+        backing_object.internal_get_own_property(agent, property_key)
+    } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
+        Ok(Some(PropertyDescriptor {
+            value: Some(func.get_length(agent).into()),
+            writable: Some(false),
+            enumerable: Some(false),
+            configurable: Some(true),
+            ..Default::default()
+        }))
+    } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name) {
+        Ok(Some(PropertyDescriptor {
+            value: Some(func.get_name(agent).into_value()),
+            writable: Some(false),
+            enumerable: Some(false),
+            configurable: Some(true),
+            ..Default::default()
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+pub(crate) fn function_internal_define_own_property(
+    func: impl FunctionInternalProperties,
+    agent: &mut Agent,
+    property_key: PropertyKey,
+    property_descriptor: PropertyDescriptor,
+) -> JsResult<bool> {
+    let backing_object = func
+        .get_backing_object(agent)
+        .unwrap_or_else(|| func.create_backing_object(agent));
+    backing_object.internal_define_own_property(agent, property_key, property_descriptor)
+}
+
+pub(crate) fn function_internal_has_property(
+    func: impl FunctionInternalProperties,
+    agent: &mut Agent,
+    property_key: PropertyKey,
+) -> JsResult<bool> {
+    if let Some(backing_object) = func.get_backing_object(agent) {
+        backing_object.internal_has_property(agent, property_key)
+    } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length)
+        || property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name)
+    {
+        Ok(true)
+    } else {
+        let parent = func.internal_get_prototype_of(agent)?;
+        parent.map_or(Ok(false), |parent| {
+            parent.internal_has_property(agent, property_key)
+        })
+    }
+}
+
+pub(crate) fn function_internal_get(
+    func: impl FunctionInternalProperties,
+    agent: &mut Agent,
+    property_key: PropertyKey,
+    receiver: Value,
+) -> JsResult<Value> {
+    if let Some(backing_object) = func.get_backing_object(agent) {
+        backing_object.internal_get(agent, property_key, receiver)
+    } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
+        Ok(func.get_length(agent).into())
+    } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name) {
+        Ok(func.get_name(agent).into_value())
+    } else {
+        let parent = func.internal_get_prototype_of(agent)?;
+        parent.map_or(Ok(Value::Undefined), |parent| {
+            parent.internal_get(agent, property_key, receiver)
+        })
+    }
+}
+
+pub(crate) fn function_internal_set(
+    func: impl FunctionInternalProperties,
+    agent: &mut Agent,
+    property_key: PropertyKey,
+    value: Value,
+    receiver: Value,
+) -> JsResult<bool> {
+    if let Some(backing_object) = func.get_backing_object(agent) {
+        backing_object.internal_set(agent, property_key, value, receiver)
+    } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length)
+        || property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name)
+    {
+        // length and name are not writable
+        Ok(false)
+    } else {
+        func.create_backing_object(agent)
+            .internal_set(agent, property_key, value, receiver)
+    }
+}
+
+pub(crate) fn function_internal_delete(
+    func: impl FunctionInternalProperties,
+    agent: &mut Agent,
+    property_key: PropertyKey,
+) -> JsResult<bool> {
+    if let Some(backing_object) = func.get_backing_object(agent) {
+        backing_object.internal_delete(agent, property_key)
+    } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length)
+        || property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name)
+    {
+        let backing_object = func.create_backing_object(agent);
+        backing_object.internal_delete(agent, property_key)
+    } else {
+        // Non-existing property
+        Ok(true)
+    }
+}
+
+pub(crate) fn function_internal_own_property_keys(
+    func: impl FunctionInternalProperties,
+    agent: &mut Agent,
+) -> JsResult<Vec<PropertyKey>> {
+    if let Some(backing_object) = func.get_backing_object(agent) {
+        backing_object.internal_own_property_keys(agent)
+    } else {
+        Ok(vec![
+            PropertyKey::from(BUILTIN_STRING_MEMORY.length),
+            PropertyKey::from(BUILTIN_STRING_MEMORY.name),
+        ])
+    }
 }

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -259,6 +259,10 @@ impl InternalSlots for OrdinaryObject {
         Some(self)
     }
 
+    fn set_backing_object(self, _agent: &mut Agent, _backing_object: OrdinaryObject) {
+        unreachable!();
+    }
+
     fn create_backing_object(self, _: &mut Agent) -> OrdinaryObject {
         unreachable!();
     }
@@ -500,6 +504,10 @@ impl Hash for Object {
 impl InternalSlots for Object {
     fn get_backing_object(self, _: &Agent) -> Option<OrdinaryObject> {
         unreachable!("Object should not try to access its backing object");
+    }
+
+    fn set_backing_object(self, _agent: &mut Agent, _backing_object: OrdinaryObject) {
+        unreachable!("Object should not try to create its backing object");
     }
 
     fn create_backing_object(self, _: &mut Agent) -> OrdinaryObject {


### PR DESCRIPTION
Just some cleanup in preparation for class constructor heap vectors. Those will require creating more Function variants, but we don't want to keep copying their basic code all over the place.