### PR TITLE
feat(engine): GcScope

### DIFF
--- a/nova_vm/src/ecmascript/abstract_operations/operations_on_objects.rs
+++ b/nova_vm/src/ecmascript/abstract_operations/operations_on_objects.rs
@@ -11,6 +11,7 @@ use super::{
     testing_and_comparison::{is_callable, require_object_coercible, same_value},
     type_conversion::{to_length, to_object, to_property_key},
 };
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::operations_on_iterator_objects::iterator_step_value,
@@ -67,9 +68,15 @@ pub(crate) fn make_basic_object(_agent: &mut Agent, _internal_slots_list: ()) ->
 /// key) and returns either a normal completion containing an ECMAScript
 /// language value or a throw completion. It is used to retrieve the value of a
 /// specific property of an object.
-pub(crate) fn get(agent: &mut Agent, o: impl IntoObject, p: PropertyKey) -> JsResult<Value> {
+pub(crate) fn get(
+    agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
+    o: impl IntoObject,
+    p: PropertyKey,
+) -> JsResult<Value> {
     // 1. Return ? O.[[Get]](P, O).
-    o.into_object().internal_get(agent, p, o.into_value())
+    o.into_object().internal_get(agent, gc, p, o.into_value())
 }
 
 /// ### [7.3.3 GetV ( V, P )](https://tc39.es/ecma262/#sec-getv)
@@ -80,11 +87,17 @@ pub(crate) fn get(agent: &mut Agent, o: impl IntoObject, p: PropertyKey) -> JsRe
 /// to retrieve the value of a specific property of an ECMAScript language
 /// value. If the value is not an object, the property lookup is performed
 /// using a wrapper object appropriate for the type of the value.
-pub(crate) fn get_v(agent: &mut Agent, v: Value, p: PropertyKey) -> JsResult<Value> {
+pub(crate) fn get_v(
+    agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
+    v: Value,
+    p: PropertyKey,
+) -> JsResult<Value> {
     // 1. Let O be ? ToObject(V).
     let o = to_object(agent, v)?;
     // 2. Return ? O.[[Get]](P, V).
-    o.internal_get(agent, p, o.into())
+    o.internal_get(agent, gc, p, o.into())
 }
 
 /// ### [7.3.4 Set ( O, P, V, Throw )](https://tc39.es/ecma262/#sec-set-o-p-v-throw)
@@ -96,13 +109,15 @@ pub(crate) fn get_v(agent: &mut Agent, v: Value, p: PropertyKey) -> JsResult<Val
 /// value for the property.
 pub(crate) fn set(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     o: Object,
     p: PropertyKey,
     v: Value,
     throw: bool,
 ) -> JsResult<()> {
     // 1. Let success be ? O.[[Set]](P, V, O).
-    let success = o.internal_set(agent, p, v, o.into_value())?;
+    let success = o.internal_set(agent, gc, p, v, o.into_value())?;
     // 2. If success is false and Throw is true, throw a TypeError exception.
     if !success && throw {
         return Err(agent.throw_exception(
@@ -128,6 +143,8 @@ pub(crate) fn set(
 /// > [\[DefineOwnProperty]] will return false.
 pub(crate) fn create_data_property(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     object: impl InternalMethods,
     property_key: PropertyKey,
     value: Value,
@@ -142,7 +159,7 @@ pub(crate) fn create_data_property(
         configurable: Some(true),
     };
     // 2. Return ? O.[[DefineOwnProperty]](P, newDesc).
-    object.internal_define_own_property(agent, property_key, new_desc)
+    object.internal_define_own_property(agent, gc, property_key, new_desc)
 }
 
 /// ### [7.3.7 CreateDataPropertyOrThrow ( O, P, V )](https://tc39.es/ecma262/#sec-createdatapropertyorthrow)
@@ -154,11 +171,13 @@ pub(crate) fn create_data_property(
 /// exception if the requested property update cannot be performed.
 pub(crate) fn create_data_property_or_throw(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     object: impl InternalMethods,
     property_key: PropertyKey,
     value: Value,
 ) -> JsResult<()> {
-    let success = create_data_property(agent, object, property_key, value)?;
+    let success = create_data_property(agent, gc, object, property_key, value)?;
     if !success {
         Err(agent.throw_exception(
             ExceptionType::TypeError,
@@ -182,12 +201,14 @@ pub(crate) fn create_data_property_or_throw(
 /// cannot be performed.
 pub(crate) fn define_property_or_throw(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     object: impl InternalMethods,
     property_key: PropertyKey,
     desc: PropertyDescriptor,
 ) -> JsResult<()> {
     // 1. Let success be ? O.[[DefineOwnProperty]](P, desc).
-    let success = object.internal_define_own_property(agent, property_key, desc)?;
+    let success = object.internal_define_own_property(agent, gc, property_key, desc)?;
     // 2. If success is false, throw a TypeError exception.
     if !success {
         Err(agent.throw_exception_with_static_message(
@@ -208,11 +229,13 @@ pub(crate) fn define_property_or_throw(
 /// of an object. It throws an exception if the property is not configurable.
 pub(crate) fn delete_property_or_throw(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     o: Object,
     p: PropertyKey,
 ) -> JsResult<()> {
     // 1. Let success be ? O.[[Delete]](P).
-    let success = o.internal_delete(agent, p)?;
+    let success = o.internal_delete(agent, gc, p)?;
     // 2. If success is false, throw a TypeError exception.
     if !success {
         Err(agent.throw_exception_with_static_message(
@@ -235,11 +258,13 @@ pub(crate) fn delete_property_or_throw(
 
 pub(crate) fn get_method(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     v: Value,
     p: PropertyKey,
 ) -> JsResult<Option<Function>> {
     // 1. Let func be ? GetV(V, P).
-    let func = get_v(agent, v, p)?;
+    let func = get_v(agent, gc, v, p)?;
     // 2. If func is either undefined or null, return undefined.
     if func.is_undefined() || func.is_null() {
         return Ok(None);
@@ -263,9 +288,15 @@ pub(crate) fn get_method(
 /// or a throw completion. It is used to determine whether an object has a
 /// property with the specified property key. The property may be either own or
 /// inherited.
-pub(crate) fn has_property(agent: &mut Agent, o: Object, p: PropertyKey) -> JsResult<bool> {
+pub(crate) fn has_property(
+    agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
+    o: Object,
+    p: PropertyKey,
+) -> JsResult<bool> {
     // 1. Return ? O.[[HasProperty]](P).
-    o.internal_has_property(agent, p)
+    o.internal_has_property(agent, gc, p)
 }
 
 /// ### [7.3.13 HasOwnProperty ( O, P )](https://tc39.es/ecma262/#sec-hasownproperty)
@@ -274,9 +305,15 @@ pub(crate) fn has_property(agent: &mut Agent, o: Object, p: PropertyKey) -> JsRe
 /// (a property key) and returns either a normal completion containing a
 /// Boolean or a throw completion. It is used to determine whether an object
 /// has an own property with the specified property key.
-pub(crate) fn has_own_property(agent: &mut Agent, o: Object, p: PropertyKey) -> JsResult<bool> {
+pub(crate) fn has_own_property(
+    agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
+    o: Object,
+    p: PropertyKey,
+) -> JsResult<bool> {
     // 1. Let desc be ? O.[[GetOwnProperty]](P).
-    let desc = o.internal_get_own_property(agent, p)?;
+    let desc = o.internal_get_own_property(agent, gc, p)?;
     // 2. If desc is undefined, return false.
     // 3. Return true.
     Ok(desc.is_some())
@@ -295,6 +332,8 @@ pub(crate) fn has_own_property(agent: &mut Agent, o: Object, p: PropertyKey) -> 
 /// present, a new empty List is used as its value.
 pub(crate) fn call(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     f: Value,
     v: Value,
     arguments_list: Option<ArgumentsList>,
@@ -308,7 +347,7 @@ pub(crate) fn call(
             "Not a callable object",
         )),
         // 3. Return ? F.[[Call]](V, argumentsList).
-        Some(f) => f.internal_call(agent, v, arguments_list),
+        Some(f) => f.internal_call(agent, gc, v, arguments_list),
     }
 }
 
@@ -343,15 +382,20 @@ pub(crate) mod integrity {
 /// level (SEALED or FROZEN) and returns either a normal completion containing
 /// a Boolean or a throw completion. It is used to fix the set of own
 /// properties of an object.
-pub(crate) fn set_integrity_level<T: Level>(agent: &mut Agent, o: Object) -> JsResult<bool> {
+pub(crate) fn set_integrity_level<T: Level>(
+    agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
+    o: Object,
+) -> JsResult<bool> {
     // 1. Let status be ? O.[[PreventExtensions]]().
-    let status = o.internal_prevent_extensions(agent)?;
+    let status = o.internal_prevent_extensions(agent, gc.reborrow())?;
     // 2. If status is false, return false.
     if !status {
         return Ok(false);
     }
     // 3. Let keys be ? O.[[OwnPropertyKeys]]().
-    let keys = o.internal_own_property_keys(agent)?;
+    let keys = o.internal_own_property_keys(agent, gc.reborrow())?;
     // 4. If level is SEALED, then
     if T::LEVEL == IntegrityLevel::Sealed {
         // a. For each element k of keys, do
@@ -359,6 +403,7 @@ pub(crate) fn set_integrity_level<T: Level>(agent: &mut Agent, o: Object) -> JsR
             // i. Perform ? DefinePropertyOrThrow(O, k, PropertyDescriptor { [[Configurable]]: false }).
             define_property_or_throw(
                 agent,
+                gc.reborrow(),
                 o,
                 k,
                 PropertyDescriptor {
@@ -373,7 +418,7 @@ pub(crate) fn set_integrity_level<T: Level>(agent: &mut Agent, o: Object) -> JsR
         // b. For each element k of keys, do
         for k in keys {
             // i. Let currentDesc be ? O.[[GetOwnProperty]](k).
-            let current_desc = o.internal_get_own_property(agent, k)?;
+            let current_desc = o.internal_get_own_property(agent, gc.reborrow(), k)?;
             // ii. If currentDesc is not undefined, then
             if let Some(current_desc) = current_desc {
                 // 1. If IsAccessorDescriptor(currentDesc) is true, then
@@ -393,7 +438,7 @@ pub(crate) fn set_integrity_level<T: Level>(agent: &mut Agent, o: Object) -> JsR
                     }
                 };
                 // 3. Perform ? DefinePropertyOrThrow(O, k, desc).
-                define_property_or_throw(agent, o, k, desc)?;
+                define_property_or_throw(agent, gc.reborrow(), o, k, desc)?;
             }
         }
     }
@@ -407,21 +452,26 @@ pub(crate) fn set_integrity_level<T: Level>(agent: &mut Agent, o: Object) -> JsR
 /// level (SEALED or FROZEN) and returns either a normal completion containing a
 /// Boolean or a throw completion. It is used to determine if the set of own
 /// properties of an object are fixed.
-pub(crate) fn test_integrity_level<T: Level>(agent: &mut Agent, o: Object) -> JsResult<bool> {
+pub(crate) fn test_integrity_level<T: Level>(
+    agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
+    o: Object,
+) -> JsResult<bool> {
     // 1. Let extensible be ? IsExtensible(O).
     // 2. If extensible is true, return false.
     // 3. NOTE: If the object is extensible, none of its properties are examined.
-    if o.internal_is_extensible(agent)? {
+    if o.internal_is_extensible(agent, gc.reborrow())? {
         return Ok(false);
     }
 
     // 4. Let keys be ? O.[[OwnPropertyKeys]]().
-    let keys = o.internal_own_property_keys(agent)?;
+    let keys = o.internal_own_property_keys(agent, gc.reborrow())?;
     // 5. For each element k of keys, do
     for k in keys {
         // a. Let currentDesc be ? O.[[GetOwnProperty]](k).
         // b. If currentDesc is not undefined, then
-        if let Some(current_desc) = o.internal_get_own_property(agent, k)? {
+        if let Some(current_desc) = o.internal_get_own_property(agent, gc.reborrow(), k)? {
             // i. If currentDesc.[[Configurable]] is true, return false.
             if current_desc.configurable == Some(true) {
                 return Ok(false);
@@ -466,15 +516,25 @@ pub(crate) fn create_array_from_list(agent: &mut Agent, elements: &[Value]) -> A
 /// returns either a normal completion containing a non-negative integer or a
 /// throw completion. It returns the value of the "length" property of an
 /// array-like object.
-pub(crate) fn length_of_array_like(agent: &mut Agent, obj: Object) -> JsResult<i64> {
+pub(crate) fn length_of_array_like(
+    agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
+    obj: Object,
+) -> JsResult<i64> {
     // NOTE: Fast path for Array objects.
     if let Ok(array) = Array::try_from(obj) {
         return Ok(array.len(agent) as i64);
     }
 
     // 1. Return ℝ(? ToLength(? Get(obj, "length"))).
-    let property = get(agent, obj, PropertyKey::from(BUILTIN_STRING_MEMORY.length))?;
-    to_length(agent, property)
+    let property = get(
+        agent,
+        gc.reborrow(),
+        obj,
+        PropertyKey::from(BUILTIN_STRING_MEMORY.length),
+    )?;
+    to_length(agent, gc, property)
 }
 
 /// ### [7.3.19 CreateListFromArrayLike ( obj [ , elementTypes ] )](https://tc39.es/ecma262/#sec-createlistfromarraylike)
@@ -487,7 +547,12 @@ pub(crate) fn length_of_array_like(agent: &mut Agent, obj: Object) -> JsResult<i
 /// for element values of the List that is created.
 ///
 /// NOTE: This implementation doesn't yet support `elementTypes`.
-pub(crate) fn create_list_from_array_like(agent: &mut Agent, obj: Value) -> JsResult<Vec<Value>> {
+pub(crate) fn create_list_from_array_like(
+    agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
+    obj: Value,
+) -> JsResult<Vec<Value>> {
     match obj {
         Value::Array(array) => Ok(array
             .as_slice(agent)
@@ -498,7 +563,7 @@ pub(crate) fn create_list_from_array_like(agent: &mut Agent, obj: Value) -> JsRe
         _ if obj.is_object() => {
             let object = Object::try_from(obj).unwrap();
             // 3. Let len be ? LengthOfArrayLike(obj).
-            let len = length_of_array_like(agent, object)?;
+            let len = length_of_array_like(agent, gc.reborrow(), object)?;
             let len = usize::try_from(len).unwrap();
             // 4. Let list be a new empty list.
             let mut list = Vec::with_capacity(len);
@@ -509,6 +574,7 @@ pub(crate) fn create_list_from_array_like(agent: &mut Agent, obj: Value) -> JsRe
                 // b. Let next be ? Get(obj, indexName).
                 let next = get(
                     agent,
+                    gc.reborrow(),
                     object,
                     PropertyKey::Integer(SmallInteger::try_from(i as u64).unwrap()),
                 )?;
@@ -530,16 +596,20 @@ pub(crate) fn create_list_from_array_like(agent: &mut Agent, obj: Value) -> JsRe
 /// Abstract operation Call specialized for a Function.
 pub(crate) fn call_function(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     f: Function,
     v: Value,
     arguments_list: Option<ArgumentsList>,
 ) -> JsResult<Value> {
     let arguments_list = arguments_list.unwrap_or_default();
-    f.internal_call(agent, v, arguments_list)
+    f.internal_call(agent, gc, v, arguments_list)
 }
 
 pub(crate) fn construct(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     f: Function,
     arguments_list: Option<ArgumentsList>,
     new_target: Option<Function>,
@@ -548,7 +618,7 @@ pub(crate) fn construct(
     let new_target = new_target.unwrap_or(f);
     // 2. If argumentsList is not present, set argumentsList to a new empty List.
     let arguments_list = arguments_list.unwrap_or_default();
-    f.internal_construct(agent, arguments_list, new_target)
+    f.internal_construct(agent, gc, arguments_list, new_target)
 }
 
 /// ### [7.3.20 Invoke ( V, P \[ , argumentsList \] )]()
@@ -563,6 +633,8 @@ pub(crate) fn construct(
 /// argumentsList is not present, a new empty List is used as its value.
 pub(crate) fn invoke(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     v: Value,
     p: PropertyKey,
     arguments_list: Option<ArgumentsList>,
@@ -570,9 +642,9 @@ pub(crate) fn invoke(
     // 1. If argumentsList is not present, set argumentsList to a new empty List.
     let arguments_list = arguments_list.unwrap_or_default();
     // 2. Let func be ? GetV(V, P).
-    let func = get_v(agent, v, p)?;
+    let func = get_v(agent, gc.reborrow(), v, p)?;
     // 3. Return ? Call(func, V, argumentsList).
-    call(agent, func, v, Some(arguments_list))
+    call(agent, gc, func, v, Some(arguments_list))
 }
 
 /// ### [7.3.21 OrdinaryHasInstance ( C, O )](https://tc39.es/ecma262/#sec-ordinaryhasinstance)
@@ -584,6 +656,8 @@ pub(crate) fn invoke(
 /// object inheritance path provided by C.
 pub(crate) fn ordinary_has_instance(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     c: impl TryInto<Function>,
     o: impl IntoValue,
 ) -> JsResult<bool> {
@@ -596,7 +670,7 @@ pub(crate) fn ordinary_has_instance(
         // a. Let BC be C.[[BoundTargetFunction]].
         let bc = agent[c].bound_target_function;
         // b. Return ? InstanceofOperator(O, BC).
-        return instanceof_operator(agent, o, bc);
+        return instanceof_operator(agent, gc.reborrow(), o, bc);
     }
     // 3. If O is not an Object, return false.
     let Ok(mut o) = Object::try_from(o.into_value()) else {
@@ -604,7 +678,7 @@ pub(crate) fn ordinary_has_instance(
     };
     // 4. Let P be ? Get(C, "prototype").
     let key = PropertyKey::from(BUILTIN_STRING_MEMORY.prototype);
-    let p = get(agent, c, key)?;
+    let p = get(agent, gc.reborrow(), c, key)?;
     // 5. If P is not an Object, throw a TypeError exception.
     let Ok(p) = Object::try_from(p) else {
         return Err(agent.throw_exception_with_static_message(
@@ -615,7 +689,7 @@ pub(crate) fn ordinary_has_instance(
     // 6. Repeat,
     loop {
         // a. Set O to ? O.[[GetPrototypeOf]]().
-        let o_prototype = o.internal_get_prototype_of(agent)?;
+        let o_prototype = o.internal_get_prototype_of(agent, gc.reborrow())?;
         if let Some(o_prototype) = o_prototype {
             o = o_prototype;
         } else {
@@ -668,10 +742,12 @@ pub(crate) mod enumerable_properties_kind {
 /// completion.
 pub(crate) fn enumerable_own_properties<Kind: EnumerablePropertiesKind>(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     o: Object,
 ) -> JsResult<Vec<Value>> {
     // 1. Let ownKeys be ? O.[[OwnPropertyKeys]]().
-    let own_keys = o.internal_own_property_keys(agent)?;
+    let own_keys = o.internal_own_property_keys(agent, gc.reborrow())?;
     // 2. Let results be a new empty List.
     let mut results: Vec<Value> = Vec::with_capacity(own_keys.len());
     // 3. For each element key of ownKeys, do
@@ -680,7 +756,7 @@ pub(crate) fn enumerable_own_properties<Kind: EnumerablePropertiesKind>(
             continue;
         }
         // i. Let desc be ? O.[[GetOwnProperty]](key).
-        let desc = o.internal_get_own_property(agent, key)?;
+        let desc = o.internal_get_own_property(agent, gc.reborrow(), key)?;
         // ii. If desc is not undefined and desc.[[Enumerable]] is true, then
         let Some(desc) = desc else {
             continue;
@@ -706,7 +782,7 @@ pub(crate) fn enumerable_own_properties<Kind: EnumerablePropertiesKind>(
         } else {
             // 2. Else,
             // a. Let value be ? Get(O, key).
-            let value = get(agent, o, key)?;
+            let value = get(agent, gc.reborrow(), o, key)?;
             // b. If kind is VALUE, then
             if Kind::KIND == EnumPropKind::Value {
                 // i. Append value to results.
@@ -780,6 +856,8 @@ pub(crate) fn get_function_realm(
 /// object literals, but not the rest operator in object destructuring.
 pub(crate) fn copy_data_properties(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     target: OrdinaryObject,
     source: Value,
 ) -> JsResult<()> {
@@ -791,7 +869,7 @@ pub(crate) fn copy_data_properties(
     let from = to_object(agent, source).unwrap();
 
     // 3. Let keys be ? from.[[OwnPropertyKeys]]().
-    let keys = from.internal_own_property_keys(agent)?;
+    let keys = from.internal_own_property_keys(agent, gc.reborrow())?;
     // Reserve space in the target's vectors.
     {
         let new_size = agent[target]
@@ -810,12 +888,12 @@ pub(crate) fn copy_data_properties(
     for next_key in keys {
         // i. Let desc be ? from.[[GetOwnProperty]](nextKey).
         // ii. If desc is not undefined and desc.[[Enumerable]] is true, then
-        if let Some(dest) = from.internal_get_own_property(agent, next_key)? {
+        if let Some(dest) = from.internal_get_own_property(agent, gc.reborrow(), next_key)? {
             if dest.enumerable.unwrap() {
                 // 1. Let propValue be ? Get(from, nextKey).
-                let prop_value = get(agent, from, next_key)?;
+                let prop_value = get(agent, gc.reborrow(), from, next_key)?;
                 // 2. Perform ! CreateDataPropertyOrThrow(target, nextKey, propValue).
-                create_data_property(agent, target, next_key, prop_value).unwrap();
+                create_data_property(agent, gc.reborrow(), target, next_key, prop_value).unwrap();
             }
         }
     }
@@ -834,6 +912,8 @@ pub(crate) fn copy_data_properties(
 /// object destructuring, but not the spread operator in object literals.
 pub(crate) fn copy_data_properties_into_object(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     source: impl IntoObject,
     excluded_items: &AHashSet<PropertyKey>,
 ) -> JsResult<OrdinaryObject> {
@@ -842,7 +922,7 @@ pub(crate) fn copy_data_properties_into_object(
 
     // 3. Let keys be ? from.[[OwnPropertyKeys]]().
     // 4. For each element nextKey of keys, do
-    for next_key in from.internal_own_property_keys(agent)? {
+    for next_key in from.internal_own_property_keys(agent, gc.reborrow())? {
         // a. Let excluded be false.
         // b. For each element e of excludedItems, do
         //   i. If SameValue(e, nextKey) is true, then
@@ -854,10 +934,10 @@ pub(crate) fn copy_data_properties_into_object(
         // c. If excluded is false, then
         //   i. Let desc be ? from.[[GetOwnProperty]](nextKey).
         //   ii. If desc is not undefined and desc.[[Enumerable]] is true, then
-        if let Some(dest) = from.internal_get_own_property(agent, next_key)? {
+        if let Some(dest) = from.internal_get_own_property(agent, gc.reborrow(), next_key)? {
             if dest.enumerable.unwrap() {
                 // 1. Let propValue be ? Get(from, nextKey).
-                let prop_value = get(agent, from, next_key)?;
+                let prop_value = get(agent, gc.reborrow(), from, next_key)?;
                 // 2. Perform ! CreateDataPropertyOrThrow(target, nextKey, propValue).
                 entries.push(ObjectEntry::new_data_entry(next_key, prop_value));
             }
@@ -881,6 +961,8 @@ pub(crate) fn copy_data_properties_into_object(
 /// a normal completion containing unused or a throw completion.
 pub(crate) fn initialize_instance_elements(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     o: Object,
     constructor: BuiltinConstructorFunction,
 ) -> JsResult<()> {
@@ -924,7 +1006,7 @@ pub(crate) fn initialize_instance_elements(
             realm: agent[constructor].realm,
             script_or_module: None,
         });
-        let _ = Vm::execute(agent, bytecode, None).into_js_result()?;
+        let _ = Vm::execute(agent, gc, bytecode, None).into_js_result()?;
         agent.execution_context_stack.pop();
     }
     Ok(())
@@ -982,6 +1064,8 @@ pub(crate) struct GroupByRecord<K: Copy + Into<Value>> {
 /// Note: This version is for "property" keyCoercion.
 pub(crate) fn group_by_property(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     items: Value,
     callback_fn: Value,
 ) -> JsResult<Vec<GroupByRecord<PropertyKey>>> {
@@ -1000,7 +1084,7 @@ pub(crate) fn group_by_property(
     let mut groups: Vec<GroupByRecord<PropertyKey>> = vec![];
 
     // 4. Let iteratorRecord be ? GetIterator(iterable).
-    let mut iterator_record = get_iterator(agent, items, false)?;
+    let mut iterator_record = get_iterator(agent, gc.reborrow(), items, false)?;
 
     // 5. Let k be 0.
     let mut k = 0;
@@ -1017,11 +1101,11 @@ pub(crate) fn group_by_property(
             );
 
             // ii. Return ? IteratorClose(iteratorRecord, error).
-            return iterator_close(agent, &iterator_record, Err(error));
+            return iterator_close(agent, gc.reborrow(), &iterator_record, Err(error));
         }
 
         // b. Let next be ? IteratorStepValue(iteratorRecord).
-        let next = iterator_step_value(agent, &mut iterator_record)?;
+        let next = iterator_step_value(agent, gc.reborrow(), &mut iterator_record)?;
 
         // c. If next is DONE, then
         //   i. Return groups.
@@ -1039,20 +1123,21 @@ pub(crate) fn group_by_property(
         // e. Let key be Completion(Call(callback, undefined, « value, 𝔽(k) »)).
         let key = call_function(
             agent,
+            gc.reborrow(),
             callback_fn,
             Value::Undefined,
             Some(ArgumentsList(&[value, fk])),
         );
 
         // f. IfAbruptCloseIterator(key, iteratorRecord).
-        let key = if_abrupt_close_iterator(agent, key, &iterator_record)?;
+        let key = if_abrupt_close_iterator(agent, gc.reborrow(), key, &iterator_record)?;
 
         // g. If keyCoercion is property, then
         // i. Set key to Completion(ToPropertyKey(key)).
-        let key = to_property_key(agent, key);
+        let key = to_property_key(agent, gc.reborrow(), key);
 
         // ii. IfAbruptCloseIterator(key, iteratorRecord).
-        let key = if_abrupt_close_iterator(agent, key, &iterator_record)?;
+        let key = if_abrupt_close_iterator(agent, gc.reborrow(), key, &iterator_record)?;
 
         // i. Perform AddValueToKeyedGroup(groups, key, value).
         add_value_to_keyed_group(agent, &mut groups, key, value)?;
@@ -1072,6 +1157,8 @@ pub(crate) fn group_by_property(
 /// Note: This version is for "collection" keyCoercion.
 pub(crate) fn group_by_collection(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     items: Value,
     callback_fn: Value,
 ) -> JsResult<Vec<GroupByRecord<Value>>> {
@@ -1090,7 +1177,7 @@ pub(crate) fn group_by_collection(
     let mut groups: Vec<GroupByRecord<Value>> = vec![];
 
     // 4. Let iteratorRecord be ? GetIterator(iterable).
-    let mut iterator_record = get_iterator(agent, items, false)?;
+    let mut iterator_record = get_iterator(agent, gc.reborrow(), items, false)?;
 
     // 5. Let k be 0.
     let mut k = 0;
@@ -1107,11 +1194,11 @@ pub(crate) fn group_by_collection(
             );
 
             // ii. Return ? IteratorClose(iteratorRecord, error).
-            return iterator_close(agent, &iterator_record, Err(error));
+            return iterator_close(agent, gc.reborrow(), &iterator_record, Err(error));
         }
 
         // b. Let next be ? IteratorStepValue(iteratorRecord).
-        let next = iterator_step_value(agent, &mut iterator_record)?;
+        let next = iterator_step_value(agent, gc.reborrow(), &mut iterator_record)?;
 
         // c. If next is DONE, then
         //   i. Return groups.
@@ -1129,13 +1216,14 @@ pub(crate) fn group_by_collection(
         // e. Let key be Completion(Call(callback, undefined, « value, 𝔽(k) »)).
         let key = call_function(
             agent,
+            gc.reborrow(),
             callback_fn,
             Value::Undefined,
             Some(ArgumentsList(&[value, fk])),
         );
 
         // f. IfAbruptCloseIterator(key, iteratorRecord).
-        let key = if_abrupt_close_iterator(agent, key, &iterator_record)?;
+        let key = if_abrupt_close_iterator(agent, gc.reborrow(), key, &iterator_record)?;
 
         // h. Else,
         // i. Assert: keyCoercion is collection.

--- a/nova_vm/src/ecmascript/abstract_operations/type_conversion.rs
+++ b/nova_vm/src/ecmascript/abstract_operations/type_conversion.rs
@@ -14,6 +14,7 @@
 //! The BigInt type has no implicit conversions in the ECMAScript language;
 //! programmers must call BigInt explicitly to convert values from other types.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builtins::{
@@ -59,6 +60,8 @@ pub enum PreferredType {
 /// > absence of a hint as if the hint were STRING.
 pub(crate) fn to_primitive(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     input: impl Into<Value> + Copy,
     preferred_type: Option<PreferredType>,
 ) -> JsResult<Primitive> {
@@ -68,6 +71,7 @@ pub(crate) fn to_primitive(
         // a. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
         let exotic_to_prim = get_method(
             agent,
+            gc.reborrow(),
             input.into_value(),
             PropertyKey::Symbol(WellKnownSymbolIndexes::ToPrimitive.into()),
         )?;
@@ -88,6 +92,7 @@ pub(crate) fn to_primitive(
             // iv. Let result be ? Call(exoticToPrim, input, « hint »).
             let result: Value = call_function(
                 agent,
+                gc,
                 exotic_to_prim,
                 input.into(),
                 Some(ArgumentsList(&[hint.into()])),
@@ -105,6 +110,7 @@ pub(crate) fn to_primitive(
             // d. Return ? OrdinaryToPrimitive(input, preferredType).
             ordinary_to_primitive(
                 agent,
+                gc,
                 input,
                 preferred_type.unwrap_or(PreferredType::Number),
             )
@@ -122,6 +128,8 @@ pub(crate) fn to_primitive(
 /// containing an ECMAScript language value or a throw completion.
 pub(crate) fn ordinary_to_primitive(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     o: Object,
     hint: PreferredType,
 ) -> JsResult<Primitive> {
@@ -142,11 +150,11 @@ pub(crate) fn ordinary_to_primitive(
     // 3. For each element name of methodNames, do
     for name in method_names {
         // a. Let method be ? Get(O, name).
-        let method = get(agent, o, name)?;
+        let method = get(agent, gc.reborrow(), o, name)?;
         // b. If IsCallable(method) is true, then
         if let Some(method) = is_callable(method) {
             // i. Let result be ? Call(method, O).
-            let result: Value = call_function(agent, method, o.into(), None)?;
+            let result: Value = call_function(agent, gc.reborrow(), method, o.into(), None)?;
             // ii. If result is not an Object, return result.
             if let Ok(result) = Primitive::try_from(result) {
                 return Ok(result);
@@ -161,7 +169,7 @@ pub(crate) fn ordinary_to_primitive(
 }
 
 /// ### [7.1.2 ToBoolean ( argument )](https://tc39.es/ecma262/#sec-toboolean)
-pub(crate) fn to_boolean(agent: &mut Agent, argument: Value) -> bool {
+pub(crate) fn to_boolean(agent: &Agent, argument: Value) -> bool {
     // 1. If argument is a Boolean, return argument.
     if let Value::Boolean(ret) = argument {
         return ret;
@@ -186,9 +194,14 @@ pub(crate) fn to_boolean(agent: &mut Agent, argument: Value) -> bool {
 }
 
 /// ### [7.1.3 ToNumeric ( value )](https://tc39.es/ecma262/#sec-tonumeric)
-pub(crate) fn to_numeric(agent: &mut Agent, value: impl Into<Value> + Copy) -> JsResult<Numeric> {
+pub(crate) fn to_numeric(
+    agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
+    value: impl Into<Value> + Copy,
+) -> JsResult<Numeric> {
     // 1. Let primValue be ? ToPrimitive(value, number).
-    let prim_value = to_primitive(agent, value, Some(PreferredType::Number))?;
+    let prim_value = to_primitive(agent, gc.reborrow(), value, Some(PreferredType::Number))?;
 
     // 2. If primValue is a BigInt, return primValue.
     if let Ok(prim_value) = BigInt::try_from(prim_value) {
@@ -196,11 +209,16 @@ pub(crate) fn to_numeric(agent: &mut Agent, value: impl Into<Value> + Copy) -> J
     }
 
     // 3. Return ? ToNumber(primValue).
-    to_number(agent, value).map(|n| n.into_numeric())
+    to_number(agent, gc, value).map(|n| n.into_numeric())
 }
 
 /// ### [7.1.4 ToNumber ( argument )](https://tc39.es/ecma262/#sec-tonumber)
-pub(crate) fn to_number(agent: &mut Agent, argument: impl Into<Value> + Copy) -> JsResult<Number> {
+pub(crate) fn to_number(
+    agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
+    argument: impl Into<Value> + Copy,
+) -> JsResult<Number> {
     let argument: Value = argument.into();
 
     match argument {
@@ -230,10 +248,11 @@ pub(crate) fn to_number(agent: &mut Agent, argument: impl Into<Value> + Copy) ->
             // 7. Assert: argument is an Object.
             let argument = Object::try_from(argument).unwrap();
             // 8. Let primValue be ? ToPrimitive(argument, number).
-            let prim_value = to_primitive(agent, argument, Some(PreferredType::Number))?;
+            let prim_value =
+                to_primitive(agent, gc.reborrow(), argument, Some(PreferredType::Number))?;
             // 9. Assert: primValue is not an Object.
             // 10. Return ? ToNumber(primValue).
-            to_number(agent, prim_value)
+            to_number(agent, gc, prim_value)
         }
     }
 }
@@ -312,13 +331,18 @@ fn string_to_number(agent: &mut Agent, str: String) -> Number {
 
 /// ### [7.1.5 ToIntegerOrInfinity ( argument )](https://tc39.es/ecma262/#sec-tointegerorinfinity)
 // TODO: Should we add another [`Value`] newtype for IntegerOrInfinity?
-pub(crate) fn to_integer_or_infinity(agent: &mut Agent, argument: Value) -> JsResult<Number> {
+pub(crate) fn to_integer_or_infinity(
+    agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
+    argument: Value,
+) -> JsResult<Number> {
     // Fast path: A safe integer is already an integer.
     if let Value::Integer(int) = argument {
         return Ok(int.into());
     }
     // 1. Let number be ? ToNumber(argument).
-    let number = to_number(agent, argument)?;
+    let number = to_number(agent, gc, argument)?;
 
     // 2. If number is one of NaN, +0𝔽, or -0𝔽, return 0.
     if number.is_nan(agent) || number.is_pos_zero(agent) || number.is_neg_zero(agent) {
@@ -340,7 +364,7 @@ pub(crate) fn to_integer_or_infinity(agent: &mut Agent, argument: Value) -> JsRe
 }
 
 /// ### [7.1.6 ToInt32 ( argument )](https://tc39.es/ecma262/#sec-toint32)
-pub(crate) fn to_int32(agent: &mut Agent, argument: Value) -> JsResult<i32> {
+pub(crate) fn to_int32(agent: &mut Agent, gc: GcScope<'_, '_>, argument: Value) -> JsResult<i32> {
     if let Value::Integer(int) = argument {
         // Fast path: Integer value is very nearly int32 already.
         let int = int.into_i64();
@@ -348,17 +372,23 @@ pub(crate) fn to_int32(agent: &mut Agent, argument: Value) -> JsResult<i32> {
     }
 
     // 1. Let number be ? ToNumber(argument).
-    let number = to_number(agent, argument)?;
+    let number = to_number(agent, gc, argument)?;
 
+    Ok(to_int32_number(agent, number))
+}
+
+/// ### [7.1.6 ToInt32 ( argument )](https://tc39.es/ecma262/#sec-toint32)
+///
+/// Implements steps 2 to 5 of the abstract operation, callable only with Numbers.
+pub(crate) fn to_int32_number(agent: &mut Agent, number: Number) -> i32 {
     if let Number::Integer(int) = number {
-        // Fast path: Integer value is very nearly int32 already.
         let int = int.into_i64();
-        return Ok(int as i32);
+        return int as i32;
     }
 
     // 2. If number is not finite or number is either +0𝔽 or -0𝔽, return +0𝔽.
     if !number.is_finite(agent) || number.is_pos_zero(agent) || number.is_neg_zero(agent) {
-        return Ok(0);
+        return 0;
     }
 
     // 3. Let int be truncate(ℝ(number)).
@@ -368,32 +398,38 @@ pub(crate) fn to_int32(agent: &mut Agent, argument: Value) -> JsResult<i32> {
     let int32bit = int % 2i64.pow(32);
 
     // 5. If int32bit ≥ 2^31, return 𝔽(int32bit - 2^32); otherwise return 𝔽(int32bit).
-    Ok(if int32bit >= 2i64.pow(32) {
-        int32bit - 2i64.pow(32)
+    if int32bit >= 2i64.pow(32) {
+        (int32bit - 2i64.pow(32)) as i32
     } else {
-        int32bit
-    } as i32)
+        int32bit as i32
+    }
 }
 
 /// ### [7.1.7 ToUint32 ( argument )](https://tc39.es/ecma262/#sec-touint32)
-pub(crate) fn to_uint32(agent: &mut Agent, argument: Value) -> JsResult<u32> {
+pub(crate) fn to_uint32(agent: &mut Agent, gc: GcScope<'_, '_>, argument: Value) -> JsResult<u32> {
     if let Value::Integer(int) = argument {
         // Fast path: Integer value is very nearly uint32 already.
         let int = int.into_i64();
         return Ok(int as u32);
     }
     // 1. Let number be ? ToNumber(argument).
-    let number = to_number(agent, argument)?;
+    let number = to_number(agent, gc, argument)?;
 
+    Ok(to_uint32_number(agent, number))
+}
+
+/// ### [7.1.7 ToUint32 ( argument )](https://tc39.es/ecma262/#sec-touint32)
+///
+/// Implements steps 2 to 5 of the abstract operation, callable only with Numbers.
+pub(crate) fn to_uint32_number(agent: &mut Agent, number: Number) -> u32 {
     if let Number::Integer(int) = number {
-        // Fast path: Integer value is very nearly uint32 already.
         let int = int.into_i64();
-        return Ok(int as u32);
+        return int as u32;
     }
 
     // 2. If number is not finite or number is either +0𝔽 or -0𝔽, return +0𝔽.
     if !number.is_finite(agent) || number.is_pos_zero(agent) || number.is_neg_zero(agent) {
-        return Ok(0);
+        return 0;
     }
 
     // 3. Let int be truncate(ℝ(number)).
@@ -403,11 +439,11 @@ pub(crate) fn to_uint32(agent: &mut Agent, argument: Value) -> JsResult<u32> {
     let int32bit = int % 2i64.pow(32);
 
     // 5. Return 𝔽(int32bit).
-    Ok(int32bit as u32)
+    int32bit as u32
 }
 
 /// ### [7.1.8 ToInt16 ( argument )](https://tc39.es/ecma262/#sec-toint16)
-pub(crate) fn to_int16(agent: &mut Agent, argument: Value) -> JsResult<i16> {
+pub(crate) fn to_int16(agent: &mut Agent, gc: GcScope<'_, '_>, argument: Value) -> JsResult<i16> {
     if let Value::Integer(int) = argument {
         // Fast path: Integer value is very nearly int16 already.
         let int = int.into_i64();
@@ -415,7 +451,7 @@ pub(crate) fn to_int16(agent: &mut Agent, argument: Value) -> JsResult<i16> {
     }
 
     // 1. Let number be ? ToNumber(argument).
-    let number = to_number(agent, argument)?;
+    let number = to_number(agent, gc, argument)?;
 
     if let Number::Integer(int) = number {
         // Fast path: Integer value is very nearly int16 already.
@@ -443,7 +479,7 @@ pub(crate) fn to_int16(agent: &mut Agent, argument: Value) -> JsResult<i16> {
 }
 
 /// ### [7.1.9 ToUint16 ( argument )](https://tc39.es/ecma262/#sec-touint16)
-pub(crate) fn to_uint16(agent: &mut Agent, argument: Value) -> JsResult<u16> {
+pub(crate) fn to_uint16(agent: &mut Agent, gc: GcScope<'_, '_>, argument: Value) -> JsResult<u16> {
     if let Value::Integer(int) = argument {
         // Fast path: Integer value is very nearly uint16 already.
         let int = int.into_i64();
@@ -451,7 +487,7 @@ pub(crate) fn to_uint16(agent: &mut Agent, argument: Value) -> JsResult<u16> {
     }
 
     // 1. Let number be ? ToNumber(argument).
-    let number = to_number(agent, argument)?;
+    let number = to_number(agent, gc, argument)?;
 
     if let Number::Integer(int) = number {
         // Fast path: Integer value is very nearly uin16 already.
@@ -475,7 +511,7 @@ pub(crate) fn to_uint16(agent: &mut Agent, argument: Value) -> JsResult<u16> {
 }
 
 /// ### [7.1.10 ToInt8 ( argument )](https://tc39.es/ecma262/#sec-toint8)
-pub(crate) fn to_int8(agent: &mut Agent, argument: Value) -> JsResult<i8> {
+pub(crate) fn to_int8(agent: &mut Agent, gc: GcScope<'_, '_>, argument: Value) -> JsResult<i8> {
     if let Value::Integer(int) = argument {
         // Fast path: Integer value is very nearly int8 already.
         let int = int.into_i64();
@@ -483,7 +519,7 @@ pub(crate) fn to_int8(agent: &mut Agent, argument: Value) -> JsResult<i8> {
     }
 
     // 1. Let number be ? ToNumber(argument).
-    let number = to_number(agent, argument)?;
+    let number = to_number(agent, gc, argument)?;
 
     if let Number::Integer(int) = number {
         // Fast path: Integer value is very nearly uint32 already.
@@ -511,7 +547,7 @@ pub(crate) fn to_int8(agent: &mut Agent, argument: Value) -> JsResult<i8> {
 }
 
 /// ### [7.1.11 ToUint8 ( argument )](https://tc39.es/ecma262/#sec-touint8)
-pub(crate) fn to_uint8(agent: &mut Agent, argument: Value) -> JsResult<u8> {
+pub(crate) fn to_uint8(agent: &mut Agent, gc: GcScope<'_, '_>, argument: Value) -> JsResult<u8> {
     if let Value::Integer(int) = argument {
         // Fast path: Integer value is very nearly uint32 already.
         let int = int.into_i64();
@@ -519,7 +555,7 @@ pub(crate) fn to_uint8(agent: &mut Agent, argument: Value) -> JsResult<u8> {
     }
 
     // 1. Let number be ? ToNumber(argument).
-    let number = to_number(agent, argument)?;
+    let number = to_number(agent, gc, argument)?;
 
     if let Number::Integer(int) = number {
         // Fast path: Integer value is very nearly uint32 already.
@@ -543,7 +579,12 @@ pub(crate) fn to_uint8(agent: &mut Agent, argument: Value) -> JsResult<u8> {
 }
 
 /// ### [7.1.12 ToUint8Clamp ( argument )](https://tc39.es/ecma262/#sec-touint8clamp)
-pub(crate) fn to_uint8_clamp(agent: &mut Agent, argument: Value) -> JsResult<u8> {
+pub(crate) fn to_uint8_clamp(
+    agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
+    argument: Value,
+) -> JsResult<u8> {
     if let Value::Integer(int) = argument {
         // Fast path: Integer value is very nearly uint8 already.
         let int = int.into_i64().clamp(0, 255);
@@ -551,7 +592,7 @@ pub(crate) fn to_uint8_clamp(agent: &mut Agent, argument: Value) -> JsResult<u8>
     }
 
     // 1. Let number be ? ToNumber(argument).
-    let number = to_number(agent, argument)?;
+    let number = to_number(agent, gc, argument)?;
 
     if let Number::Integer(int) = number {
         // Fast path: Integer value is very nearly uint8 already.
@@ -594,9 +635,14 @@ pub(crate) fn to_uint8_clamp(agent: &mut Agent, argument: Value) -> JsResult<u8>
 
 /// ### [7.1.13 ToBigInt ( argument )](https://tc39.es/ecma262/#sec-tobigint)
 #[inline(always)]
-pub(crate) fn to_big_int(agent: &mut Agent, argument: Value) -> JsResult<BigInt> {
+pub(crate) fn to_big_int(
+    agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
+    argument: Value,
+) -> JsResult<BigInt> {
     // 1. Let prim be ? ToPrimitive(argument, number).
-    let prim = to_primitive(agent, argument, Some(PreferredType::Number))?;
+    let prim = to_primitive(agent, gc, argument, Some(PreferredType::Number))?;
 
     // 2. Return the value that prim corresponds to in Table 12.
     match prim {
@@ -662,7 +708,12 @@ pub(crate) fn string_to_big_int(_agent: &mut Agent, _argument: String) -> Option
 }
 
 /// ### [7.1.17 ToString ( argument )](https://tc39.es/ecma262/#sec-tostring)
-pub(crate) fn to_string(agent: &mut Agent, argument: impl Into<Value> + Copy) -> JsResult<String> {
+pub(crate) fn to_string(
+    agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
+    argument: impl Into<Value> + Copy,
+) -> JsResult<String> {
     let argument: Value = argument.into();
     // 1. If argument is a String, return argument.
     match argument {
@@ -698,10 +749,11 @@ pub(crate) fn to_string(agent: &mut Agent, argument: impl Into<Value> + Copy) ->
             // 9. Assert: argument is an Object.
             assert!(Object::try_from(argument).is_ok());
             // 10. Let primValue be ? ToPrimitive(argument, string).
-            let prim_value = to_primitive(agent, argument, Some(PreferredType::String))?;
+            let prim_value =
+                to_primitive(agent, gc.reborrow(), argument, Some(PreferredType::String))?;
             // 11. Assert: primValue is not an Object.
             // 12. Return ? ToString(primValue).
-            to_string(agent, prim_value)
+            to_string(agent, gc, prim_value)
         }
     }
 }
@@ -791,7 +843,12 @@ pub(crate) fn to_object(agent: &mut Agent, argument: Value) -> JsResult<Object> 
 }
 
 /// ### [7.1.19 ToPropertyKey ( argument )](https://tc39.es/ecma262/#sec-topropertykey)
-pub(crate) fn to_property_key(agent: &mut Agent, argument: Value) -> JsResult<PropertyKey> {
+pub(crate) fn to_property_key(
+    agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
+    argument: Value,
+) -> JsResult<PropertyKey> {
     // Note: Fast path and non-standard special case combined. Usually the
     // argument is already a valid property key. We also need to parse integer
     // strings back into integer property keys.
@@ -804,7 +861,7 @@ pub(crate) fn to_property_key(agent: &mut Agent, argument: Value) -> JsResult<Pr
     // We call ToPrimitive in case we're dealing with an object.
 
     // 1. Let key be ? ToPrimitive(argument, hint String).
-    let key = to_primitive(agent, argument, Some(PreferredType::String))?;
+    let key = to_primitive(agent, gc.reborrow(), argument, Some(PreferredType::String))?;
 
     // 2. If Type(key) is Symbol, then
     //    a. Return key.
@@ -819,7 +876,7 @@ pub(crate) fn to_property_key(agent: &mut Agent, argument: Value) -> JsResult<Pr
         // stringifying.
 
         // 3. Return ! ToString(key).
-        to_string(agent, key).unwrap().into()
+        to_string(agent, gc, key).unwrap().into()
     }))
 }
 
@@ -901,11 +958,11 @@ pub(crate) fn parse_string_to_integer_property_key(str: &str) -> Option<Property
 }
 
 /// ### [7.1.20 ToLength ( argument )](https://tc39.es/ecma262/#sec-tolength)
-pub(crate) fn to_length(agent: &mut Agent, argument: Value) -> JsResult<i64> {
+pub(crate) fn to_length(agent: &mut Agent, gc: GcScope<'_, '_>, argument: Value) -> JsResult<i64> {
     // TODO: This can be heavily optimized by inlining `to_integer_or_infinity`.
 
     // 1. Let len be ? ToIntegerOrInfinity(argument).
-    let len = to_integer_or_infinity(agent, argument)?;
+    let len = to_integer_or_infinity(agent, gc, argument)?;
 
     // 2. If len ≤ 0, return +0𝔽.
     if match len {
@@ -927,6 +984,8 @@ pub(crate) fn to_length(agent: &mut Agent, argument: Value) -> JsResult<i64> {
 /// ### [7.1.21 CanonicalNumericIndexString ( argument )](https://tc39.es/ecma262/#sec-canonicalnumericindexstring)
 pub(crate) fn canonical_numeric_index_string(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     argument: String,
 ) -> Option<Number> {
     // 1. If argument is "-0", return -0𝔽.
@@ -935,10 +994,10 @@ pub(crate) fn canonical_numeric_index_string(
     }
 
     // 2. Let n be ! ToNumber(argument).
-    let n = to_number(agent, argument).unwrap();
+    let n = to_number(agent, gc.reborrow(), argument).unwrap();
 
     // 3. If ! ToString(n) is argument, return n.
-    if to_string(agent, n).unwrap() == argument {
+    if to_string(agent, gc, n).unwrap() == argument {
         return Some(n);
     }
 
@@ -947,7 +1006,7 @@ pub(crate) fn canonical_numeric_index_string(
 }
 
 /// ### [7.1.22 ToIndex ( value )](https://tc39.es/ecma262/#sec-toindex)
-pub(crate) fn to_index(agent: &mut Agent, argument: Value) -> JsResult<i64> {
+pub(crate) fn to_index(agent: &mut Agent, gc: GcScope<'_, '_>, argument: Value) -> JsResult<i64> {
     // Fast path: A safe integer is already an integer.
     if let Value::Integer(integer) = argument {
         let integer = integer.into_i64();
@@ -962,7 +1021,7 @@ pub(crate) fn to_index(agent: &mut Agent, argument: Value) -> JsResult<i64> {
     // TODO: This can be heavily optimized by inlining `to_integer_or_infinity`.
 
     // 1. Let integer be ? ToIntegerOrInfinity(value).
-    let integer = to_integer_or_infinity(agent, argument)?;
+    let integer = to_integer_or_infinity(agent, gc, argument)?;
 
     // 2. If integer is not in the inclusive interval from 0 to 2**53 - 1, throw a RangeError exception.
     let integer = if let Number::Integer(n) = integer {

--- a/nova_vm/src/ecmascript/builtins/arguments.rs
+++ b/nova_vm/src/ecmascript/builtins/arguments.rs
@@ -26,6 +26,7 @@
 //!
 //! ECMAScript implementations of arguments exotic objects have historically contained an accessor property named "caller". Prior to ECMAScript 2017, this specification included the definition of a throwing "caller" property on ordinary arguments objects. Since implementations do not contain this extension any longer, ECMAScript 2017 dropped the requirement for a throwing "caller" accessor.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::operations_on_objects::{
@@ -122,6 +123,8 @@ use super::ordinary::ordinary_object_create_with_intrinsics;
 /// ordinary object.
 pub(crate) fn create_unmapped_arguments_object(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     arguments_list: &[Value],
 ) -> Object {
     // 1. Let len be the number of elements in argumentsList.
@@ -137,6 +140,7 @@ pub(crate) fn create_unmapped_arguments_object(
     let key = PropertyKey::from(BUILTIN_STRING_MEMORY.length);
     define_property_or_throw(
         agent,
+        gc.reborrow(),
         obj,
         key,
         PropertyDescriptor {
@@ -160,7 +164,7 @@ pub(crate) fn create_unmapped_arguments_object(
         debug_assert!(index < u32::MAX as usize);
         let index = index as u32;
         let key = PropertyKey::Integer(index.into());
-        create_data_property_or_throw(agent, obj, key, *val).unwrap();
+        create_data_property_or_throw(agent, gc.reborrow(), obj, key, *val).unwrap();
         // c. Set index to index + 1.
     }
     // 7. Perform ! DefinePropertyOrThrow(obj, @@iterator, PropertyDescriptor {
@@ -169,6 +173,7 @@ pub(crate) fn create_unmapped_arguments_object(
     // let array_prototype_values = agent.current_realm().intrinsics().array_prototype();
     define_property_or_throw(
         agent,
+        gc.reborrow(),
         obj,
         key,
         PropertyDescriptor {
@@ -195,6 +200,7 @@ pub(crate) fn create_unmapped_arguments_object(
     let key = PropertyKey::from(BUILTIN_STRING_MEMORY.callee);
     define_property_or_throw(
         agent,
+        gc.reborrow(),
         obj,
         key,
         PropertyDescriptor {

--- a/nova_vm/src/ecmascript/builtins/array.rs
+++ b/nova_vm/src/ecmascript/builtins/array.rs
@@ -12,6 +12,7 @@ mod data;
 use std::ops::{Index, IndexMut, RangeInclusive};
 
 use super::{array_set_length, ordinary::ordinary_define_own_property};
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -84,18 +85,20 @@ impl Array {
     fn internal_get_backing(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         receiver: Value,
     ) -> JsResult<Value> {
         if let Some(object_index) = self.get_backing_object(agent) {
             // If backing object exists, then we might have properties there
-            object_index.internal_get(agent, property_key, receiver)
+            object_index.internal_get(agent, gc, property_key, receiver)
         } else {
             // If backing object doesn't exist, then we might still have
             // properties in the prototype.
             self.internal_prototype(agent)
                 .unwrap()
-                .internal_get(agent, property_key, receiver)
+                .internal_get(agent, gc, property_key, receiver)
         }
     }
 
@@ -206,13 +209,15 @@ impl InternalMethods for Array {
     fn internal_get_own_property(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         if let PropertyKey::Integer(index) = property_key {
             let index = index.into_i64();
             if !ARRAY_INDEX_RANGE.contains(&index) {
                 if let Some(backing_object) = self.get_backing_object(agent) {
-                    return backing_object.internal_get_own_property(agent, property_key);
+                    return backing_object.internal_get_own_property(agent, gc, property_key);
                 } else {
                     return Ok(None);
                 }
@@ -249,7 +254,7 @@ impl InternalMethods for Array {
                 ..Default::default()
             }))
         } else if let Some(backing_object) = array_data.object_index {
-            backing_object.internal_get_own_property(agent, property_key)
+            backing_object.internal_get_own_property(agent, gc, property_key)
         } else {
             Ok(None)
         }
@@ -258,11 +263,13 @@ impl InternalMethods for Array {
     fn internal_define_own_property(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
-            array_set_length(agent, self, property_descriptor)
+            array_set_length(agent, gc.reborrow(), self, property_descriptor)
         } else if let PropertyKey::Integer(index) = property_key {
             let index = index.into_i64();
             if !ARRAY_INDEX_RANGE.contains(&index) {
@@ -272,6 +279,7 @@ impl InternalMethods for Array {
                     .into_object();
                 return ordinary_define_own_property(
                     agent,
+                    gc.reborrow(),
                     backing_object,
                     property_key,
                     property_descriptor,
@@ -328,23 +336,35 @@ impl InternalMethods for Array {
                 .get_backing_object(agent)
                 .unwrap_or_else(|| self.create_backing_object(agent))
                 .into_object();
-            ordinary_define_own_property(agent, backing_object, property_key, property_descriptor)
+            ordinary_define_own_property(
+                agent,
+                gc,
+                backing_object,
+                property_key,
+                property_descriptor,
+            )
         }
     }
 
-    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
-        let has_own = self.internal_get_own_property(agent, property_key)?;
+    fn internal_has_property(
+        self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
+        let has_own = self.internal_get_own_property(agent, gc.reborrow(), property_key)?;
         if has_own.is_some() {
             return Ok(true);
         }
 
         // 3. Let parent be ? O.[[GetPrototypeOf]]().
-        let parent = self.internal_get_prototype_of(agent)?;
+        let parent = self.internal_get_prototype_of(agent, gc.reborrow())?;
 
         // 4. If parent is not null, then
         if let Some(parent) = parent {
             // a. Return ? parent.[[HasProperty]](P).
-            return parent.internal_has_property(agent, property_key);
+            return parent.internal_has_property(agent, gc, property_key);
         }
 
         // 5. Return false.
@@ -354,6 +374,8 @@ impl InternalMethods for Array {
     fn internal_get(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         receiver: Value,
     ) -> JsResult<Value> {
@@ -363,7 +385,7 @@ impl InternalMethods for Array {
             let index = index.into_i64();
             if !ARRAY_INDEX_RANGE.contains(&index) {
                 // Negative indexes and indexes over 2^32 - 2 go into backing store
-                return self.internal_get_backing(agent, property_key, receiver);
+                return self.internal_get_backing(agent, gc.reborrow(), property_key, receiver);
             }
             let index = index as u32;
             let elements = agent[self].elements;
@@ -372,7 +394,7 @@ impl InternalMethods for Array {
                 // defined: If they were, then the length would be larger.
                 // Hence, we look in the prototype.
                 return if let Some(prototype) = self.internal_prototype(agent) {
-                    prototype.internal_get(agent, property_key, receiver)
+                    prototype.internal_get(agent, gc, property_key, receiver)
                 } else {
                     Ok(Value::Undefined)
                 };
@@ -390,22 +412,28 @@ impl InternalMethods for Array {
                     if let Some(descriptor) = descriptors.get(&index) {
                         if let Some(getter) = descriptor.getter_function() {
                             // 7. Return ? Call(getter, Receiver).
-                            return call_function(agent, getter, receiver, None);
+                            return call_function(agent, gc, getter, receiver, None);
                         }
                     }
                 }
                 if let Some(prototype) = self.internal_prototype(agent) {
-                    prototype.internal_get(agent, property_key, receiver)
+                    prototype.internal_get(agent, gc, property_key, receiver)
                 } else {
                     Ok(Value::Undefined)
                 }
             }
         } else {
-            self.internal_get_backing(agent, property_key, receiver)
+            self.internal_get_backing(agent, gc.reborrow(), property_key, receiver)
         }
     }
 
-    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(
+        self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
         if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
             Ok(true)
         } else if let PropertyKey::Integer(index) = property_key {
@@ -414,7 +442,7 @@ impl InternalMethods for Array {
                 return self
                     .get_backing_object(agent)
                     .map_or(Ok(true), |object_index| {
-                        object_index.internal_delete(agent, property_key)
+                        object_index.internal_delete(agent, gc.reborrow(), property_key)
                     });
             }
             let index = index as u32;
@@ -441,14 +469,18 @@ impl InternalMethods for Array {
         } else {
             self.get_backing_object(agent)
                 .map_or(Ok(true), |object_index| {
-                    object_index.internal_delete(agent, property_key)
+                    object_index.internal_delete(agent, gc.reborrow(), property_key)
                 })
         }
     }
 
-    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+    ) -> JsResult<Vec<PropertyKey>> {
         let backing_keys = if let Some(backing_object) = self.get_backing_object(agent) {
-            backing_object.internal_own_property_keys(agent)?
+            backing_object.internal_own_property_keys(agent, gc)?
         } else {
             Default::default()
         };

--- a/nova_vm/src/ecmascript/builtins/array_buffer/abstract_operations.rs
+++ b/nova_vm/src/ecmascript/builtins/array_buffer/abstract_operations.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{ArrayBuffer, ArrayBufferHeapData};
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::operations_on_objects::get,
@@ -181,6 +182,8 @@ pub(crate) fn clone_array_buffer(
 /// completion.
 pub(crate) fn get_array_buffer_max_byte_length_option(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     options: Value,
 ) -> JsResult<Option<i64>> {
     // 1. If options is not an Object, return EMPTY.
@@ -191,14 +194,14 @@ pub(crate) fn get_array_buffer_max_byte_length_option(
     };
     // 2. Let maxByteLength be ? Get(options, "maxByteLength").
     let property = PropertyKey::from(BUILTIN_STRING_MEMORY.maxByteLength);
-    let max_byte_length = get(agent, options, property)?;
+    let max_byte_length = get(agent, gc.reborrow(), options, property)?;
     // 3. If maxByteLength is undefined, return EMPTY.
     if max_byte_length.is_undefined() {
         return Ok(None);
     }
     // 4. Return ? ToIndex(maxByteLength).
     // TODO: Consider de-inlining this once ToIndex is implemented.
-    let number = max_byte_length.to_number(agent)?;
+    let number = max_byte_length.to_number(agent, gc)?;
     let integer = if number.is_nan(agent) || number.is_pos_zero(agent) || number.is_neg_zero(agent)
     {
         0

--- a/nova_vm/src/ecmascript/builtins/bound_function.rs
+++ b/nova_vm/src/ecmascript/builtins/bound_function.rs
@@ -4,6 +4,7 @@
 
 use std::ops::{Index, IndexMut};
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -75,12 +76,14 @@ impl IntoFunction for BoundFunction {
 /// used to specify the creation of new bound function exotic objects.
 pub(crate) fn bound_function_create(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     target_function: Function,
     bound_this: Value,
     bound_args: &[Value],
 ) -> JsResult<BoundFunction> {
     // 1. Let proto be ? targetFunction.[[GetPrototypeOf]]().
-    let proto = target_function.internal_get_prototype_of(agent)?;
+    let proto = target_function.internal_get_prototype_of(agent, gc.reborrow())?;
     // 2. Let internalSlotsList be the list-concatenation of « [[Prototype]],
     //     [[Extensible]] » and the internal slots listed in Table 31.
     // 3. Let obj be MakeBasicObject(internalSlotsList).
@@ -109,7 +112,8 @@ pub(crate) fn bound_function_create(
     // 8. Set obj.[[BoundThis]] to boundThis.
     // 9. Set obj.[[BoundArguments]] to boundArgs.
     let obj = agent.heap.create(data);
-    obj.internal_set_prototype_of(agent, proto).unwrap();
+    obj.internal_set_prototype_of(agent, gc.reborrow(), proto)
+        .unwrap();
     // 10. Return obj.
     Ok(obj)
 }
@@ -145,6 +149,8 @@ impl InternalMethods for BoundFunction {
     fn internal_get_own_property(
         self,
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         function_internal_get_own_property(self, agent, property_key)
@@ -153,41 +159,69 @@ impl InternalMethods for BoundFunction {
     fn internal_define_own_property(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
-        function_internal_define_own_property(self, agent, property_key, property_descriptor)
+        function_internal_define_own_property(
+            self,
+            agent,
+            gc.reborrow(),
+            property_key,
+            property_descriptor,
+        )
     }
 
-    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
-        function_internal_has_property(self, agent, property_key)
+    fn internal_has_property(
+        self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
+        function_internal_has_property(self, agent, gc.reborrow(), property_key)
     }
 
     fn internal_get(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         receiver: Value,
     ) -> JsResult<Value> {
-        function_internal_get(self, agent, property_key, receiver)
+        function_internal_get(self, agent, gc.reborrow(), property_key, receiver)
     }
 
     fn internal_set(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         value: Value,
         receiver: Value,
     ) -> JsResult<bool> {
-        function_internal_set(self, agent, property_key, value, receiver)
+        function_internal_set(self, agent, gc.reborrow(), property_key, value, receiver)
     }
 
-    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
-        function_internal_delete(self, agent, property_key)
+    fn internal_delete(
+        self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
+        function_internal_delete(self, agent, gc.reborrow(), property_key)
     }
 
-    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
-        function_internal_own_property_keys(self, agent)
+    fn internal_own_property_keys(
+        self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+    ) -> JsResult<Vec<PropertyKey>> {
+        function_internal_own_property_keys(self, agent, gc.reborrow())
     }
 
     /// ### [10.4.1.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist)
@@ -200,6 +234,8 @@ impl InternalMethods for BoundFunction {
     fn internal_call(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         _: Value,
         arguments_list: ArgumentsList,
     ) -> JsResult<Value> {
@@ -213,7 +249,7 @@ impl InternalMethods for BoundFunction {
         if bound_args.is_empty() {
             // Optimisation: If only `this` is bound, then we can pass the
             // arguments list without changes to the bound function.
-            call_function(agent, target, bound_this, Some(arguments_list))
+            call_function(agent, gc, target, bound_this, Some(arguments_list))
         } else {
             // Note: We currently cannot optimise against an empty arguments
             // list, as we must create a Vec from the bound_args ElementsVector
@@ -225,7 +261,7 @@ impl InternalMethods for BoundFunction {
                 .for_each(|item| args.push(item.unwrap()));
             args.extend_from_slice(&arguments_list);
             // 5. Return ? Call(target, boundThis, args).
-            call_function(agent, target, bound_this, Some(ArgumentsList(&args)))
+            call_function(agent, gc, target, bound_this, Some(ArgumentsList(&args)))
         }
     }
 
@@ -238,6 +274,8 @@ impl InternalMethods for BoundFunction {
     fn internal_construct(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         arguments_list: ArgumentsList,
         new_target: Function,
     ) -> JsResult<Object> {
@@ -264,7 +302,13 @@ impl InternalMethods for BoundFunction {
             .for_each(|item| args.push(item.unwrap()));
         args.extend_from_slice(&arguments_list);
         // 6. Return ? Construct(target, args, newTarget).
-        construct(agent, target, Some(ArgumentsList(&args)), Some(new_target))
+        construct(
+            agent,
+            gc.reborrow(),
+            target,
+            Some(ArgumentsList(&args)),
+            Some(new_target),
+        )
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -4,6 +4,7 @@
 
 use std::ops::{Deref, Index, IndexMut};
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         execution::{
@@ -44,9 +45,9 @@ impl ArgumentsList<'_> {
     }
 }
 
-pub type RegularFn = fn(&mut Agent, Value, ArgumentsList<'_>) -> JsResult<Value>;
+pub type RegularFn = fn(&mut Agent, GcScope, Value, ArgumentsList<'_>) -> JsResult<Value>;
 pub type ConstructorFn =
-    fn(&mut Agent, Value, ArgumentsList<'_>, Option<Object>) -> JsResult<Value>;
+    fn(&mut Agent, GcScope, Value, ArgumentsList<'_>, Option<Object>) -> JsResult<Value>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Behaviour {
@@ -234,6 +235,8 @@ impl InternalMethods for BuiltinFunction {
     fn internal_get_own_property(
         self,
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         function_internal_get_own_property(self, agent, property_key)
@@ -242,41 +245,63 @@ impl InternalMethods for BuiltinFunction {
     fn internal_define_own_property(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
-        function_internal_define_own_property(self, agent, property_key, property_descriptor)
+        function_internal_define_own_property(self, agent, gc, property_key, property_descriptor)
     }
 
-    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
-        function_internal_has_property(self, agent, property_key)
+    fn internal_has_property(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
+        function_internal_has_property(self, agent, gc, property_key)
     }
 
     fn internal_get(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         receiver: Value,
     ) -> JsResult<Value> {
-        function_internal_get(self, agent, property_key, receiver)
+        function_internal_get(self, agent, gc, property_key, receiver)
     }
 
     fn internal_set(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         value: Value,
         receiver: Value,
     ) -> JsResult<bool> {
-        function_internal_set(self, agent, property_key, value, receiver)
+        function_internal_set(self, agent, gc, property_key, value, receiver)
     }
 
-    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
-        function_internal_delete(self, agent, property_key)
+    fn internal_delete(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
+        function_internal_delete(self, agent, gc, property_key)
     }
 
-    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
-        function_internal_own_property_keys(self, agent)
+    fn internal_own_property_keys(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+    ) -> JsResult<Vec<PropertyKey>> {
+        function_internal_own_property_keys(self, agent, gc)
     }
 
     /// ### [10.3.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist)
@@ -289,11 +314,13 @@ impl InternalMethods for BuiltinFunction {
     fn internal_call(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         this_argument: Value,
         arguments_list: ArgumentsList,
     ) -> JsResult<Value> {
         // 1. Return ? BuiltinCallOrConstruct(F, thisArgument, argumentsList, undefined).
-        builtin_call_or_construct(agent, self, Some(this_argument), arguments_list, None)
+        builtin_call_or_construct(agent, gc, self, Some(this_argument), arguments_list, None)
     }
 
     /// ### [10.3.2 \[\[Construct\]\] ( argumentsList, newTarget )](https://tc39.es/ecma262/#sec-built-in-function-objects-construct-argumentslist-newtarget)
@@ -305,11 +332,13 @@ impl InternalMethods for BuiltinFunction {
     fn internal_construct(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         arguments_list: ArgumentsList,
         new_target: Function,
     ) -> JsResult<Object> {
         // 1. Return ? BuiltinCallOrConstruct(F, uninitialized, argumentsList, newTarget).
-        builtin_call_or_construct(agent, self, None, arguments_list, Some(new_target))
+        builtin_call_or_construct(agent, gc, self, None, arguments_list, Some(new_target))
             .map(|result| result.try_into().unwrap())
     }
 }
@@ -323,6 +352,8 @@ impl InternalMethods for BuiltinFunction {
 /// completion containing an ECMAScript language value or a throw completion.
 pub(crate) fn builtin_call_or_construct(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     f: BuiltinFunction,
     this_argument: Option<Value>,
     arguments_list: ArgumentsList,
@@ -369,6 +400,7 @@ pub(crate) fn builtin_call_or_construct(
             } else {
                 func(
                     agent,
+                    gc,
                     this_argument.unwrap_or(Value::Undefined),
                     arguments_list,
                 )
@@ -376,6 +408,7 @@ pub(crate) fn builtin_call_or_construct(
         }
         Behaviour::Constructor(func) => func(
             agent,
+            gc,
             this_argument.unwrap_or(Value::Undefined),
             arguments_list,
             new_target.map(|target| target.into_object()),
@@ -494,31 +527,6 @@ pub fn create_builtin_function(
         realm,
         object_index,
     })
-}
-
-pub fn define_builtin_function(
-    agent: &mut Agent,
-    _object: Object,
-    name: &'static str,
-    behaviour: RegularFn,
-    length: u32,
-    realm: RealmIdentifier,
-) -> JsResult<()> {
-    let _function = create_builtin_function(
-        agent,
-        Behaviour::Regular(behaviour),
-        BuiltinFunctionArgs::new(length, name, realm),
-    );
-
-    Ok(())
-}
-
-pub fn define_builtin_property(
-    _object: Object,
-    _name: &'static str,
-    _descriptor: PropertyDescriptor,
-) -> JsResult<()> {
-    Ok(())
 }
 
 impl CreateHeapData<BuiltinFunctionHeapData, BuiltinFunction> for Heap {

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/async_function_objects/async_function_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/async_function_objects/async_function_constructor.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -30,6 +31,8 @@ impl BuiltinIntrinsicConstructor for AsyncFunctionConstructor {
 impl AsyncFunctionConstructor {
     fn behaviour(
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
         new_target: Option<Object>,
@@ -49,6 +52,7 @@ impl AsyncFunctionConstructor {
         // 3. Return ? CreateDynamicFunction(C, NewTarget, async, parameterArgs, bodyArg).
         Ok(create_dynamic_function(
             agent,
+            gc,
             constructor,
             DynamicFunctionKind::Async,
             parameter_args,

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/async_generator_function_objects/async_generator_function_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/async_generator_function_objects/async_generator_function_constructor.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -28,6 +29,8 @@ impl BuiltinIntrinsicConstructor for AsyncGeneratorFunctionConstructor {
 impl AsyncGeneratorFunctionConstructor {
     fn behaviour(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/async_generator_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/async_generator_objects.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -40,19 +41,33 @@ impl Builtin for AsyncGeneratorPrototypeThrow {
 }
 
 impl AsyncGeneratorPrototype {
-    fn next(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
-        todo!()
-    }
-
-    fn r#return(
+    fn next(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {
         todo!()
     }
 
-    fn throw(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn r#return(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
+        todo!()
+    }
+
+    fn throw(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_function_objects/generator_function_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_function_objects/generator_function_constructor.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::operations_on_objects::define_property_or_throw,
@@ -37,6 +38,8 @@ impl BuiltinIntrinsicConstructor for GeneratorFunctionConstructor {
 impl GeneratorFunctionConstructor {
     fn behaviour(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
         new_target: Option<Object>,
@@ -57,6 +60,7 @@ impl GeneratorFunctionConstructor {
         // 3. Return ? CreateDynamicFunction(C, NewTarget, generator, parameterArgs, bodyArg).
         let f = create_dynamic_function(
             agent,
+            gc.reborrow(),
             constructor,
             DynamicFunctionKind::Generator,
             parameter_args,
@@ -79,6 +83,7 @@ impl GeneratorFunctionConstructor {
         //   b. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
         define_property_or_throw(
             agent,
+            gc,
             f,
             BUILTIN_STRING_MEMORY.prototype.to_property_key(),
             PropertyDescriptor {

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::operations_on_iterator_objects::create_iter_result_object,
@@ -47,7 +48,13 @@ impl Builtin for GeneratorPrototypeThrow {
 }
 
 impl GeneratorPrototype {
-    fn next(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn next(
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // GeneratorResume: 1. Let state be ? GeneratorValidate(generator, generatorBrand).
         let Value::Generator(generator) = this_value else {
             return Err(agent.throw_exception_with_static_message(
@@ -57,10 +64,16 @@ impl GeneratorPrototype {
         };
 
         // 1. Return ? GeneratorResume(this value, value, empty).
-        Ok(generator.resume(agent, arguments.get(0))?.into_value())
+        Ok(generator.resume(agent, gc, arguments.get(0))?.into_value())
     }
 
-    fn r#return(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn r#return(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let g be the this value.
         // 2. Let C be Completion Record { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
         // 3. Return ? GeneratorResumeAbrupt(g, C, empty).
@@ -108,7 +121,13 @@ impl GeneratorPrototype {
         Ok(create_iter_result_object(agent, arguments.get(0), true).into_value())
     }
 
-    fn throw(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn throw(
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // GeneratorResumeAbrupt: 1. Let state be ? GeneratorValidate(generator, generatorBrand).
         let Value::Generator(generator) = this_value else {
             return Err(agent.throw_exception_with_static_message(
@@ -121,7 +140,7 @@ impl GeneratorPrototype {
         // 2. Let C be ThrowCompletion(exception).
         // 3. Return ? GeneratorResumeAbrupt(g, C, empty).
         Ok(generator
-            .resume_throw(agent, arguments.get(0))?
+            .resume_throw(agent, gc, arguments.get(0))?
             .into_value())
     }
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/async_from_sync_iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/async_from_sync_iterator_prototype.rs
@@ -2,11 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::{
-    builders::ordinary_object_builder::OrdinaryObjectBuilder,
-    builtins::{ArgumentsList, Behaviour, Builtin},
-    execution::{Agent, JsResult, RealmIdentifier},
-    types::{String, Value, BUILTIN_STRING_MEMORY},
+use crate::{
+    ecmascript::{
+        builders::ordinary_object_builder::OrdinaryObjectBuilder,
+        builtins::{ArgumentsList, Behaviour, Builtin},
+        execution::{Agent, JsResult, RealmIdentifier},
+        types::{String, Value, BUILTIN_STRING_MEMORY},
+    },
+    engine::context::GcScope,
 };
 
 pub(crate) struct AsyncFromSyncIteratorPrototype;
@@ -31,15 +34,33 @@ impl Builtin for AsyncFromSyncIteratorPrototypeThrow {
 }
 
 impl AsyncFromSyncIteratorPrototype {
-    fn next(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn next(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn r#return(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn r#return(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn throw(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn throw(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/async_iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/async_iterator_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -23,7 +24,13 @@ impl Builtin for AsyncIteratorPrototypeIterator {
 }
 
 impl AsyncIteratorPrototype {
-    fn iterator(_agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn iterator(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         Ok(this_value)
     }
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/iterator_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -23,7 +24,13 @@ impl Builtin for IteratorPrototypeIterator {
 }
 
 impl IteratorPrototype {
-    fn iterator(_agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn iterator(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         Ok(this_value)
     }
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_capability_records.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_capability_records.rs
@@ -4,6 +4,7 @@
 
 //! ## [27.2.1.1 PromiseCapability Records]()
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::operations_on_objects::get,
@@ -62,7 +63,7 @@ impl PromiseCapability {
         self.promise
     }
 
-    fn is_already_resolved(self, agent: &mut Agent) -> bool {
+    fn is_already_resolved(self, agent: &Agent) -> bool {
         // If `self.must_be_unresolved` is true, then `alreadyResolved`
         // corresponds with the `is_resolved` flag in PromiseState::Pending.
         // Otherwise, it corresponds to `promise_state` not being Pending.
@@ -136,7 +137,7 @@ impl PromiseCapability {
     }
 
     /// [27.2.1.3.2 Promise Resolve Functions](https://tc39.es/ecma262/#sec-promise-resolve-functions)
-    pub fn resolve(self, agent: &mut Agent, resolution: Value) {
+    pub fn resolve(self, agent: &mut Agent, gc: GcScope<'_, '_>, resolution: Value) {
         // 1. Let F be the active function object.
         // 2. Assert: F has a [[Promise]] internal slot whose value is an Object.
         // 3. Let promise be F.[[Promise]].
@@ -173,7 +174,7 @@ impl PromiseCapability {
         };
 
         // 9. Let then be Completion(Get(resolution, "then")).
-        let then_action = match get(agent, resolution, BUILTIN_STRING_MEMORY.then.into()) {
+        let then_action = match get(agent, gc, resolution, BUILTIN_STRING_MEMORY.then.into()) {
             // 11. Let thenAction be then.[[Value]].
             Ok(then_action) => then_action,
             // 10. If then is an abrupt completion, then

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
@@ -4,6 +4,7 @@
 
 use std::ops::{Index, IndexMut};
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builtins::{control_abstraction_objects::promise_objects::promise_abstract_operations::promise_capability_records::PromiseCapability, ArgumentsList},
@@ -118,6 +119,8 @@ impl InternalMethods for BuiltinPromiseResolvingFunction {
     fn internal_get_own_property(
         self,
         agent: &mut Agent,
+        _: GcScope<'_, '_>,
+
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         function_internal_get_own_property(self, agent, property_key)
@@ -126,53 +129,77 @@ impl InternalMethods for BuiltinPromiseResolvingFunction {
     fn internal_define_own_property(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
-        function_internal_define_own_property(self, agent, property_key, property_descriptor)
+        function_internal_define_own_property(self, agent, gc, property_key, property_descriptor)
     }
 
-    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
-        function_internal_has_property(self, agent, property_key)
+    fn internal_has_property(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
+        function_internal_has_property(self, agent, gc, property_key)
     }
 
     fn internal_get(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         receiver: Value,
     ) -> JsResult<Value> {
-        function_internal_get(self, agent, property_key, receiver)
+        function_internal_get(self, agent, gc, property_key, receiver)
     }
 
     fn internal_set(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         value: Value,
         receiver: Value,
     ) -> JsResult<bool> {
-        function_internal_set(self, agent, property_key, value, receiver)
+        function_internal_set(self, agent, gc, property_key, value, receiver)
     }
 
-    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
-        function_internal_delete(self, agent, property_key)
+    fn internal_delete(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
+        function_internal_delete(self, agent, gc, property_key)
     }
 
-    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
-        function_internal_own_property_keys(self, agent)
+    fn internal_own_property_keys(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+    ) -> JsResult<Vec<PropertyKey>> {
+        function_internal_own_property_keys(self, agent, gc)
     }
 
     fn internal_call(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         _this_value: Value,
         args: ArgumentsList,
     ) -> JsResult<Value> {
         let arg = args.get(0);
         let promise_capability = agent[self].promise_capability;
         match agent[self].resolve_type {
-            PromiseResolvingFunctionType::Resolve => promise_capability.resolve(agent, arg),
+            PromiseResolvingFunctionType::Resolve => promise_capability.resolve(agent, gc, arg),
             PromiseResolvingFunctionType::Reject => promise_capability.reject(agent, arg),
         };
         Ok(Value::Undefined)

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::operations_on_objects::invoke,
@@ -52,7 +53,13 @@ impl Builtin for PromisePrototypeThen {
 }
 
 impl PromisePrototype {
-    fn catch(agent: &mut Agent, this_value: Value, args: ArgumentsList) -> JsResult<Value> {
+    fn catch(
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        args: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let promise be the this value.
         // 2. Return ? Invoke(promise, "then", « undefined, onRejected »).
         // TODO: Add a fast path that calls `perform_promise_then` if we know
@@ -60,17 +67,30 @@ impl PromisePrototype {
         let on_rejected = args.get(0);
         invoke(
             agent,
+            gc,
             this_value,
             BUILTIN_STRING_MEMORY.then.into(),
             Some(ArgumentsList(&[Value::Undefined, on_rejected])),
         )
     }
 
-    fn finally(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn finally(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn then(agent: &mut Agent, this_value: Value, args: ArgumentsList) -> JsResult<Value> {
+    fn then(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        args: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let promise be the this value.
         // 2. If IsPromise(promise) is false, throw a TypeError exception.
         let Value::Promise(promise) = this_value else {

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -11,11 +11,10 @@ use oxc_ast::ast::{FormalParameters, FunctionBody};
 use oxc_ecmascript::IsSimpleParameterList;
 use oxc_span::Span;
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
-        abstract_operations::{
-            operations_on_objects::define_property_or_throw, type_conversion::to_object,
-        },
+        abstract_operations::type_conversion::to_object,
         execution::{
             agent::{
                 get_active_script_or_module,
@@ -345,6 +344,8 @@ impl InternalMethods for ECMAScriptFunction {
     fn internal_get_own_property(
         self,
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         function_internal_get_own_property(self, agent, property_key)
@@ -353,41 +354,63 @@ impl InternalMethods for ECMAScriptFunction {
     fn internal_define_own_property(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
-        function_internal_define_own_property(self, agent, property_key, property_descriptor)
+        function_internal_define_own_property(self, agent, gc, property_key, property_descriptor)
     }
 
-    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
-        function_internal_has_property(self, agent, property_key)
+    fn internal_has_property(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
+        function_internal_has_property(self, agent, gc, property_key)
     }
 
     fn internal_get(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         receiver: Value,
     ) -> JsResult<Value> {
-        function_internal_get(self, agent, property_key, receiver)
+        function_internal_get(self, agent, gc, property_key, receiver)
     }
 
     fn internal_set(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         value: Value,
         receiver: Value,
     ) -> JsResult<bool> {
-        function_internal_set(self, agent, property_key, value, receiver)
+        function_internal_set(self, agent, gc, property_key, value, receiver)
     }
 
-    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
-        function_internal_delete(self, agent, property_key)
+    fn internal_delete(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
+        function_internal_delete(self, agent, gc, property_key)
     }
 
-    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
-        function_internal_own_property_keys(self, agent)
+    fn internal_own_property_keys(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+    ) -> JsResult<Vec<PropertyKey>> {
+        function_internal_own_property_keys(self, agent, gc)
     }
 
     /// ### [10.2.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-call)
@@ -400,6 +423,8 @@ impl InternalMethods for ECMAScriptFunction {
     fn internal_call(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         this_argument: Value,
         arguments_list: ArgumentsList<'_>,
     ) -> JsResult<Value> {
@@ -439,7 +464,7 @@ impl InternalMethods for ECMAScriptFunction {
         };
         ordinary_call_bind_this(agent, self, local_env, this_argument);
         // 6. Let result be Completion(OrdinaryCallEvaluateBody(F, argumentsList)).
-        let result = ordinary_call_evaluate_body(agent, self, arguments_list);
+        let result = ordinary_call_evaluate_body(agent, gc, self, arguments_list);
         // 7. Remove calleeContext from the execution context stack and restore callerContext as the running execution context.
         // NOTE: calleeContext must not be destroyed if it is suspended and retained for later resumption by an accessible Generator.
         agent.execution_context_stack.pop();
@@ -452,6 +477,8 @@ impl InternalMethods for ECMAScriptFunction {
     fn internal_construct(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         arguments_list: ArgumentsList,
         new_target: Function,
     ) -> JsResult<Object> {
@@ -465,6 +492,7 @@ impl InternalMethods for ECMAScriptFunction {
             // a. Let thisArgument be ? OrdinaryCreateFromConstructor(newTarget, "%Object.prototype%").
             Some(ordinary_create_from_constructor(
                 agent,
+                gc.reborrow(),
                 new_target,
                 ProtoIntrinsics::Object,
             )?)
@@ -504,7 +532,7 @@ impl InternalMethods for ECMAScriptFunction {
         }
 
         // 8. Let result be Completion(OrdinaryCallEvaluateBody(F, argumentsList)).
-        let result = ordinary_call_evaluate_body(agent, self, arguments_list);
+        let result = ordinary_call_evaluate_body(agent, gc.reborrow(), self, arguments_list);
         // 9. Remove calleeContext from the execution context stack and restore
         //    callerContext as the running execution context.
         agent.execution_context_stack.pop();
@@ -525,7 +553,7 @@ impl InternalMethods for ECMAScriptFunction {
         if !value.is_undefined() {
             let message = format!(
                 "derived class constructor returned invalid value {}",
-                value.string_repr(agent).as_str(agent)
+                value.string_repr(agent, gc).as_str(agent)
             );
             let message = String::from_string(agent, message);
             Err(agent.throw_exception_with_message(ExceptionType::TypeError, message))
@@ -655,6 +683,8 @@ pub(crate) fn ordinary_call_bind_this(
 /// ECMAScript language value or an abrupt completion.
 pub(crate) fn evaluate_body(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     function_object: ECMAScriptFunction,
     arguments_list: ArgumentsList,
 ) -> JsResult<Value> {
@@ -666,7 +696,10 @@ pub(crate) fn evaluate_body(
             // 1. Return ? EvaluateAsyncFunctionBody of AsyncFunctionBody with arguments functionObject and argumentsList.
             // AsyncConciseBody : ExpressionBody
             // 1. Return ? EvaluateAsyncConciseBody of AsyncConciseBody with arguments functionObject and argumentsList.
-            Ok(evaluate_async_function_body(agent, function_object, arguments_list).into_value())
+            Ok(
+                evaluate_async_function_body(agent, gc, function_object, arguments_list)
+                    .into_value(),
+            )
         }
         (false, false) => {
             // SAFETY: AS the ECMAScriptFunction is alive in the heap, its referred
@@ -684,12 +717,12 @@ pub(crate) fn evaluate_body(
             // 1. Return ? EvaluateFunctionBody of FunctionBody with arguments functionObject and argumentsList.
             // ConciseBody : ExpressionBody
             // 1. Return ? EvaluateConciseBody of ConciseBody with arguments functionObject and argumentsList.
-            evaluate_function_body(agent, function_object, arguments_list)
+            evaluate_function_body(agent, gc, function_object, arguments_list)
         }
         (true, false) => {
             // GeneratorBody : FunctionBody
             // 1. Return ? EvaluateGeneratorBody of GeneratorBody with arguments functionObject and argumentsList.
-            evaluate_generator_body(agent, function_object, arguments_list)
+            evaluate_generator_body(agent, gc, function_object, arguments_list)
         }
         // AsyncGeneratorBody : FunctionBody
         // 1. Return ? EvaluateAsyncGeneratorBody of AsyncGeneratorBody with arguments functionObject and argumentsList.
@@ -721,11 +754,13 @@ pub(crate) fn evaluate_body(
 /// ECMAScript language value or an abrupt completion.
 pub(crate) fn ordinary_call_evaluate_body(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     f: ECMAScriptFunction,
     arguments_list: ArgumentsList,
 ) -> JsResult<Value> {
     // 1. Return ? EvaluateBody of F.[[ECMAScriptCode]] with arguments F and argumentsList.
-    evaluate_body(agent, f, arguments_list)
+    evaluate_body(agent, gc, f, arguments_list)
 }
 
 /// ### [10.2.3 OrdinaryFunctionCreate ( functionPrototype, sourceText, ParameterList, Body, thisMode, env, privateEnv )](https://tc39.es/ecma262/#sec-ordinaryfunctioncreate)
@@ -853,7 +888,7 @@ pub(crate) fn ordinary_function_create<'agent, 'program>(
 /// UNUSED. It converts F into a constructor.
 pub(crate) fn make_constructor(
     agent: &mut Agent,
-    function: impl IntoFunction,
+    function: impl IntoFunction + InternalMethods,
     writable_prototype: Option<bool>,
     prototype: Option<Object>,
 ) {
@@ -888,9 +923,8 @@ pub(crate) fn make_constructor(
             ordinary_object_create_with_intrinsics(agent, Some(ProtoIntrinsics::Object), None);
         // b. Perform ! DefinePropertyOrThrow(prototype, "constructor", PropertyDescriptor { [[Value]]: F, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: true }).
         let key = PropertyKey::from(BUILTIN_STRING_MEMORY.constructor);
-        define_property_or_throw(
+        prototype.property_storage().set(
             agent,
-            prototype,
             key,
             PropertyDescriptor {
                 value: Some(function.into_value()),
@@ -899,15 +933,17 @@ pub(crate) fn make_constructor(
                 configurable: Some(true),
                 ..Default::default()
             },
-        )
-        .unwrap();
+        );
         prototype
     });
     // 6. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: false }).
     let key = PropertyKey::from(BUILTIN_STRING_MEMORY.prototype);
-    define_property_or_throw(
+    let backing_object = function
+        .get_backing_object(agent)
+        .unwrap_or_else(|| function.create_backing_object(agent))
+        .into_object();
+    backing_object.property_storage().set(
         agent,
-        function.into_object(),
         key,
         PropertyDescriptor {
             value: Some(prototype.into_value()),
@@ -916,8 +952,7 @@ pub(crate) fn make_constructor(
             configurable: Some(false),
             ..Default::default()
         },
-    )
-    .unwrap();
+    );
     // 7. Return UNUSED.
 }
 

--- a/nova_vm/src/ecmascript/builtins/embedder_object.rs
+++ b/nova_vm/src/ecmascript/builtins/embedder_object.rs
@@ -4,6 +4,7 @@
 
 use std::ops::{Index, IndexMut};
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         execution::{Agent, JsResult},
@@ -103,23 +104,33 @@ impl InternalSlots for EmbedderObject {
 }
 
 impl InternalMethods for EmbedderObject {
-    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+    fn internal_get_prototype_of(
+        self,
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+    ) -> JsResult<Option<Object>> {
         Ok(self.internal_prototype(agent))
     }
 
     fn internal_set_prototype_of(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _prototype: Option<Object>,
     ) -> JsResult<bool> {
         todo!();
     }
 
-    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+    fn internal_is_extensible(self, agent: &mut Agent, _gc: GcScope<'_, '_>) -> JsResult<bool> {
         Ok(self.internal_extensible(agent))
     }
 
-    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+    fn internal_prevent_extensions(
+        self,
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+    ) -> JsResult<bool> {
         self.internal_set_extensible(agent, false);
         Ok(true)
     }
@@ -127,6 +138,8 @@ impl InternalMethods for EmbedderObject {
     fn internal_get_own_property(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         todo!();
@@ -135,6 +148,8 @@ impl InternalMethods for EmbedderObject {
     fn internal_define_own_property(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _property_key: PropertyKey,
         _property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
@@ -144,6 +159,8 @@ impl InternalMethods for EmbedderObject {
     fn internal_has_property(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _property_key: PropertyKey,
     ) -> JsResult<bool> {
         todo!();
@@ -152,6 +169,8 @@ impl InternalMethods for EmbedderObject {
     fn internal_get(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _property_key: PropertyKey,
         _receiver: Value,
     ) -> JsResult<Value> {
@@ -161,6 +180,8 @@ impl InternalMethods for EmbedderObject {
     fn internal_set(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _property_key: PropertyKey,
         _value: Value,
         _receiver: Value,
@@ -168,11 +189,21 @@ impl InternalMethods for EmbedderObject {
         todo!();
     }
 
-    fn internal_delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(
+        self,
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _property_key: PropertyKey,
+    ) -> JsResult<bool> {
         todo!();
     }
 
-    fn internal_own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(
+        self,
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+    ) -> JsResult<Vec<PropertyKey>> {
         todo!();
     }
 }

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/boolean_objects/boolean_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/boolean_objects/boolean_constructor.rs
@@ -21,6 +21,7 @@ use crate::ecmascript::types::IntoValue;
 use crate::ecmascript::types::Object;
 use crate::ecmascript::types::BUILTIN_STRING_MEMORY;
 use crate::ecmascript::types::{String, Value};
+use crate::engine::context::GcScope;
 use crate::heap::IntrinsicConstructorIndexes;
 
 pub(crate) struct BooleanConstructor;
@@ -39,6 +40,8 @@ impl BuiltinIntrinsicConstructor for BooleanConstructor {
 impl BooleanConstructor {
     fn behaviour(
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
         new_target: Option<Object>,
@@ -51,6 +54,7 @@ impl BooleanConstructor {
         let new_target = Function::try_from(new_target).unwrap();
         let o = PrimitiveObject::try_from(ordinary_create_from_constructor(
             agent,
+            gc,
             new_target,
             ProtoIntrinsics::Boolean,
         )?)

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/boolean_objects/boolean_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/boolean_objects/boolean_prototype.rs
@@ -2,14 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::{
-    builders::ordinary_object_builder::OrdinaryObjectBuilder,
-    builtins::{
-        primitive_objects::{PrimitiveObjectData, PrimitiveObjectHeapData},
-        ArgumentsList, Builtin,
+use crate::{
+    ecmascript::{
+        builders::ordinary_object_builder::OrdinaryObjectBuilder,
+        builtins::{
+            primitive_objects::{PrimitiveObjectData, PrimitiveObjectHeapData},
+            ArgumentsList, Builtin,
+        },
+        execution::{agent::ExceptionType, Agent, JsResult, RealmIdentifier},
+        types::{String, Value, BUILTIN_STRING_MEMORY},
     },
-    execution::{agent::ExceptionType, Agent, JsResult, RealmIdentifier},
-    types::{String, Value, BUILTIN_STRING_MEMORY},
+    engine::context::GcScope,
 };
 
 pub(crate) struct BooleanPrototype;
@@ -35,7 +38,13 @@ impl Builtin for BooleanPrototypeValueOf {
 }
 
 impl BooleanPrototype {
-    fn to_string(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_string(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let b = this_boolean_value(agent, this_value)?;
         if b {
             Ok(BUILTIN_STRING_MEMORY.r#true.into())
@@ -44,7 +53,13 @@ impl BooleanPrototype {
         }
     }
 
-    fn value_of(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn value_of(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         this_boolean_value(agent, this_value).map(|result| result.into())
     }
 

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/aggregate_error_constructors.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/aggregate_error_constructors.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -27,6 +28,8 @@ impl BuiltinIntrinsicConstructor for AggregateErrorConstructor {
 impl AggregateErrorConstructor {
     fn behaviour(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/object_objects/object_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/object_objects/object_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -82,16 +83,20 @@ impl Builtin for ObjectPrototypeValueOf {
 impl ObjectPrototype {
     fn has_own_property(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
-        let p = to_property_key(agent, arguments.get(0))?;
+        let p = to_property_key(agent, gc.reborrow(), arguments.get(0))?;
         let o = to_object(agent, this_value)?;
-        has_own_property(agent, o, p).map(|result| result.into())
+        has_own_property(agent, gc.reborrow(), o, p).map(|result| result.into())
     }
 
     fn is_prototype_of(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -101,7 +106,7 @@ impl ObjectPrototype {
         };
         let o = to_object(agent, this_value)?;
         loop {
-            let proto = v.internal_get_prototype_of(agent)?;
+            let proto = v.internal_get_prototype_of(agent, gc.reborrow())?;
             if let Some(proto) = proto {
                 v = proto;
                 if same_value(agent, o, v) {
@@ -115,12 +120,14 @@ impl ObjectPrototype {
 
     fn property_is_enumerable(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
-        let p = to_property_key(agent, arguments.get(0))?;
+        let p = to_property_key(agent, gc.reborrow(), arguments.get(0))?;
         let o = to_object(agent, this_value)?;
-        let desc = o.internal_get_own_property(agent, p)?;
+        let desc = o.internal_get_own_property(agent, gc.reborrow(), p)?;
         if let Some(desc) = desc {
             Ok(desc.enumerable.unwrap_or(false).into())
         } else {
@@ -130,16 +137,20 @@ impl ObjectPrototype {
 
     fn to_locale_string(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {
         let o = this_value;
         let p = PropertyKey::from(BUILTIN_STRING_MEMORY.toString);
-        invoke(agent, o, p, None)
+        invoke(agent, gc.reborrow(), o, p, None)
     }
 
     fn to_string(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -199,7 +210,12 @@ impl ObjectPrototype {
                 | PrimitiveObjectData::BigInt(_)
                 | PrimitiveObjectData::SmallBigInt(_) => {
                     let o = to_object(agent, this_value).unwrap();
-                    let tag = get(agent, o, WellKnownSymbolIndexes::ToStringTag.into())?;
+                    let tag = get(
+                        agent,
+                        gc.reborrow(),
+                        o,
+                        WellKnownSymbolIndexes::ToStringTag.into(),
+                    )?;
                     if let Ok(tag) = String::try_from(tag) {
                         let str = format!("[object {}]", tag.as_str(agent));
                         Ok(Value::from_string(agent, str))
@@ -215,7 +231,12 @@ impl ObjectPrototype {
                 // 15. Let tag be ? Get(O, @@toStringTag).
                 // 16. If tag is not a String, set tag to builtinTag.
                 let o = to_object(agent, this_value).unwrap();
-                let tag = get(agent, o, WellKnownSymbolIndexes::ToStringTag.into())?;
+                let tag = get(
+                    agent,
+                    gc.reborrow(),
+                    o,
+                    WellKnownSymbolIndexes::ToStringTag.into(),
+                )?;
                 if let Ok(tag) = String::try_from(tag) {
                     let str = format!("[object {}]", tag.as_str(agent));
                     Ok(Value::from_string(agent, str))
@@ -230,6 +251,8 @@ impl ObjectPrototype {
 
     fn value_of(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/symbol_objects/symbol_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/symbol_objects/symbol_constructor.rs
@@ -20,6 +20,7 @@ use crate::ecmascript::types::String;
 use crate::ecmascript::types::SymbolHeapData;
 use crate::ecmascript::types::Value;
 use crate::ecmascript::types::BUILTIN_STRING_MEMORY;
+use crate::engine::context::GcScope;
 use crate::heap::CreateHeapData;
 use crate::heap::IntrinsicConstructorIndexes;
 use crate::heap::WellKnownSymbolIndexes;
@@ -60,6 +61,8 @@ impl Builtin for SymbolKeyFor {
 impl SymbolConstructor {
     fn behaviour(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
         new_target: Option<Object>,
@@ -74,7 +77,7 @@ impl SymbolConstructor {
         let desc_string = if description.is_undefined() {
             None
         } else {
-            Some(to_string(agent, description)?)
+            Some(to_string(agent, gc.reborrow(), description)?)
         };
 
         Ok(agent
@@ -85,12 +88,20 @@ impl SymbolConstructor {
             .into_value())
     }
 
-    fn r#for(_agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn r#for(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         Ok(arguments.get(0))
     }
 
     fn key_for(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/symbol_objects/symbol_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/symbol_objects/symbol_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -68,7 +69,13 @@ impl SymbolPrototype {
     ///
     /// Symbol.prototype.description is an accessor property whose set accessor
     /// function is undefined.
-    fn get_description(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_description(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let s be the this value.
         // 2. Let sym be ? ThisSymbolValue(s).
         let sym = this_symbol_value(agent, this_value)?;
@@ -78,12 +85,24 @@ impl SymbolPrototype {
             .map_or_else(|| Ok(Value::Undefined), |desc| Ok(desc.into_value()))
     }
 
-    fn to_string(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_string(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let symb = this_symbol_value(agent, this_value)?;
         Ok(symbol_descriptive_string(agent, symb).into_value())
     }
 
-    fn value_of(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn value_of(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         this_symbol_value(agent, this_value).map(|res| res.into_value())
     }
 

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
@@ -6,6 +6,7 @@ use std::cmp::Ordering;
 
 use small_string::SmallString;
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -282,14 +283,20 @@ impl Builtin for ArrayPrototypeWith {
 
 impl ArrayPrototype {
     /// ### [23.1.3.1 Array.prototype.at ( index )](https://tc39.es/ecma262/#sec-array.prototype.at)
-    fn at(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn at(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         let index = arguments.get(0);
         // 3. Let relativeIndex be ? ToIntegerOrInfinity(index).
-        let relative_index = to_integer_or_infinity(agent, index)?;
+        let relative_index = to_integer_or_infinity(agent, gc.reborrow(), index)?;
         let relative_index = match relative_index {
             Number::SmallF64(_) | Number::Number(_) => {
                 // Heap number or f32 here means that the value is over the
@@ -312,7 +319,12 @@ impl ArrayPrototype {
             Ok(Value::Undefined)
         } else {
             // 7. Return ? Get(O, ! ToString(𝔽(k))).
-            get(agent, o, PropertyKey::Integer(k.try_into().unwrap()))
+            get(
+                agent,
+                gc.reborrow(),
+                o,
+                PropertyKey::Integer(k.try_into().unwrap()),
+            )
         }
     }
 
@@ -329,11 +341,17 @@ impl ArrayPrototype {
     /// > Note 2: This method is intentionally generic; it does not require
     /// > that its this value be an Array. Therefore it can be transferred to
     /// > other kinds of objects for use as a method.
-    fn concat(agent: &mut Agent, this_value: Value, items: ArgumentsList) -> JsResult<Value> {
+    fn concat(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        items: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let A be ? ArraySpeciesCreate(O, 0).
-        let a = array_species_create(agent, o, 0)?;
+        let a = array_species_create(agent, gc.reborrow(), o, 0)?;
         // 3. Let n be 0.
         let mut n = 0;
         // 4. Prepend O to items.
@@ -342,11 +360,11 @@ impl ArrayPrototype {
         // 5. For each element E of items, do
         for e in items {
             // a. Let spreadable be ? IsConcatSpreadable(E).
-            let e_is_spreadable = is_concat_spreadable(agent, e)?;
+            let e_is_spreadable = is_concat_spreadable(agent, gc.reborrow(), e)?;
             // b. If spreadable is true, then
             if let Some(e) = e_is_spreadable {
                 // i. Let len be ? LengthOfArrayLike(E).
-                let len = length_of_array_like(agent, e)?;
+                let len = length_of_array_like(agent, gc.reborrow(), e)?;
                 // ii. If n + len > 2**53 - 1, throw a TypeError exception.
                 if (n + len) > SmallInteger::MAX_NUMBER {
                     return Err(agent.throw_exception_with_static_message(
@@ -361,14 +379,15 @@ impl ArrayPrototype {
                     // 1. Let Pk be ! ToString(𝔽(k)).
                     let pk = PropertyKey::Integer(k.try_into().unwrap());
                     // 2. Let exists be ? HasProperty(E, Pk).
-                    let exists = has_property(agent, e, pk)?;
+                    let exists = has_property(agent, gc.reborrow(), e, pk)?;
                     // 3. If exists is true, then
                     if exists {
                         // a. Let subElement be ? Get(E, Pk).
-                        let sub_element = get(agent, e, pk)?;
+                        let sub_element = get(agent, gc.reborrow(), e, pk)?;
                         // b. Perform ? CreateDataPropertyOrThrow(A, ! ToString(𝔽(n)), subElement).
                         create_data_property_or_throw(
                             agent,
+                            gc.reborrow(),
                             a,
                             PropertyKey::Integer(n.try_into().unwrap()),
                             sub_element,
@@ -392,6 +411,7 @@ impl ArrayPrototype {
                 // iii. Perform ? CreateDataPropertyOrThrow(A, ! ToString(𝔽(n)), E).
                 create_data_property_or_throw(
                     agent,
+                    gc.reborrow(),
                     a,
                     PropertyKey::Integer(n.try_into().unwrap()),
                     e,
@@ -403,6 +423,7 @@ impl ArrayPrototype {
         // 6. Perform ? Set(A, "length", 𝔽(n), true).
         set(
             agent,
+            gc.reborrow(),
             a,
             BUILTIN_STRING_MEMORY.length.into(),
             Value::try_from(n).unwrap(),
@@ -432,6 +453,8 @@ impl ArrayPrototype {
     /// > kinds of objects for use as a method.
     fn copy_within(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -490,11 +513,11 @@ impl ArrayPrototype {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len: i64 = length_of_array_like(agent, o)?;
+        let len: i64 = length_of_array_like(agent, gc.reborrow(), o)?;
         let len_f64 = len as f64;
 
         // 3. Let relativeTarget be ? ToIntegerOrInfinity(target).
-        let relative_target = to_integer_or_infinity(agent, target)?;
+        let relative_target = to_integer_or_infinity(agent, gc.reborrow(), target)?;
 
         let to = if relative_target.is_neg_infinity(agent) {
             // 4. If relativeTarget = -∞, let to be 0.
@@ -508,7 +531,7 @@ impl ArrayPrototype {
         };
 
         // 7. Let relativeStart be ? ToIntegerOrInfinity(start).
-        let relative_start = to_integer_or_infinity(agent, start)?;
+        let relative_start = to_integer_or_infinity(agent, gc.reborrow(), start)?;
 
         let from = if relative_start.is_neg_infinity(agent) {
             // 8. If relativeStart = -∞, let from be 0.
@@ -525,7 +548,7 @@ impl ArrayPrototype {
         let relative_end = if end.is_none() || end.unwrap().is_undefined() {
             len_f64
         } else {
-            to_integer_or_infinity(agent, end.unwrap())?.to_real(agent)
+            to_integer_or_infinity(agent, gc.reborrow(), end.unwrap())?.to_real(agent)
         };
         // 12. If relativeEnd = -∞, let final be 0.
         let final_end = if relative_end == f64::NEG_INFINITY {
@@ -560,18 +583,18 @@ impl ArrayPrototype {
             // b. Let toKey be ! ToString(𝔽(to)).
             let to_key = PropertyKey::Integer(to.try_into().unwrap());
             // c. Let fromPresent be ? HasProperty(O, fromKey).
-            let from_present = has_property(agent, o, from_key)?;
+            let from_present = has_property(agent, gc.reborrow(), o, from_key)?;
             // d. If fromPresent is true, then
             if from_present {
                 // i. Let fromValue be ? Get(O, fromKey).
-                let from_value = get(agent, o, from_key)?;
+                let from_value = get(agent, gc.reborrow(), o, from_key)?;
                 // ii. Perform ? Set(O, toKey, fromValue, true).
-                set(agent, o, to_key, from_value, true)?;
+                set(agent, gc.reborrow(), o, to_key, from_value, true)?;
             } else {
                 // e. Else,
                 // i. Assert: fromPresent is false.
                 // ii. Perform ? DeletePropertyOrThrow(O, toKey).
-                delete_property_or_throw(agent, o, to_key)?;
+                delete_property_or_throw(agent, gc.reborrow(), o, to_key)?;
             }
             // f. Set from to from + direction.
             from += direction;
@@ -584,7 +607,13 @@ impl ArrayPrototype {
         Ok(o.into_value())
     }
 
-    fn entries(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn entries(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be ? ToObject(this value).
         let Ok(o) = Object::try_from(this_value) else {
             return Err(agent.throw_exception_with_static_message(
@@ -632,11 +661,17 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that its this
     /// > value be an Array. Therefore it can be transferred to other kinds of
     /// > objects for use as a method.
-    fn every(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn every(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         let callback_fn = arguments.get(0);
         // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let Some(callback_fn) = is_callable(callback_fn) else {
@@ -653,15 +688,16 @@ impl ArrayPrototype {
             // a. Let Pk be ! ToString(𝔽(k)).
             let pk = PropertyKey::Integer(k.try_into().unwrap());
             // b. Let kPresent be ? HasProperty(O, Pk).
-            let k_present = has_property(agent, o, pk)?;
+            let k_present = has_property(agent, gc.reborrow(), o, pk)?;
             // c. If kPresent is true, then
             if k_present {
                 // i. Let kValue be ? Get(O, Pk).
-                let k_value = get(agent, o, pk)?;
+                let k_value = get(agent, gc.reborrow(), o, pk)?;
                 // ii. Let testResult be ToBoolean(? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »)).
                 let f_k = Number::try_from(k).unwrap().into_value();
                 let test_result = call_function(
                     agent,
+                    gc.reborrow(),
                     callback_fn,
                     this_arg,
                     Some(ArgumentsList(&[k_value, f_k])),
@@ -699,7 +735,13 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that its
     /// > this value be an Array. Therefore it can be transferred to other
     /// > kinds of objects for use as a method.
-    fn fill(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn fill(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let value = arguments.get(0);
         let start = arguments.get(1);
         let end = arguments.get(2);
@@ -746,9 +788,9 @@ impl ArrayPrototype {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         // 3. Let relativeStart be ? ToIntegerOrInfinity(start).
-        let relative_start = to_integer_or_infinity(agent, start)?.to_real(agent);
+        let relative_start = to_integer_or_infinity(agent, gc.reborrow(), start)?.to_real(agent);
 
         // 4. If relativeStart = -∞, let k be 0.
         let mut k = if relative_start == f64::NEG_INFINITY {
@@ -765,7 +807,7 @@ impl ArrayPrototype {
         let final_end = if end.is_undefined() {
             len
         } else {
-            let relative_end = to_integer_or_infinity(agent, end)?.to_real(agent);
+            let relative_end = to_integer_or_infinity(agent, gc.reborrow(), end)?.to_real(agent);
             // 8. If relativeEnd = -∞, let final be 0.
             if relative_end == f64::NEG_INFINITY {
                 0
@@ -783,7 +825,7 @@ impl ArrayPrototype {
             // a. Let Pk be ! ToString(𝔽(k)).
             let pk = PropertyKey::Integer(k.try_into().unwrap());
             // b. Perform ? Set(O, Pk, value, true).
-            set(agent, o, pk, value, true)?;
+            set(agent, gc.reborrow(), o, pk, value, true)?;
             // c. Set k to k + 1.
             k += 1;
         }
@@ -825,14 +867,20 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that its
     /// > **this** value be an Array. Therefore it can be transferred to other
     /// > kinds of objects for use as a method.
-    fn filter(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn filter(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let callback_fn = arguments.get(0);
         let this_arg = arguments.get(1);
 
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let Some(callback_fn) = is_callable(callback_fn) else {
             return Err(agent.throw_exception_with_static_message(
@@ -841,7 +889,7 @@ impl ArrayPrototype {
             ));
         };
         // 4. Let A be ? ArraySpeciesCreate(O, 0).
-        let a = array_species_create(agent, o, 0)?;
+        let a = array_species_create(agent, gc.reborrow(), o, 0)?;
         // 5. Let k be 0.
         let mut k = 0;
         // 6. Let to be 0.
@@ -851,14 +899,15 @@ impl ArrayPrototype {
             // a. Let Pk be ! ToString(𝔽(k)).
             let pk = PropertyKey::from(SmallInteger::try_from(k).unwrap());
             // b. Let kPresent be ? HasProperty(O, Pk).
-            let k_present = has_property(agent, o, pk)?;
+            let k_present = has_property(agent, gc.reborrow(), o, pk)?;
             // c. If kPresent is true, then
             if k_present {
                 // i. Let kValue be ? Get(O, Pk).
-                let k_value = get(agent, o, pk)?;
+                let k_value = get(agent, gc.reborrow(), o, pk)?;
                 // ii. Let selected be ToBoolean(? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »)).
                 let result = call_function(
                     agent,
+                    gc.reborrow(),
                     callback_fn,
                     this_arg,
                     Some(ArgumentsList(&[
@@ -871,7 +920,7 @@ impl ArrayPrototype {
                 // iii. If selected is true, then
                 if selected {
                     // 1. Perform ? CreateDataPropertyOrThrow(A, ! ToString(𝔽(to)), kValue).
-                    create_data_property_or_throw(agent, a, to.into(), k_value)?;
+                    create_data_property_or_throw(agent, gc.reborrow(), a, to.into(), k_value)?;
                     // 2. Set to to to + 1.
                     to += 1;
                 }
@@ -900,15 +949,21 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that its
     /// > this value be an Array. Therefore it can be transferred to other
     /// > kinds of objects for use as a method.
-    fn find(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn find(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         let predicate = arguments.get(0);
         let this_arg = arguments.get(1);
         // 3. Let findRec be ? FindViaPredicate(O, len, ascending, predicate, thisArg).
-        let find_rec = find_via_predicate(agent, o, len, true, predicate, this_arg)?;
+        let find_rec = find_via_predicate(agent, gc.reborrow(), o, len, true, predicate, this_arg)?;
         // 4. Return findRec.[[Value]].
         Ok(find_rec.1)
     }
@@ -932,17 +987,19 @@ impl ArrayPrototype {
     /// > kinds of objects for use as a method.
     fn find_index(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         let predicate = arguments.get(0);
         let this_arg = arguments.get(1);
         // 3. Let findRec be ? FindViaPredicate(O, len, ascending, predicate, thisArg).
-        let find_rec = find_via_predicate(agent, o, len, true, predicate, this_arg)?;
+        let find_rec = find_via_predicate(agent, gc.reborrow(), o, len, true, predicate, this_arg)?;
         // 4. Return findRec.[[Index]].
         Ok(Number::try_from(find_rec.0).unwrap().into_value())
     }
@@ -950,17 +1007,20 @@ impl ArrayPrototype {
     /// ### [23.1.3.11 Array.prototype.findLast ( predicate \[ , thisArg \] )](https://tc39.es/ecma262/#sec-array.prototype.findlast)
     fn find_last(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         let predicate = arguments.get(0);
         let this_arg = arguments.get(1);
         // 3. Let findRec be ? FindViaPredicate(O, len, descending, predicate, thisArg).
-        let find_rec = find_via_predicate(agent, o, len, false, predicate, this_arg)?;
+        let find_rec =
+            find_via_predicate(agent, gc.reborrow(), o, len, false, predicate, this_arg)?;
         // 4. Return findRec.[[Value]].
         Ok(find_rec.1)
     }
@@ -968,44 +1028,54 @@ impl ArrayPrototype {
     /// ### [23.1.3.12 Array.prototype.findLastIndex ( predicate \[ , thisArg \] )](https://tc39.es/ecma262/#sec-array.prototype.findlastindex)
     fn find_last_index(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         let predicate = arguments.get(0);
         let this_arg = arguments.get(1);
         // 3. Let findRec be ? FindViaPredicate(O, len, descending, predicate, thisArg).
-        let find_rec = find_via_predicate(agent, o, len, false, predicate, this_arg)?;
+        let find_rec =
+            find_via_predicate(agent, gc.reborrow(), o, len, false, predicate, this_arg)?;
         // 4. Return findRec.[[Index]].
         Ok(Number::try_from(find_rec.0).unwrap().into_value())
     }
 
     /// ### [23.1.3.13 Array.prototype.flat ( \[ depth \] )]()
-    fn flat(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn flat(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let depth = arguments.get(0);
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let sourceLen be ? LengthOfArrayLike(O).
-        let source_len = length_of_array_like(agent, o)? as usize;
+        let source_len = length_of_array_like(agent, gc.reborrow(), o)? as usize;
         // 3. Let depthNum be 1.
         let mut depth_num = 1;
         // 4. If depth is not undefined, then
         if !depth.is_undefined() {
             // a. Set depthNum to ? ToIntegerOrInfinity(depth).
-            depth_num = to_integer_or_infinity(agent, depth)?.into_i64(agent);
+            depth_num = to_integer_or_infinity(agent, gc.reborrow(), depth)?.into_i64(agent);
         }
         // b. If depthNum < 0, set depthNum to 0.
         if depth_num < 0 {
             depth_num = 0;
         }
         // 5. Let A be ? ArraySpeciesCreate(O, 0).
-        let a = array_species_create(agent, o, 0)?;
+        let a = array_species_create(agent, gc.reborrow(), o, 0)?;
         // 6. Perform ? FlattenIntoArray(A, O, sourceLen, 0, depthNum).
         flatten_into_array(
             agent,
+            gc.reborrow(),
             a,
             o,
             source_len,
@@ -1019,14 +1089,20 @@ impl ArrayPrototype {
     }
 
     /// ### [23.1.3.14 Array.prototype.flatMap ( mapperFunction \[ , thisArg \] )](https://tc39.es/ecma262/#sec-array.prototype.flatmap)
-    fn flat_map(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn flat_map(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let mapper_function = arguments.get(0);
         let this_arg = arguments.get(1);
 
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let sourceLen be ? LengthOfArrayLike(O).
-        let source_len = length_of_array_like(agent, o)? as usize;
+        let source_len = length_of_array_like(agent, gc.reborrow(), o)? as usize;
         // 3. If IsCallable(mapperFunction) is false, throw a TypeError exception.
         let Some(mapper_function) = is_callable(mapper_function) else {
             return Err(agent.throw_exception_with_static_message(
@@ -1035,10 +1111,11 @@ impl ArrayPrototype {
             ));
         };
         // 4. Let A be ? ArraySpeciesCreate(O, 0).
-        let a = array_species_create(agent, o, 0)?;
+        let a = array_species_create(agent, gc.reborrow(), o, 0)?;
         // 5. Perform ? FlattenIntoArray(A, O, sourceLen, 0, 1, mapperFunction, thisArg).
         flatten_into_array(
             agent,
+            gc.reborrow(),
             a,
             o,
             source_len,
@@ -1085,11 +1162,17 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that
     /// > its this value be an Array. Therefore it can be transferred to
     /// > other kinds of objects for use as a method.
-    fn for_each(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn for_each(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
 
         let callback_fn = arguments.get(0);
 
@@ -1109,14 +1192,15 @@ impl ArrayPrototype {
             // a. Let Pk be ! ToString(𝔽(k)).
             let pk = PropertyKey::Integer(k.try_into().unwrap());
             // b. Let kPresent be ? HasProperty(O, Pk).
-            let k_present = has_property(agent, o, pk)?;
+            let k_present = has_property(agent, gc.reborrow(), o, pk)?;
             // c. If kPresent is true, then
             if k_present {
                 // i. Let kValue be ? Get(O, Pk).
-                let k_value = get(agent, o, pk)?;
+                let k_value = get(agent, gc.reborrow(), o, pk)?;
                 // ii. Perform ? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »).
                 call_function(
                     agent,
+                    gc.reborrow(),
                     callback_fn,
                     this_arg,
                     Some(ArgumentsList(&[
@@ -1162,7 +1246,13 @@ impl ArrayPrototype {
     /// > of IsStrictlyEqual, allowing it to detect NaN array elements.
     /// > Second, it does not skip missing array elements, instead treating
     /// > them as undefined.
-    fn includes(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn includes(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let search_element = arguments.get(0);
         let from_index = arguments.get(1);
         if let (Value::Array(array), Value::Undefined | Value::Integer(_)) =
@@ -1209,13 +1299,13 @@ impl ArrayPrototype {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         // 3. If len = 0, return false.
         if len == 0 {
             return Ok(false.into());
         }
         // 4. Let n be ? ToIntegerOrInfinity(fromIndex).
-        let n = to_integer_or_infinity(agent, from_index)?;
+        let n = to_integer_or_infinity(agent, gc.reborrow(), from_index)?;
         // 5. Assert: If fromIndex is undefined, then n is 0.
         assert_eq!(from_index.is_undefined(), n.is_pos_zero(agent));
         // 6. If n = +∞, return false.
@@ -1247,7 +1337,7 @@ impl ArrayPrototype {
         while k < len {
             // a. Let elementK be ? Get(O, ! ToString(𝔽(k))).
             let pk = PropertyKey::Integer(k.try_into().unwrap());
-            let element_k = get(agent, o, pk)?;
+            let element_k = get(agent, gc.reborrow(), o, pk)?;
             // b. If SameValueZero(searchElement, elementK) is true, return true.
             if same_value_zero(agent, search_element, element_k) {
                 return Ok(true.into());
@@ -1280,7 +1370,13 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that
     /// > its this value be an Array. Therefore it can be transferred to
     /// > other kinds of objects for use as a method.
-    fn index_of(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn index_of(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let search_element = arguments.get(0);
         let from_index = arguments.get(1);
         if let (Value::Array(array), Value::Undefined | Value::Integer(_)) =
@@ -1327,13 +1423,13 @@ impl ArrayPrototype {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         // 3. If len = 0, return -1𝔽.
         if len == 0 {
             return Ok((-1).into());
         }
         // 4. Let n be ? ToIntegerOrInfinity(fromIndex).
-        let n = to_integer_or_infinity(agent, from_index)?;
+        let n = to_integer_or_infinity(agent, gc.reborrow(), from_index)?;
         // 5. Assert: If fromIndex is undefined, then n is 0.
         assert_eq!(from_index.is_undefined(), n.is_pos_zero(agent));
         // 6. If n = +∞, return -1𝔽.
@@ -1366,11 +1462,11 @@ impl ArrayPrototype {
             // a. Let Pk be ! ToString(𝔽(k)).
             let pk = PropertyKey::Integer(k.try_into().unwrap());
             // b. Let kPresent be ? HasProperty(O, Pk).
-            let k_present = has_property(agent, o, pk)?;
+            let k_present = has_property(agent, gc.reborrow(), o, pk)?;
             // c. If kPresent is true, then
             if k_present {
                 // i. Let elementK be ? Get(O, Pk).
-                let element_k = get(agent, o, pk)?;
+                let element_k = get(agent, gc.reborrow(), o, pk)?;
                 // ii. If IsStrictlyEqual(searchElement, elementK) is true, return 𝔽(k).
                 if is_strictly_equal(agent, search_element, element_k) {
                     return Ok(k.try_into().unwrap());
@@ -1388,13 +1484,19 @@ impl ArrayPrototype {
     /// This method converts the elements of the array to Strings, and then
     /// concatenates these Strings, separated by occurrences of the separator.
     /// If no separator is provided, a single comma is used as the separator.
-    fn join(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn join(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let separator = arguments.get(0);
 
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         if len == 0 {
             return Ok(String::EMPTY_STRING.into_value());
         }
@@ -1404,7 +1506,7 @@ impl ArrayPrototype {
             SmallString::from_str_unchecked(",").into()
         } else {
             // 4. Else, let sep be ? ToString(separator).
-            to_string(agent, separator)?
+            to_string(agent, gc.reborrow(), separator)?
         };
         // 5. Let R be the empty String.
         let mut r = std::string::String::with_capacity(len * 10);
@@ -1412,11 +1514,11 @@ impl ArrayPrototype {
         // 7. Repeat, while k < len,
         // b. Let element be ? Get(O, ! ToString(𝔽(k))).
         {
-            let element = get(agent, o, 0.into())?;
+            let element = get(agent, gc.reborrow(), o, 0.into())?;
             // c. If element is neither undefined nor null, then
             if !element.is_undefined() && !element.is_null() {
                 // i. Let S be ? ToString(element).
-                let s = to_string(agent, element)?;
+                let s = to_string(agent, gc.reborrow(), element)?;
                 // ii. Set R to the string-concatenation of R and S.
                 r.push_str(s.as_str(agent));
             }
@@ -1425,11 +1527,16 @@ impl ArrayPrototype {
             // a. If k > 0, set R to the string-concatenation of R and sep.
             r.push_str(separator.as_str(agent));
             // b. Let element be ? Get(O, ! ToString(𝔽(k))).
-            let element = get(agent, o, SmallInteger::try_from(k as u64).unwrap().into())?;
+            let element = get(
+                agent,
+                gc.reborrow(),
+                o,
+                SmallInteger::try_from(k as u64).unwrap().into(),
+            )?;
             // c. If element is neither undefined nor null, then
             if !element.is_undefined() && !element.is_null() {
                 // i. Let S be ? ToString(element).
-                let s = to_string(agent, element)?;
+                let s = to_string(agent, gc.reborrow(), element)?;
                 // ii. Set R to the string-concatenation of R and S.
                 r.push_str(s.as_str(agent));
             }
@@ -1439,7 +1546,13 @@ impl ArrayPrototype {
         Ok(Value::from_string(agent, r).into_value())
     }
 
-    fn keys(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn keys(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be ? ToObject(this value).
         let Ok(o) = Object::try_from(this_value) else {
             return Err(agent.throw_exception_with_static_message(
@@ -1474,6 +1587,8 @@ impl ArrayPrototype {
     /// > kinds of objects for use as a method.
     fn last_index_of(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -1530,14 +1645,14 @@ impl ArrayPrototype {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         // 3. If len = 0, return -1𝔽.
         if len == 0 {
             return Ok((-1).into());
         }
         // 4. If fromIndex is present, let n be ? ToIntegerOrInfinity(fromIndex); else let n be len - 1.
         let n = if let Some(from_index) = from_index {
-            to_integer_or_infinity(agent, from_index)?.into_f64(agent)
+            to_integer_or_infinity(agent, gc.reborrow(), from_index)?.into_f64(agent)
         } else {
             (len - 1) as f64
         };
@@ -1560,11 +1675,11 @@ impl ArrayPrototype {
             // a. Let Pk be ! ToString(𝔽(k)).
             let pk = PropertyKey::Integer(k.try_into().unwrap());
             // b. Let kPresent be ? HasProperty(O, Pk).
-            let k_present = has_property(agent, o, pk)?;
+            let k_present = has_property(agent, gc.reborrow(), o, pk)?;
             // c. If kPresent is true, then
             if k_present {
                 // i. Let elementK be ? Get(O, Pk).
-                let element_k = get(agent, o, pk)?;
+                let element_k = get(agent, gc.reborrow(), o, pk)?;
                 // ii. If IsStrictlyEqual(searchElement, elementK) is true, return 𝔽(k).
                 if is_strictly_equal(agent, search_element, element_k) {
                     return Ok(k.try_into().unwrap());
@@ -1610,14 +1725,20 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that its
     /// > this value be an Array. Therefore it can be transferred to other
     /// > kinds of objects for use as a method.
-    fn map(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn map(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let callback_fn = arguments.get(0);
         let this_arg = arguments.get(1);
 
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let Some(callback_fn) = is_callable(callback_fn) else {
             return Err(agent.throw_exception_with_static_message(
@@ -1626,7 +1747,7 @@ impl ArrayPrototype {
             ));
         };
         // 4. Let A be ? ArraySpeciesCreate(O, len).
-        let a = array_species_create(agent, o, len as usize)?;
+        let a = array_species_create(agent, gc.reborrow(), o, len as usize)?;
         // 5. Let k be 0.
         let mut k = 0;
         // 6. Repeat, while k < len,
@@ -1634,14 +1755,15 @@ impl ArrayPrototype {
             // a. Let Pk be ! ToString(𝔽(k)).
             let pk = PropertyKey::Integer(k.try_into().unwrap());
             // b. Let kPresent be ? HasProperty(O, Pk).
-            let k_present = has_property(agent, o, pk)?;
+            let k_present = has_property(agent, gc.reborrow(), o, pk)?;
             // c. If kPresent is true, then
             if k_present {
                 // i. Let kValue be ? Get(O, Pk).
-                let k_value = get(agent, o, pk)?;
+                let k_value = get(agent, gc.reborrow(), o, pk)?;
                 // ii. Let mappedValue be ? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »).
                 let mapped_value = call_function(
                     agent,
+                    gc.reborrow(),
                     callback_fn,
                     this_arg,
                     Some(ArgumentsList(&[
@@ -1651,7 +1773,7 @@ impl ArrayPrototype {
                     ])),
                 )?;
                 // iii. Perform ? CreateDataPropertyOrThrow(A, Pk, mappedValue).
-                create_data_property_or_throw(agent, a, pk, mapped_value)?;
+                create_data_property_or_throw(agent, gc.reborrow(), a, pk, mapped_value)?;
             }
             // d. Set k to k + 1.
             k += 1;
@@ -1671,7 +1793,13 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that
     /// > its this value be an Array. Therefore it can be transferred to
     /// > other kinds of objects for use as a method.
-    fn pop(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn pop(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         if let Value::Array(array) = this_value {
             // Fast path: Trivial (no descriptors) array means mutating
             // elements is direct.
@@ -1709,12 +1837,13 @@ impl ArrayPrototype {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         // 3. If len = 0, then
         if len == 0 {
             // a. Perform ? Set(O, "length", +0𝔽, true).
             set(
                 agent,
+                gc.reborrow(),
                 o,
                 BUILTIN_STRING_MEMORY.length.into(),
                 0.into(),
@@ -1731,12 +1860,13 @@ impl ArrayPrototype {
             // c. Let index be ! ToString(newLen).
             let index = PropertyKey::Integer(new_len.try_into().unwrap());
             // d. Let element be ? Get(O, index).
-            let element = get(agent, o, index)?;
+            let element = get(agent, gc.reborrow(), o, index)?;
             // e. Perform ? DeletePropertyOrThrow(O, index).
-            delete_property_or_throw(agent, o, index)?;
+            delete_property_or_throw(agent, gc.reborrow(), o, index)?;
             // f. Perform ? Set(O, "length", newLen, true).
             set(
                 agent,
+                gc.reborrow(),
                 o,
                 BUILTIN_STRING_MEMORY.length.into(),
                 new_len.try_into().unwrap(),
@@ -1760,11 +1890,17 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that
     /// > its this value be an Array. Therefore it can be transferred to
     /// > other kinds of objects for use as a method.
-    fn push(agent: &mut Agent, this_value: Value, items: ArgumentsList) -> JsResult<Value> {
+    fn push(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        items: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let mut len = length_of_array_like(agent, o)?;
+        let mut len = length_of_array_like(agent, gc.reborrow(), o)?;
         // 3. Let argCount be the number of elements in items.
         let arg_count = items.len();
         // 4. If len + argCount > 2**53 - 1, throw a TypeError exception.
@@ -1788,6 +1924,7 @@ impl ArrayPrototype {
             // a. Perform ? Set(O, ! ToString(𝔽(len)), E, true).
             set(
                 agent,
+                gc.reborrow(),
                 o,
                 PropertyKey::Integer(len.try_into().unwrap()),
                 *e,
@@ -1798,7 +1935,14 @@ impl ArrayPrototype {
         }
         // 6. Perform ? Set(O, "length", 𝔽(len), true).
         let len: Value = len.try_into().unwrap();
-        set(agent, o, BUILTIN_STRING_MEMORY.length.into(), len, true)?;
+        set(
+            agent,
+            gc.reborrow(),
+            o,
+            BUILTIN_STRING_MEMORY.length.into(),
+            len,
+            true,
+        )?;
 
         // 7. Return 𝔽(len).
         Ok(len)
@@ -1840,7 +1984,13 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that
     /// > its this value be an Array. Therefore it can be transferred to
     /// > other kinds of objects for use as a method.
-    fn reduce(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn reduce(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let callback_fn = arguments.get(0);
         let initial_value = if arguments.len() >= 2 {
             Some(arguments.get(1))
@@ -1851,7 +2001,7 @@ impl ArrayPrototype {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
 
         // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let Some(callback_fn) = is_callable(callback_fn) else {
@@ -1887,12 +2037,12 @@ impl ArrayPrototype {
                 let pk = PropertyKey::Integer(k.try_into().unwrap());
 
                 // ii. Set kPresent to ? HasProperty(O, Pk).
-                k_present = has_property(agent, o, pk)?;
+                k_present = has_property(agent, gc.reborrow(), o, pk)?;
 
                 // iii. If kPresent is true, then
                 if k_present {
                     // 1. Set accumulator to ? Get(O, Pk).
-                    accumulator = get(agent, o, pk)?;
+                    accumulator = get(agent, gc.reborrow(), o, pk)?;
                 }
 
                 // iv. Set k to k + 1.
@@ -1915,16 +2065,17 @@ impl ArrayPrototype {
             let pk = PropertyKey::Integer(k_int);
 
             // b. Let kPresent be ? HasProperty(O, Pk).
-            let k_present = has_property(agent, o, pk)?;
+            let k_present = has_property(agent, gc.reborrow(), o, pk)?;
 
             // c. If kPresent is true, then
             if k_present {
                 // i. Let kValue be ? Get(O, Pk).
-                let k_value = get(agent, o, pk)?;
+                let k_value = get(agent, gc.reborrow(), o, pk)?;
 
                 // ii. Set accumulator to ? Call(callbackfn, undefined, « accumulator, kValue, 𝔽(k), O »).
                 accumulator = call_function(
                     agent,
+                    gc.reborrow(),
                     callback_fn,
                     Value::Undefined,
                     Some(ArgumentsList(&[
@@ -1982,6 +2133,8 @@ impl ArrayPrototype {
     /// > kinds of objects for use as a method.
     fn reduce_right(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -1996,7 +2149,7 @@ impl ArrayPrototype {
         let o = to_object(agent, this_value)?;
 
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
 
         // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let Some(callback_fn) = is_callable(callback_fn) else {
@@ -2032,12 +2185,12 @@ impl ArrayPrototype {
                 let pk = PropertyKey::try_from(k).unwrap();
 
                 // ii. Set kPresent to ? HasProperty(O, Pk).
-                k_present = has_property(agent, o, pk)?;
+                k_present = has_property(agent, gc.reborrow(), o, pk)?;
 
                 // iii. If kPresent is true, then
                 if k_present {
                     // 1. Set accumulator to ? Get(O, Pk).
-                    accumulator = get(agent, o, pk)?;
+                    accumulator = get(agent, gc.reborrow(), o, pk)?;
                 }
 
                 // iv. Set k to k - 1.
@@ -2059,16 +2212,17 @@ impl ArrayPrototype {
             let pk = PropertyKey::try_from(k).unwrap();
 
             // b. Let kPresent be ? HasProperty(O, Pk).
-            let k_present = has_property(agent, o, pk)?;
+            let k_present = has_property(agent, gc.reborrow(), o, pk)?;
 
             // c. If kPresent is true, then
             if k_present {
                 // i. Let kValue be ? Get(O, Pk).
-                let k_value = get(agent, o, pk)?;
+                let k_value = get(agent, gc.reborrow(), o, pk)?;
 
                 // ii. Set accumulator to ? Call(callbackfn, undefined, « accumulator, kValue, 𝔽(k), O »).
                 accumulator = call_function(
                     agent,
+                    gc.reborrow(),
                     callback_fn,
                     Value::Undefined,
                     Some(ArgumentsList(&[
@@ -2088,7 +2242,13 @@ impl ArrayPrototype {
         Ok(accumulator)
     }
 
-    fn reverse(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn reverse(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         if let Value::Array(array) = this_value {
             // Fast path: Array is dense and contains no descriptors. No JS
             // functions can thus be called by shift.
@@ -2101,7 +2261,7 @@ impl ArrayPrototype {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         // 3. Let middle be floor(len / 2).
         let middle = len / 2;
         // 4. Let lower be 0.
@@ -2117,36 +2277,36 @@ impl ArrayPrototype {
             //    d. Let lowerExists be ? HasProperty(O, lowerP).
             //    e. If lowerExists is true, then
             //       i. Let lowerValue be ? Get(O, lowerP).
-            let lower_exists = has_property(agent, o, lower_p)?;
+            let lower_exists = has_property(agent, gc.reborrow(), o, lower_p)?;
             //    f. Let upperExists be ? HasProperty(O, upperP).
             //    g. If upperExists is true, then
             //       i. Let upperValue be ? Get(O, upperP).
-            let upper_exists = has_property(agent, o, upper_p)?;
+            let upper_exists = has_property(agent, gc.reborrow(), o, upper_p)?;
 
             //    h. If lowerExists is true and upperExists is true, then
             if lower_exists && upper_exists {
                 //       i. Perform ? Set(O, lowerP, upperValue, true).
                 //       ii. Perform ? Set(O, upperP, lowerValue, true).
-                let lower_value = get(agent, o, lower_p)?;
-                let upper_value = get(agent, o, upper_p)?;
-                set(agent, o, lower_p, upper_value, true)?;
-                set(agent, o, upper_p, lower_value, true)?;
+                let lower_value = get(agent, gc.reborrow(), o, lower_p)?;
+                let upper_value = get(agent, gc.reborrow(), o, upper_p)?;
+                set(agent, gc.reborrow(), o, lower_p, upper_value, true)?;
+                set(agent, gc.reborrow(), o, upper_p, lower_value, true)?;
             }
             //    i. Else if lowerExists is false and upperExists is true, then
             else if !lower_exists && upper_exists {
                 //       i. Perform ? Set(O, lowerP, upperValue, true).
                 //       ii. Perform ? DeletePropertyOrThrow(O, upperP).
-                let upper_value = get(agent, o, upper_p)?;
-                set(agent, o, lower_p, upper_value, true)?;
-                delete_property_or_throw(agent, o, upper_p)?;
+                let upper_value = get(agent, gc.reborrow(), o, upper_p)?;
+                set(agent, gc.reborrow(), o, lower_p, upper_value, true)?;
+                delete_property_or_throw(agent, gc.reborrow(), o, upper_p)?;
             }
             //    j. Else if lowerExists is true and upperExists is false, then
             else if lower_exists && !upper_exists {
                 //       i. Perform ? DeletePropertyOrThrow(O, lowerP).
                 //       ii. Perform ? Set(O, upperP, lowerValue, true).
-                let lower_value = get(agent, o, lower_p)?;
-                delete_property_or_throw(agent, o, lower_p)?;
-                set(agent, o, upper_p, lower_value, true)?;
+                let lower_value = get(agent, gc.reborrow(), o, lower_p)?;
+                delete_property_or_throw(agent, gc.reborrow(), o, lower_p)?;
+                set(agent, gc.reborrow(), o, upper_p, lower_value, true)?;
             }
             //    k. Else,
             else {
@@ -2170,7 +2330,13 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that its
     /// > this value be an Array. Therefore it can be transferred to other
     /// > kinds of objects for use as a method.
-    fn shift(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn shift(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         if let Value::Array(array) = this_value {
             if array.is_empty(agent) {
                 if agent[array].elements.len_writable {
@@ -2179,6 +2345,7 @@ impl ArrayPrototype {
                     // This will throw
                     set(
                         agent,
+                        gc.reborrow(),
                         array.into_object(),
                         BUILTIN_STRING_MEMORY.length.into(),
                         0.into(),
@@ -2202,6 +2369,7 @@ impl ArrayPrototype {
                     // This will throw
                     set(
                         agent,
+                        gc.reborrow(),
                         array.into_object(),
                         BUILTIN_STRING_MEMORY.length.into(),
                         (array.len(agent) - 1).into(),
@@ -2214,12 +2382,13 @@ impl ArrayPrototype {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         // 3. If len = 0, then
         if len == 0 {
             // a. Perform ? Set(O, "length", +0𝔽, true).
             set(
                 agent,
+                gc.reborrow(),
                 o,
                 BUILTIN_STRING_MEMORY.length.into(),
                 0.into(),
@@ -2229,7 +2398,7 @@ impl ArrayPrototype {
             return Ok(Value::Undefined);
         }
         // 4. Let first be ? Get(O, "0").
-        let first = get(agent, o, 0.into())?;
+        let first = get(agent, gc.reborrow(), o, 0.into())?;
         // 5. Let k be 1.
         let mut k = 1;
         // 6. Repeat, while k < len,
@@ -2239,27 +2408,28 @@ impl ArrayPrototype {
             // b. Let to be ! ToString(𝔽(k - 1)).
             let to = (k - 1).try_into().unwrap();
             // c. Let fromPresent be ? HasProperty(O, from).
-            let from_present = has_property(agent, o, from)?;
+            let from_present = has_property(agent, gc.reborrow(), o, from)?;
             // d. If fromPresent is true, then
             if from_present {
                 // i. Let fromValue be ? Get(O, from).
-                let from_value = get(agent, o, from)?;
+                let from_value = get(agent, gc.reborrow(), o, from)?;
                 // ii. Perform ? Set(O, to, fromValue, true).
-                set(agent, o, to, from_value, true)?;
+                set(agent, gc.reborrow(), o, to, from_value, true)?;
             } else {
                 // e. Else,
                 // i. Assert: fromPresent is false.
                 // ii. Perform ? DeletePropertyOrThrow(O, to).
-                delete_property_or_throw(agent, o, to)?;
+                delete_property_or_throw(agent, gc.reborrow(), o, to)?;
             }
             // f. Set k to k + 1.
             k += 1;
         }
         // 7. Perform ? DeletePropertyOrThrow(O, ! ToString(𝔽(len - 1))).
-        delete_property_or_throw(agent, o, (len - 1).try_into().unwrap())?;
+        delete_property_or_throw(agent, gc.reborrow(), o, (len - 1).try_into().unwrap())?;
         // 8. Perform ? Set(O, "length", 𝔽(len - 1), true).
         set(
             agent,
+            gc.reborrow(),
             o,
             BUILTIN_STRING_MEMORY.length.into(),
             (len - 1).try_into().unwrap(),
@@ -2286,7 +2456,13 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that its
     /// > this value be an Array. Therefore it can be transferred to other
     /// > kinds of objects for use as a method.
-    fn slice(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn slice(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let start = arguments.get(0);
         let end = arguments.get(1);
         if let (
@@ -2318,10 +2494,11 @@ impl ArrayPrototype {
                     len
                 };
                 let count = end.saturating_sub(start);
-                let a = array_species_create(agent, array.into_object(), count)?;
+                let a = array_species_create(agent, gc.reborrow(), array.into_object(), count)?;
                 if count == 0 {
                     set(
                         agent,
+                        gc.reborrow(),
                         a,
                         BUILTIN_STRING_MEMORY.length.into(),
                         0.into(),
@@ -2347,6 +2524,7 @@ impl ArrayPrototype {
                         };
                         set(
                             agent,
+                            gc.reborrow(),
                             a.into_object(),
                             BUILTIN_STRING_MEMORY.length.into(),
                             Number::try_from(count).unwrap().into_value(),
@@ -2365,7 +2543,7 @@ impl ArrayPrototype {
                     // i. Let kValue be ? Get(O, Pk).
                     let k_value = array.as_slice(agent)[k].unwrap();
                     // ii. Perform ? CreateDataPropertyOrThrow(A, ! ToString(𝔽(n)), kValue).
-                    create_data_property_or_throw(agent, a, n.into(), k_value)?;
+                    create_data_property_or_throw(agent, gc.reborrow(), a, n.into(), k_value)?;
                     // d. Set k to k + 1.
                     k += 1;
                     // e. Set n to n + 1.
@@ -2374,6 +2552,7 @@ impl ArrayPrototype {
                 // 15. Perform ? Set(A, "length", 𝔽(n), true).
                 set(
                     agent,
+                    gc.reborrow(),
                     a.into_object(),
                     BUILTIN_STRING_MEMORY.length.into(),
                     n.into(),
@@ -2386,9 +2565,9 @@ impl ArrayPrototype {
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)? as usize;
+        let len = length_of_array_like(agent, gc.reborrow(), o)? as usize;
         // 3. Let relativeStart be ? ToIntegerOrInfinity(start).
-        let relative_start = to_integer_or_infinity(agent, start)?;
+        let relative_start = to_integer_or_infinity(agent, gc.reborrow(), start)?;
         // 4. If relativeStart = -∞, let k be 0.
         let mut k = if relative_start.is_neg_infinity(agent) {
             0
@@ -2404,7 +2583,7 @@ impl ArrayPrototype {
         let relative_end = if end.is_undefined() {
             len.try_into().unwrap()
         } else {
-            to_integer_or_infinity(agent, end)?
+            to_integer_or_infinity(agent, gc.reborrow(), end)?
         };
         // 8. If relativeEnd = -∞, let final be 0.
         let final_end = if relative_end.is_neg_infinity(agent) {
@@ -2419,7 +2598,7 @@ impl ArrayPrototype {
         // 11. Let count be max(final - k, 0).
         let count = final_end.saturating_sub(k);
         // 12. Let A be ? ArraySpeciesCreate(O, count).
-        let a = array_species_create(agent, o, count)?;
+        let a = array_species_create(agent, gc.reborrow(), o, count)?;
         // 13. Let n be 0.
         let mut n = 0u32;
         // 14. Repeat, while k < final,
@@ -2427,13 +2606,13 @@ impl ArrayPrototype {
             // a. Let Pk be ! ToString(𝔽(k)).
             let pk = k.try_into().unwrap();
             // b. Let kPresent be ? HasProperty(O, Pk).
-            let k_present = has_property(agent, o, pk)?;
+            let k_present = has_property(agent, gc.reborrow(), o, pk)?;
             // c. If kPresent is true, then
             if k_present {
                 // i. Let kValue be ? Get(O, Pk).
-                let k_value = get(agent, o, pk)?;
+                let k_value = get(agent, gc.reborrow(), o, pk)?;
                 // ii. Perform ? CreateDataPropertyOrThrow(A, ! ToString(𝔽(n)), kValue).
-                create_data_property_or_throw(agent, a, n.into(), k_value)?;
+                create_data_property_or_throw(agent, gc.reborrow(), a, n.into(), k_value)?;
             }
             // d. Set k to k + 1.
             k += 1;
@@ -2443,6 +2622,7 @@ impl ArrayPrototype {
         // 15. Perform ? Set(A, "length", 𝔽(n), true).
         set(
             agent,
+            gc.reborrow(),
             a,
             BUILTIN_STRING_MEMORY.length.into(),
             n.into(),
@@ -2490,14 +2670,20 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that its
     /// > this value be an Array. Therefore it can be transferred to other
     /// > kinds of objects for use as a method.
-    fn some(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn some(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let callback_fn = arguments.get(0);
         let this_arg = arguments.get(1);
 
         // 1. Let O be ? ToObject(this value).
         let o = to_object(agent, this_value)?;
         // 2. Let len be ? LengthOfArrayLike(O).
-        let len = length_of_array_like(agent, o)?;
+        let len = length_of_array_like(agent, gc.reborrow(), o)?;
         // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let Some(callback_fn) = is_callable(callback_fn) else {
             return Err(agent.throw_exception_with_static_message(
@@ -2512,14 +2698,15 @@ impl ArrayPrototype {
             // a. Let Pk be ! ToString(𝔽(k)).
             let pk = k.try_into().unwrap();
             // b. Let kPresent be ? HasProperty(O, Pk).
-            let k_present = has_property(agent, o, pk)?;
+            let k_present = has_property(agent, gc.reborrow(), o, pk)?;
             // c. If kPresent is true, then
             if k_present {
                 // i. Let kValue be ? Get(O, Pk).
-                let k_value = get(agent, o, pk)?;
+                let k_value = get(agent, gc.reborrow(), o, pk)?;
                 // ii. Let testResult be ToBoolean(? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »)).
                 let test_result = call_function(
                     agent,
+                    gc.reborrow(),
                     callback_fn,
                     this_arg,
                     Some(ArgumentsList(&[
@@ -2564,7 +2751,13 @@ impl ArrayPrototype {
     /// > This method is intentionally generic; it does not require that its
     /// > this value be an Array. Therefore, it can be transferred to other
     /// > kinds of objects for use as a method.
-    fn sort(agent: &mut Agent, this_value: Value, args: ArgumentsList) -> JsResult<Value> {
+    fn sort(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        args: ArgumentsList,
+    ) -> JsResult<Value> {
         let comparator = args.get(0);
         // 1. If comparator is not undefined and IsCallable(comparator) is false, throw a TypeError exception.
         let comparator = if comparator.is_undefined() {
@@ -2577,7 +2770,7 @@ impl ArrayPrototype {
         // 2. Let obj be ? ToObject(this value).
         let obj = to_object(agent, this_value)?;
         // 3. Let len be ? LengthOfArrayLike(obj).
-        let len = usize::try_from(length_of_array_like(agent, obj)?).unwrap();
+        let len = usize::try_from(length_of_array_like(agent, gc.reborrow(), obj)?).unwrap();
         // 4. Let SortCompare be a new Abstract Closure with parameters (x, y)
         //     that captures comparator and performs the following steps when
         //     called:
@@ -2585,7 +2778,7 @@ impl ArrayPrototype {
         // 5. Let sortedList be ? SortIndexedProperties(obj, len, SortCompare,
         //     skip-holes).
         let sorted_list: Vec<Value> =
-            sort_indexed_properties::<true, false>(agent, obj, len, comparator)?;
+            sort_indexed_properties::<true, false>(agent, gc.reborrow(), obj, len, comparator)?;
         // 6. Let itemCount be the number of elements in sortedList.
         let item_count = sorted_list.len();
         // 7. Let j be 0.
@@ -2593,7 +2786,14 @@ impl ArrayPrototype {
         // 8. Repeat, while j < itemCount,
         while j < item_count {
             // a. Perform ? Set(obj, ! ToString(𝔽(j)), sortedList[j], true).
-            set(agent, obj, j.try_into().unwrap(), sorted_list[j], true)?;
+            set(
+                agent,
+                gc.reborrow(),
+                obj,
+                j.try_into().unwrap(),
+                sorted_list[j],
+                true,
+            )?;
             // b. Set j to j + 1.
             j += 1;
         }
@@ -2604,7 +2804,7 @@ impl ArrayPrototype {
         // 10. Repeat, while j < len,
         while j < len {
             // a. Perform ? DeletePropertyOrThrow(obj, ! ToString(𝔽(j))).
-            delete_property_or_throw(agent, obj, j.try_into().unwrap())?;
+            delete_property_or_throw(agent, gc.reborrow(), obj, j.try_into().unwrap())?;
             // b. Set j to j + 1.
             j += 1;
         }
@@ -2612,36 +2812,73 @@ impl ArrayPrototype {
         Ok(obj.into_value())
     }
 
-    fn splice(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
-        todo!();
-    }
-
-    fn to_locale_string(
+    fn splice(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
         todo!();
     }
 
-    fn to_reversed(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_locale_string(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn to_sorted(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_reversed(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn to_spliced(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_sorted(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
+        todo!();
+    }
+
+    fn to_spliced(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
     /// ### [23.1.3.36 Array.prototype.toString ( )](https://tc39.es/ecma262/#sec-array.prototype.tostring)
-    fn to_string(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_string(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let array be ? ToObject(this value).
         let array = to_object(agent, this_value)?;
         // 2. Let func be ? Get(array, "join").
-        let func = get(agent, array, BUILTIN_STRING_MEMORY.join.into())?;
+        let func = get(
+            agent,
+            gc.reborrow(),
+            array,
+            BUILTIN_STRING_MEMORY.join.into(),
+        )?;
         // 3. If IsCallable(func) is false, set func to the intrinsic function %Object.prototype.toString%.
         let func = is_callable(func).unwrap_or_else(|| {
             agent
@@ -2651,14 +2888,26 @@ impl ArrayPrototype {
                 .into_function()
         });
         // 4. Return ? Call(func, array).
-        call_function(agent, func, array.into_value(), None)
+        call_function(agent, gc, func, array.into_value(), None)
     }
 
-    fn unshift(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn unshift(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn values(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn values(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be ? ToObject(this value).
         let Ok(o) = Object::try_from(this_value) else {
             return Err(agent.throw_exception_with_static_message(
@@ -2670,7 +2919,13 @@ impl ArrayPrototype {
         Ok(ArrayIterator::from_object(agent, o, CollectionIteratorKind::Value).into_value())
     }
 
-    fn with(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn with(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
@@ -2792,11 +3047,21 @@ impl ArrayPrototype {
 ///
 /// > Note: Instead of returning a bool, Nova returns an Option<Object>.
 
-fn is_concat_spreadable(agent: &mut Agent, o: Value) -> JsResult<Option<Object>> {
+fn is_concat_spreadable(
+    agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
+    o: Value,
+) -> JsResult<Option<Object>> {
     // 1. If O is not an Object, return false.
     if let Ok(o) = Object::try_from(o) {
         // 2. Let spreadable be ? Get(O, @@isConcatSpreadable).
-        let spreadable = get(agent, o, WellKnownSymbolIndexes::IsConcatSpreadable.into())?;
+        let spreadable = get(
+            agent,
+            gc.reborrow(),
+            o,
+            WellKnownSymbolIndexes::IsConcatSpreadable.into(),
+        )?;
         // 3. If spreadable is not undefined, return ToBoolean(spreadable).
         if !spreadable.is_undefined() {
             let spreadable = to_boolean(agent, spreadable);
@@ -2855,6 +3120,8 @@ fn is_concat_spreadable(agent: &mut Agent, o: Value) -> JsResult<Option<Object>>
 /// looked up from the prototype or are undefined.
 fn find_via_predicate(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     o: Object,
     len: i64,
     ascending: bool,
@@ -2870,6 +3137,8 @@ fn find_via_predicate(
     };
     // 4. For each integer k of indices, do
     let check = |agent: &mut Agent,
+                 mut gc: GcScope<'_, '_>,
+
                  o: Object,
                  predicate: Function,
                  this_arg: Value,
@@ -2879,10 +3148,11 @@ fn find_via_predicate(
         let pk = PropertyKey::Integer(k.try_into().unwrap());
         // b. NOTE: If O is a TypedArray, the following invocation of Get will return a normal completion.
         // c. Let kValue be ? Get(O, Pk).
-        let k_value = get(agent, o, pk)?;
+        let k_value = get(agent, gc.reborrow(), o, pk)?;
         // d. Let testResult be ? Call(predicate, thisArg, « kValue, 𝔽(k), O »).
         let test_result = call_function(
             agent,
+            gc.reborrow(),
             predicate,
             this_arg,
             Some(ArgumentsList(&[
@@ -2902,7 +3172,7 @@ fn find_via_predicate(
     if ascending {
         // a. Let indices be a List of the integers in the interval from 0 (inclusive) to len (exclusive), in ascending order.
         for k in 0..len {
-            if let Some(result) = check(agent, o, predicate, this_arg, k)? {
+            if let Some(result) = check(agent, gc.reborrow(), o, predicate, this_arg, k)? {
                 return Ok(result);
             }
         }
@@ -2910,7 +3180,7 @@ fn find_via_predicate(
         // 3. Else,
         // a. Let indices be a List of the integers in the interval from 0 (inclusive) to len (exclusive), in descending order.
         for k in (0..len).rev() {
-            if let Some(result) = check(agent, o, predicate, this_arg, k)? {
+            if let Some(result) = check(agent, gc.reborrow(), o, predicate, this_arg, k)? {
                 return Ok(result);
             }
         }
@@ -2929,6 +3199,8 @@ fn find_via_predicate(
 #[allow(clippy::too_many_arguments)]
 fn flatten_into_array(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     target: Object,
     source: Object,
     source_len: usize,
@@ -2949,7 +3221,7 @@ fn flatten_into_array(
         let source_index_number = Number::try_from(source_index).unwrap();
         let p = PropertyKey::try_from(source_index).unwrap();
         // b. Let exists be ? HasProperty(source, P).
-        let exists = has_property(agent, source, p)?;
+        let exists = has_property(agent, gc.reborrow(), source, p)?;
         // c. If exists is true, then
         if !exists {
             // d. Set sourceIndex to sourceIndex + 1𝔽.
@@ -2957,12 +3229,13 @@ fn flatten_into_array(
             continue;
         }
         // i. Let element be ? Get(source, P).
-        let element = get(agent, source, p)?;
+        let element = get(agent, gc.reborrow(), source, p)?;
         // ii. If mapperFunction is present, then
         let element = if let Some(mapper_function) = mapper_function {
             // 1. Set element to ? Call(mapperFunction, thisArg, « element, sourceIndex, source »).
             call_function(
                 agent,
+                gc.reborrow(),
                 mapper_function,
                 this_arg.unwrap(),
                 Some(ArgumentsList(&[
@@ -2987,10 +3260,11 @@ fn flatten_into_array(
             let element = Object::try_from(element).unwrap();
             let new_depth = depth.map(|depth| depth - 1);
             // 3. Let elementLen be ? LengthOfArrayLike(element).
-            let element_len = length_of_array_like(agent, element)? as usize;
+            let element_len = length_of_array_like(agent, gc.reborrow(), element)? as usize;
             // 4. Set targetIndex to ? FlattenIntoArray(target, element, elementLen, targetIndex, newDepth).
             target_index = flatten_into_array(
                 agent,
+                gc.reborrow(),
                 target,
                 element,
                 element_len,
@@ -3011,6 +3285,7 @@ fn flatten_into_array(
             // 2. Perform ? CreateDataPropertyOrThrow(target, ! ToString(𝔽(targetIndex)), element).
             create_data_property_or_throw(
                 agent,
+                gc.reborrow(),
                 target,
                 target_index.try_into().unwrap(),
                 element,
@@ -3079,6 +3354,8 @@ fn flatten_into_array(
 /// > equivalence classes are totally ordered.
 fn sort_indexed_properties<const SKIP_HOLES: bool, const TYPED_ARRAY: bool>(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     obj: Object,
     len: usize,
     comparator: Option<Function>,
@@ -3094,7 +3371,7 @@ fn sort_indexed_properties<const SKIP_HOLES: bool, const TYPED_ARRAY: bool>(
         // b. If holes is skip-holes, then
         let k_read = if SKIP_HOLES {
             // i. Let kRead be ? HasProperty(obj, Pk).
-            has_property(agent, obj, pk)?
+            has_property(agent, gc.reborrow(), obj, pk)?
         } else {
             // c. Else,
             // i. Assert: holes is read-through-holes.
@@ -3104,7 +3381,7 @@ fn sort_indexed_properties<const SKIP_HOLES: bool, const TYPED_ARRAY: bool>(
         // d. If kRead is true, then
         if k_read {
             // i. Let kValue be ? Get(obj, Pk).
-            let k_value = get(agent, obj, pk)?;
+            let k_value = get(agent, gc.reborrow(), obj, pk)?;
             // ii. Append kValue to items.
             items.push(k_value);
         }
@@ -3124,7 +3401,7 @@ fn sort_indexed_properties<const SKIP_HOLES: bool, const TYPED_ARRAY: bool>(
                 // This is dangerous but we don't have much of a choice.
                 return Ordering::Equal;
             }
-            let result = compare_array_elements(agent, *a, *b, comparator);
+            let result = compare_array_elements(agent, gc.reborrow(), *a, *b, comparator);
             let Ok(result) = result else {
                 error = Some(result.unwrap_err());
                 return Ordering::Equal;
@@ -3146,6 +3423,8 @@ fn sort_indexed_properties<const SKIP_HOLES: bool, const TYPED_ARRAY: bool>(
 /// completion containing a Number or an abrupt completion.
 fn compare_array_elements(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     x: Value,
     y: Value,
     comparator: Option<Function>,
@@ -3165,11 +3444,12 @@ fn compare_array_elements(
         // a. Let v be ? ToNumber(? Call(comparator, undefined, « x, y »)).
         let v = call_function(
             agent,
+            gc.reborrow(),
             comparator,
             Value::Undefined,
             Some(ArgumentsList(&[x, y])),
         )?;
-        let v = to_number(agent, v)?;
+        let v = to_number(agent, gc.reborrow(), v)?;
         // b. If v is NaN, return +0𝔽.
         // c. Return v.
         if v.is_nan(agent) {
@@ -3190,17 +3470,17 @@ fn compare_array_elements(
         Ok(x.into_f64(agent).total_cmp(&y.into_f64(agent)))
     } else {
         // 5. Let xString be ? ToString(x).
-        let x = to_string(agent, x)?;
+        let x = to_string(agent, gc.reborrow(), x)?;
         // 6. Let yString be ? ToString(y).
-        let y = to_string(agent, y)?;
+        let y = to_string(agent, gc.reborrow(), y)?;
         // 7. Let xSmaller be ! IsLessThan(xString, yString, true).
         // 8. If xSmaller is true, return -1𝔽.
-        if is_less_than::<true>(agent, x, y).unwrap() == Some(true) {
+        if is_less_than::<true>(agent, gc.reborrow(), x, y).unwrap() == Some(true) {
             Ok(Ordering::Less)
         } else
         // 9. Let ySmaller be ! IsLessThan(yString, xString, true).
         // 10. If ySmaller is true, return 1𝔽.
-        if is_less_than::<true>(agent, y, x).unwrap() == Some(true) {
+        if is_less_than::<true>(agent, gc.reborrow(), y, x).unwrap() == Some(true) {
             Ok(Ordering::Greater)
         } else {
             // 11. Return +0𝔽.

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_constructors.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_constructors.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::{
@@ -153,6 +154,8 @@ impl BuiltinIntrinsicConstructor for Float64ArrayConstructor {
 impl TypedArrayConstructors {
     fn int8_array_constructor(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -162,6 +165,8 @@ impl TypedArrayConstructors {
 
     fn uint8_array_constructor(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -171,6 +176,8 @@ impl TypedArrayConstructors {
 
     fn uint8_clamped_array_constructor(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -180,6 +187,8 @@ impl TypedArrayConstructors {
 
     fn int16_array_constructor(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -189,6 +198,8 @@ impl TypedArrayConstructors {
 
     fn uint16_array_constructor(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -198,6 +209,8 @@ impl TypedArrayConstructors {
 
     fn int32_array_constructor(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -207,6 +220,8 @@ impl TypedArrayConstructors {
 
     fn uint32_array_constructor(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -216,6 +231,8 @@ impl TypedArrayConstructors {
 
     fn big_int64_array_constructor(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -225,6 +242,8 @@ impl TypedArrayConstructors {
 
     fn big_uint64_array_constructor(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -234,6 +253,8 @@ impl TypedArrayConstructors {
 
     fn float32_array_constructor(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -243,6 +264,8 @@ impl TypedArrayConstructors {
 
     fn float64_array_constructor(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_intrinsic_object.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_intrinsic_object.rs
@@ -22,6 +22,7 @@ use crate::ecmascript::types::PropertyKey;
 use crate::ecmascript::types::String;
 use crate::ecmascript::types::Value;
 use crate::ecmascript::types::BUILTIN_STRING_MEMORY;
+use crate::engine::context::GcScope;
 use crate::heap::IntrinsicConstructorIndexes;
 use crate::heap::IntrinsicFunctionIndexes;
 use crate::heap::WellKnownSymbolIndexes;
@@ -60,6 +61,8 @@ impl BuiltinGetter for TypedArrayGetSpecies {}
 impl TypedArrayIntrinsicObject {
     fn behaviour(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -70,23 +73,43 @@ impl TypedArrayIntrinsicObject {
         ))
     }
 
-    fn from(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn from(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
     fn is_array(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
         is_array(agent, arguments.get(0)).map(Value::Boolean)
     }
 
-    fn of(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn of(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn get_species(_: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_species(
+        _: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         Ok(this_value)
     }
 
@@ -333,16 +356,30 @@ impl Builtin for TypedArrayPrototypeGetToStringTag {
 impl BuiltinGetter for TypedArrayPrototypeGetToStringTag {}
 
 impl TypedArrayPrototype {
-    fn at(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn at(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_buffer(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_buffer(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
     fn get_byte_length(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
@@ -351,146 +388,328 @@ impl TypedArrayPrototype {
 
     fn get_byte_offset(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
         todo!()
     }
 
-    fn copy_within(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn copy_within(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn entries(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn entries(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn every(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn every(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn fill(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn fill(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn filter(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn filter(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn find(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn find(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn find_index(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn find_index(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn find_last(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn find_last(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
     fn find_last_index(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
         todo!()
     }
 
-    fn for_each(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn for_each(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn includes(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn includes(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn index_of(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn index_of(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn join(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn join(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn keys(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn keys(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn last_index_of(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn last_index_of(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_length(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_length(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn map(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn map(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn reduce(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn reduce(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn reduce_right(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn reduce_right(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn reverse(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn reverse(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn set(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn slice(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn slice(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn some(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn some(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn sort(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn sort(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn subarray(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn subarray(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
     fn to_locale_string(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
         todo!();
     }
 
-    fn to_reversed(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_reversed(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn to_sorted(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_sorted(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn to_spliced(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_spliced(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn values(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn values(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn with(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn with(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
     fn get_to_string_tag(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_iterator_objects/map_iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_iterator_objects/map_iterator_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -32,7 +33,13 @@ impl Builtin for MapIteratorPrototypeNext {
 }
 
 impl MapIteratorPrototype {
-    fn next(agent: &mut Agent, this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn next(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 27.5.3.2 GeneratorValidate ( generator, generatorBrand )
         // 3. If generator.[[GeneratorBrand]] is not generatorBrand, throw a TypeError exception.
         let Value::MapIterator(iterator) = this_value else {

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_prototype.rs
@@ -6,6 +6,7 @@ use std::{hash::Hasher, ops::Index};
 
 use ahash::AHasher;
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -100,7 +101,13 @@ impl MapPrototype {
     /// > The existing \[\[MapData]] List is preserved because there may be
     /// > existing Map Iterator objects that are suspended midway through
     /// > iterating over that List.
-    fn clear(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn clear(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         let m = require_map_data_internal_slot(agent, this_value)?;
@@ -118,7 +125,13 @@ impl MapPrototype {
     /// > The value EMPTY is used as a specification device to indicate that an
     /// > entry has been deleted. Actual implementations may take other actions
     /// > such as physically removing the entry from internal data structures.
-    fn delete(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn delete(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         let m = require_map_data_internal_slot(agent, this_value)?;
@@ -168,7 +181,13 @@ impl MapPrototype {
         }
     }
 
-    fn entries(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn entries(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let M be the this value.
         // 2. Return ? CreateMapIterator(M, KEY+VALUE).
 
@@ -203,7 +222,13 @@ impl MapPrototype {
     /// > after the call to `forEach` begins and before being visited are not
     /// > visited unless the key is added again before the `forEach` call
     /// > completes.
-    fn for_each(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn for_each(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let callback_fn = arguments.get(0);
         let this_arg = arguments.get(1);
         // 1. Let M be the this value.
@@ -235,6 +260,7 @@ impl MapPrototype {
                 // i. Perform ? Call(callbackfn, thisArg, « e.[[Value]], e.[[Key]], M »).
                 call_function(
                     agent,
+                    gc.reborrow(),
                     callback_fn,
                     this_arg,
                     Some(ArgumentsList(&[v, k, m.into_value()])),
@@ -249,7 +275,13 @@ impl MapPrototype {
     }
 
     /// ### [24.1.3.6 Map.prototype.get ( key )](https://tc39.es/ecma262/#sec-map.prototype.get)
-    fn get(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn get(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         let m = require_map_data_internal_slot(agent, this_value)?;
@@ -294,7 +326,13 @@ impl MapPrototype {
     }
 
     /// ### [24.1.3.7 Map.prototype.has ( key )](https://tc39.es/ecma262/#sec-map.prototype.has)
-    fn has(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn has(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         let m = require_map_data_internal_slot(agent, this_value)?;
@@ -331,7 +369,13 @@ impl MapPrototype {
         Ok(found.into())
     }
 
-    fn keys(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn keys(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let M be the this value.
         // 2. Return ? CreateMapIterator(M, KEY).
 
@@ -342,7 +386,13 @@ impl MapPrototype {
     }
 
     /// ### [24.1.3.9 Map.prototype.set ( key, value )](https://tc39.es/ecma262/#sec-map.prototype.set)
-    fn set(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn set(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let value = arguments.get(1);
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
@@ -405,13 +455,25 @@ impl MapPrototype {
         Ok(m.into_value())
     }
 
-    fn get_size(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_size(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let m = require_map_data_internal_slot(agent, this_value)?;
         let count = agent[m].size();
         Ok(count.into())
     }
 
-    fn values(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn values(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let M be the this value.
         // 2. Return ? CreateMapIterator(M, VALUE).
 

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_iterator_objects/set_iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_iterator_objects/set_iterator_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -32,7 +33,13 @@ impl Builtin for SetIteratorPrototypeNext {
 }
 
 impl SetIteratorPrototype {
-    fn next(agent: &mut Agent, this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn next(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 27.5.3.2 GeneratorValidate ( generator, generatorBrand )
         // 3. If generator.[[GeneratorBrand]] is not generatorBrand, throw a TypeError exception.
         let Value::SetIterator(iterator) = this_value else {

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_prototype.rs
@@ -6,6 +6,7 @@ use std::hash::Hasher;
 
 use ahash::AHasher;
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -87,7 +88,13 @@ impl BuiltinIntrinsic for SetPrototypeValues {
 
 impl SetPrototype {
     /// #### [24.2.4.1 Set.prototype.add ( value )](https://tc39.es/ecma262/#sec-set.prototype.add)
-    fn add(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn add(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[SetData]]).
         let s = require_set_data_internal_slot(agent, this_value)?;
@@ -143,7 +150,13 @@ impl SetPrototype {
     /// > The existing \[\[SetData]] List is preserved because there may be
     /// > existing Set Iterator objects that are suspended midway through
     /// > iterating over that List.
-    fn clear(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn clear(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[SetData]]).
         let s = require_set_data_internal_slot(agent, this_value)?;
@@ -162,7 +175,13 @@ impl SetPrototype {
     /// > The value EMPTY is used as a specification device to indicate that an
     /// > entry has been deleted. Actual implementations may take other actions
     /// > such as physically removing the entry from internal data structures.
-    fn delete(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn delete(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[SetData]]).
         let s = require_set_data_internal_slot(agent, this_value)?;
@@ -207,7 +226,13 @@ impl SetPrototype {
         }
     }
 
-    fn entries(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn entries(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let S be the this value.
         // 2. Return ? CreateSetIterator(S, KEY+VALUE).
 
@@ -250,7 +275,13 @@ impl SetPrototype {
     /// > are not visited unless the value is added again before the
     /// > **forEach** call completes. New values added after the call to
     /// > **forEach** begins are visited.
-    fn for_each(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn for_each(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let callback_fn = arguments.get(0);
         let this_arg = arguments.get(1);
         // 1. Let S be the this value.
@@ -281,6 +312,7 @@ impl SetPrototype {
                 // i. Perform ? Call(callbackfn, thisArg, « e, e, S »).
                 call_function(
                     agent,
+                    gc.reborrow(),
                     callback_fn,
                     this_arg,
                     Some(ArgumentsList(&[e, e, s.into_value()])),
@@ -295,7 +327,13 @@ impl SetPrototype {
     }
 
     /// ### [24.2.4.8 Set.prototype.has ( value )](https://tc39.es/ecma262/#sec-set.prototype.has)
-    fn has(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn has(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[SetData]]).
         let s = require_set_data_internal_slot(agent, this_value)?;
@@ -337,7 +375,13 @@ impl SetPrototype {
     ///
     /// Set.prototype.size is an accessor property whose set accessor function
     /// is undefined.
-    fn get_size(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_size(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[SetData]]).
         let s = require_set_data_internal_slot(agent, this_value)?;
@@ -347,7 +391,13 @@ impl SetPrototype {
         Ok(Number::from(size).into_value())
     }
 
-    fn values(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn values(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let S be the this value.
         // 2. Return ? CreateSetIterator(S, VALUE).
 

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/weak_map_objects/weak_map_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/weak_map_objects/weak_map_constructor.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -27,6 +28,8 @@ impl BuiltinIntrinsicConstructor for WeakMapConstructor {
 impl WeakMapConstructor {
     fn behaviour(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/weak_map_objects/weak_map_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/weak_map_objects/weak_map_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -40,19 +41,43 @@ impl Builtin for WeakMapPrototypeSet {
 }
 
 impl WeakMapPrototype {
-    fn delete(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn delete(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn has(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn has(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn set(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/weak_set_objects/weak_set_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/weak_set_objects/weak_set_constructor.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -27,6 +28,8 @@ impl BuiltinIntrinsicConstructor for WeakSetConstructor {
 impl WeakSetConstructor {
     fn behaviour(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/weak_set_objects/weak_set_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/weak_set_objects/weak_set_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -34,15 +35,33 @@ impl Builtin for WeakSetPrototypeHas {
 }
 
 impl WeakSetPrototype {
-    fn add(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn add(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn delete(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn delete(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn has(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn has(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 

--- a/nova_vm/src/ecmascript/builtins/managing_memory/finalization_registry_objects/finalization_registry_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/managing_memory/finalization_registry_objects/finalization_registry_constructor.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -27,6 +28,8 @@ impl BuiltinIntrinsicConstructor for FinalizationRegistryConstructor {
 impl FinalizationRegistryConstructor {
     fn behaviour(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,

--- a/nova_vm/src/ecmascript/builtins/managing_memory/finalization_registry_objects/finalization_registry_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/managing_memory/finalization_registry_objects/finalization_registry_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -28,11 +29,23 @@ impl Builtin for FinalizationRegistryPrototypeUnregister {
 }
 
 impl FinalizationRegistryPrototype {
-    fn register(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn register(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn unregister(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn unregister(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 

--- a/nova_vm/src/ecmascript/builtins/managing_memory/weak_ref_objects/weak_ref_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/managing_memory/weak_ref_objects/weak_ref_constructor.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -27,6 +28,8 @@ impl BuiltinIntrinsicConstructor for WeakRefConstructor {
 impl WeakRefConstructor {
     fn behaviour(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,

--- a/nova_vm/src/ecmascript/builtins/managing_memory/weak_ref_objects/weak_ref_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/managing_memory/weak_ref_objects/weak_ref_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -22,7 +23,13 @@ impl Builtin for WeakRefPrototypeDeref {
 }
 
 impl WeakRefPrototype {
-    fn deref(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn deref(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 

--- a/nova_vm/src/ecmascript/builtins/map.rs
+++ b/nova_vm/src/ecmascript/builtins/map.rs
@@ -8,13 +8,12 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData,
-            OrdinaryObject, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
         indexes::{BaseIndex, MapIndex},
-        CompactionLists, CreateHeapData, HeapMarkAndSweep, ObjectEntry, WorkQueues,
+        CompactionLists, CreateHeapData, HeapMarkAndSweep, WorkQueues,
     },
     Heap,
 };
@@ -83,20 +82,6 @@ impl TryFrom<Object> for Map {
     }
 }
 
-fn create_map_base_object(agent: &mut Agent, map: Map, entries: &[ObjectEntry]) -> OrdinaryObject {
-    // TODO: An issue crops up if multiple realms are in play:
-    // The prototype should not be dependent on the realm we're operating in
-    // but should instead be bound to the realm the object was created in.
-    // We'll have to cross this bridge at a later point, likely be designating
-    // a "default realm" and making non-default realms always initialize ObjectHeapData.
-    let prototype = agent.current_realm().intrinsics().map_prototype();
-    let object_index = agent
-        .heap
-        .create_object_with_prototype(prototype.into(), entries);
-    agent[map].object_index = Some(object_index);
-    object_index
-}
-
 impl InternalSlots for Map {
     const DEFAULT_PROTOTYPE: ProtoIntrinsics = ProtoIntrinsics::Map;
 
@@ -107,21 +92,6 @@ impl InternalSlots for Map {
 
     fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
         assert!(agent[self].object_index.replace(backing_object).is_none());
-    }
-
-    fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        self.set_backing_object(agent, backing_object);
-        backing_object
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/bigint_objects/bigint_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/bigint_objects/bigint_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -47,14 +48,18 @@ impl Builtin for BigIntPrototypeValueOf {
 impl BigIntPrototype {
     fn to_locale_string(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
-        Self::to_string(agent, this_value, arguments)
+        Self::to_string(agent, gc.reborrow(), this_value, arguments)
     }
 
     fn to_string(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -68,7 +73,13 @@ impl BigIntPrototype {
         }
     }
 
-    fn value_of(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn value_of(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         this_big_int_value(agent, this_value).map(|result| result.into_value())
     }
 

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/date_objects/date_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/date_objects/date_constructor.rs
@@ -23,6 +23,7 @@ use crate::ecmascript::types::Number;
 use crate::ecmascript::types::Object;
 use crate::ecmascript::types::BUILTIN_STRING_MEMORY;
 use crate::ecmascript::types::{String, Value};
+use crate::engine::context::GcScope;
 use crate::heap::IntrinsicConstructorIndexes;
 use crate::SmallInteger;
 
@@ -58,6 +59,8 @@ impl Builtin for DateUTC {
 impl DateConstructor {
     fn behaviour(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
         new_target: Option<Object>,
@@ -112,6 +115,7 @@ impl DateConstructor {
         // 6. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%Date.prototype%", « [[DateValue]] »).
         let o = ordinary_create_from_constructor(
             agent,
+            gc.reborrow(),
             Function::try_from(new_target).unwrap(),
             ProtoIntrinsics::Date,
         )?;
@@ -122,7 +126,13 @@ impl DateConstructor {
     }
 
     /// ### [21.1.2.2 Number.isFinite ( number )](https://tc39.es/ecma262/#sec-number.isfinite)
-    fn now(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn now(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let time_value = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
@@ -136,48 +146,60 @@ impl DateConstructor {
     }
 
     /// ### [21.1.2.3 Number.isInteger ( number )](https://tc39.es/ecma262/#sec-number.isinteger)
-    fn parse(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn parse(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
     /// ### [21.4.3.4 Date.UTC ( year \[ , month \[ , date \[ , hours \[ , minutes \[ , seconds \[ , ms \] \] \] \] \] \] )](https://tc39.es/ecma262/#sec-date.utc)
-    fn utc(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn utc(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let _ns = arguments.get(0);
         // 1. Let y be ? ToNumber(year).
-        let _y = to_number(agent, arguments.get(0))?;
+        let _y = to_number(agent, gc.reborrow(), arguments.get(0))?;
         // 2. If month is present, let m be ? ToNumber(month); else let m be +0𝔽.
         let _m = if arguments.len() > 1 {
-            to_number(agent, arguments.get(1))?
+            to_number(agent, gc.reborrow(), arguments.get(1))?
         } else {
             0.into()
         };
         // 3. If date is present, let dt be ? ToNumber(date); else let dt be 1𝔽.
         let _dt = if arguments.len() > 2 {
-            to_number(agent, arguments.get(2))?
+            to_number(agent, gc.reborrow(), arguments.get(2))?
         } else {
             0.into()
         };
         // 4. If hours is present, let h be ? ToNumber(hours); else let h be +0𝔽.
         let _h = if arguments.len() > 3 {
-            to_number(agent, arguments.get(3))?
+            to_number(agent, gc.reborrow(), arguments.get(3))?
         } else {
             0.into()
         };
         // 5. If minutes is present, let min be ? ToNumber(minutes); else let min be +0𝔽.
         let _min = if arguments.len() > 4 {
-            to_number(agent, arguments.get(4))?
+            to_number(agent, gc.reborrow(), arguments.get(4))?
         } else {
             0.into()
         };
         // 6. If seconds is present, let s be ? ToNumber(seconds); else let s be +0𝔽.
         let _s = if arguments.len() > 5 {
-            to_number(agent, arguments.get(5))?
+            to_number(agent, gc.reborrow(), arguments.get(5))?
         } else {
             0.into()
         };
         // 7. If ms is present, let milli be ? ToNumber(ms); else let milli be +0𝔽.
         let _milli = if arguments.len() > 6 {
-            to_number(agent, arguments.get(6))?
+            to_number(agent, gc.reborrow(), arguments.get(6))?
         } else {
             0.into()
         };

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/date_objects/date_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/date_objects/date_prototype.rs
@@ -4,6 +4,7 @@
 
 use std::time::SystemTime;
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::type_conversion::{ordinary_to_primitive, PreferredType},
@@ -296,53 +297,109 @@ impl Builtin for DatePrototypeToPrimitive {
 const MAX_SYSTEM_TIME_VALUE: u128 = SmallInteger::MAX_NUMBER as u128;
 
 impl DatePrototype {
-    fn get_date(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_date(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn get_day(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_day(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn get_full_year(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_full_year(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn get_hours(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_hours(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn get_milliseconds(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_milliseconds(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn get_minutes(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_minutes(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn get_month(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_month(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn get_seconds(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_seconds(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn get_time(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_time(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
     fn get_timezone_offset(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
@@ -350,18 +407,32 @@ impl DatePrototype {
         todo!()
     }
 
-    fn get_utc_date(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_utc_date(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn get_utc_day(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_utc_day(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
     fn get_utc_full_year(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
@@ -369,13 +440,21 @@ impl DatePrototype {
         todo!()
     }
 
-    fn get_utc_hours(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_utc_hours(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
     fn get_utc_milliseconds(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
@@ -383,68 +462,142 @@ impl DatePrototype {
         todo!()
     }
 
-    fn get_utc_minutes(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_utc_minutes(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn get_utc_month(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_utc_month(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn get_utc_seconds(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_utc_seconds(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn set_date(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_date(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn set_full_year(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_full_year(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn set_hours(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_hours(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn set_milliseconds(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_milliseconds(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn set_minutes(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_minutes(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn set_month(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_month(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn set_seconds(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_seconds(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn set_time(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_time(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn set_utc_date(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_utc_date(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
     fn set_utc_full_year(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
@@ -452,13 +605,21 @@ impl DatePrototype {
         todo!()
     }
 
-    fn set_utc_hours(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_utc_hours(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
     fn set_utc_milliseconds(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
@@ -466,37 +627,75 @@ impl DatePrototype {
         todo!()
     }
 
-    fn set_utc_minutes(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_utc_minutes(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn set_utc_month(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_utc_month(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn set_utc_seconds(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_utc_seconds(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn to_date_string(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_date_string(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn to_iso_string(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_iso_string(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn to_json(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_json(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
     fn to_locale_date_string(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
@@ -505,6 +704,8 @@ impl DatePrototype {
 
     fn to_locale_string(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
@@ -513,28 +714,54 @@ impl DatePrototype {
 
     fn to_locale_time_string(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
         todo!()
     }
 
-    fn to_string(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_string(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn to_time_string(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_time_string(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn to_utc_string(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_utc_string(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let _date_object = check_date_object(agent, this_value)?;
         todo!()
     }
 
-    fn value_of(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn value_of(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         let date_object = check_date_object(agent, this_value)?;
         let data = &agent[date_object].date;
         match data {
@@ -586,6 +813,8 @@ impl DatePrototype {
     /// equivalent to "number".
     fn to_primitive(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -595,7 +824,7 @@ impl DatePrototype {
         let Ok(o) = Object::try_from(this_value) else {
             let error_message = format!(
                 "{} is not an object",
-                this_value.string_repr(agent).as_str(agent)
+                this_value.string_repr(agent, gc.reborrow(),).as_str(agent)
             );
             return Err(agent.throw_exception(ExceptionType::TypeError, error_message));
         };
@@ -614,12 +843,12 @@ impl DatePrototype {
             // a. Throw a TypeError exception.
             let error_message = format!(
                 "Expected 'hint' to be \"string\", \"default\", or \"number\", got {}",
-                hint.string_repr(agent).as_str(agent)
+                hint.string_repr(agent, gc.reborrow(),).as_str(agent)
             );
             return Err(agent.throw_exception(ExceptionType::TypeError, error_message));
         };
         // 6. Return ? OrdinaryToPrimitive(O, tryFirst).
-        ordinary_to_primitive(agent, o, try_first).map(|result| result.into_value())
+        ordinary_to_primitive(agent, gc.reborrow(), o, try_first).map(|result| result.into_value())
     }
 
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: RealmIdentifier) {

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/math_object.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/math_object.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use std::f64::consts;
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::type_conversion::{to_number, to_uint32},
@@ -335,23 +336,41 @@ impl Builtin for MathObjectTrunc {
 }
 
 impl MathObject {
-    fn abs(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
-        let n = to_number(agent, arguments.get(0))?;
+    fn abs(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
         Ok(n.abs(agent).into_value())
     }
 
-    fn acos(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn acos(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?.into_f64(agent);
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?.into_f64(agent);
         // 2. If n is NaN, n > 1𝔽, or n < -1𝔽, return NaN.
         // 3. If n is 1𝔽, return +0𝔽.
         // 4. Return an implementation-approximated Number value representing the result of the inverse cosine of ℝ(n).
         Ok(Value::from_f64(agent, n.acos()))
     }
 
-    fn acosh(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn acosh(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is either NaN or +∞𝔽, return n.
         if n.is_nan(agent) || n.is_pos_infinity(agent) {
@@ -370,9 +389,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.acosh()))
     }
 
-    fn asin(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn asin(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is one of NaN, +0𝔽, or -0𝔽, return n.
         if n.is_nan(agent) || n.is_pos_zero(agent) || n.is_neg_zero(agent) {
@@ -390,9 +415,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.asin()))
     }
 
-    fn asinh(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn asinh(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is not finite or n is either +0𝔽 or -0𝔽, return n.
         if !n.is_finite(agent) || n.is_pos_zero(agent) || n.is_neg_zero(agent) {
@@ -403,9 +434,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).asinh()))
     }
 
-    fn atan(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn atan(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is one of NaN, +0𝔽, or -0𝔽, return n.
         if n.is_nan(agent) || n.is_pos_zero(agent) || n.is_neg_zero(agent) {
@@ -426,9 +463,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).atan()))
     }
 
-    fn atanh(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn atanh(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is one of NaN, +0𝔽, or -0𝔽, return n.
         if n.is_nan(agent) || n.is_pos_zero(agent) || n.is_neg_zero(agent) {
@@ -456,11 +499,17 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.atanh()))
     }
 
-    fn atan2(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn atan2(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let ny be ? ToNumber(y).
-        let ny = to_number(agent, arguments.get(0))?;
+        let ny = to_number(agent, gc.reborrow(), arguments.get(0))?;
         // 2. Let nx be ? ToNumber(x).
-        let nx = to_number(agent, arguments.get(1))?;
+        let nx = to_number(agent, gc.reborrow(), arguments.get(1))?;
 
         // 3. If ny is NaN or nx is NaN, return NaN.
         if ny.is_nan(agent) || nx.is_nan(agent) {
@@ -578,9 +627,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, r))
     }
 
-    fn cbrt(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn cbrt(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is not finite or n is either +0𝔽 or -0𝔽, return n.
         if !n.is_finite(agent) || n.is_pos_zero(agent) || n.is_neg_zero(agent) {
@@ -591,9 +646,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).cbrt()))
     }
 
-    fn ceil(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn ceil(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 4. If n is an integral Number, return n.
         if let Number::Integer(_) = n {
@@ -616,9 +677,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.ceil()))
     }
 
-    fn clz32(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn clz32(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToUint32(x).
-        let n = to_uint32(agent, arguments.get(0))?;
+        let n = to_uint32(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. Let p be the number of leading zero bits in the unsigned 32-bit binary representation of n.
         let p = n.leading_zeros();
@@ -627,9 +694,15 @@ impl MathObject {
         Ok(Value::from(p))
     }
 
-    fn cos(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn cos(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is not finite, return NaN.
         if !n.is_finite(agent) {
@@ -645,9 +718,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).cos()))
     }
 
-    fn cosh(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn cosh(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is NaN, return NaN.
         if n.is_nan(agent) {
@@ -668,9 +747,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).cosh()))
     }
 
-    fn exp(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn exp(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         //1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         //2. If n is either NaN or +∞𝔽, return n.
         if n.is_nan(agent) || n.is_pos_infinity(agent) {
@@ -691,9 +776,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).exp()))
     }
 
-    fn expm1(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn expm1(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is one of NaN, +0𝔽, -0𝔽, or +∞𝔽, return n.
         if n.is_nan(agent)
@@ -713,9 +804,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).exp_m1()))
     }
 
-    fn floor(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn floor(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 4. If n is an integral Number, return n.
         if let Number::Integer(_) = n {
@@ -738,9 +835,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.floor()))
     }
 
-    fn fround(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn fround(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is NaN, return NaN.
         if n.is_nan(agent) {
@@ -766,14 +869,20 @@ impl MathObject {
         Ok(Value::from_f64(agent, n64))
     }
 
-    fn hypot(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn hypot(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let coerced be a new empty List.
         let mut coerced = Vec::with_capacity(arguments.len());
 
         // 2. For each element arg of args, do
         for &arg in arguments.iter() {
             // a. Let n be ? ToNumber(arg).
-            let n = to_number(agent, arg)?;
+            let n = to_number(agent, gc.reborrow(), arg)?;
 
             // b. Append n to coerced.
             coerced.push(n);
@@ -819,12 +928,18 @@ impl MathObject {
         ));
     }
 
-    fn imul(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn imul(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let a be ℝ(? ToUint32(x)).
-        let a = to_uint32(agent, arguments.get(0))?;
+        let a = to_uint32(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. Let b be ℝ(? ToUint32(y)).
-        let b = to_uint32(agent, arguments.get(1))?;
+        let b = to_uint32(agent, gc.reborrow(), arguments.get(1))?;
 
         // 3. Let product be (a × b) modulo 2**32.
         let product = a.wrapping_mul(b);
@@ -833,9 +948,15 @@ impl MathObject {
         Ok(Value::from(product as i32))
     }
 
-    fn log(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn log(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is either NaN or +∞𝔽, return n.
         if n.is_nan(agent) || n.is_pos_infinity(agent) {
@@ -861,9 +982,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).ln()))
     }
 
-    fn log1p(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn log1p(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
         // 2. If n is one of NaN, +0𝔽, -0𝔽, or +∞𝔽, return n.
         if n.is_nan(agent)
             || n.is_pos_zero(agent)
@@ -884,9 +1011,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).ln_1p()))
     }
 
-    fn log10(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn log10(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
         // 2. If n is either NaN or +∞𝔽, return n.
         if n.is_nan(agent) || n.is_pos_infinity(agent) {
             return Ok(n.into_value());
@@ -908,9 +1041,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).log10()))
     }
 
-    fn log2(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn log2(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
         // 2. If n is either NaN or +∞𝔽, return n.
         if n.is_nan(agent) || n.is_pos_infinity(agent) {
             return Ok(n.into_value());
@@ -931,7 +1070,13 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).log2()))
     }
 
-    fn max(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn max(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let coerced be a new empty List.
         let mut coerced = Vec::with_capacity(arguments.len());
 
@@ -940,7 +1085,7 @@ impl MathObject {
         // 2. For each element arg of args, do
         for &arg in arguments.iter() {
             // a. Let n be ? ToNumber(arg).
-            let n = to_number(agent, arg)?;
+            let n = to_number(agent, gc.reborrow(), arg)?;
             // b. Append n to coerced.
             coerced.push(n);
 
@@ -1007,7 +1152,13 @@ impl MathObject {
         Ok(highest.into_value())
     }
 
-    fn min(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn min(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let coerced be a new empty List.
         let mut coerced = Vec::with_capacity(arguments.len());
 
@@ -1016,7 +1167,7 @@ impl MathObject {
         // 2. For each element arg of args, do
         for &arg in arguments.iter() {
             // a. Let n be ? ToNumber(arg).
-            let n = to_number(agent, arg)?;
+            let n = to_number(agent, gc.reborrow(), arg)?;
             // b. Append n to coerced.
             coerced.push(n);
 
@@ -1083,7 +1234,13 @@ impl MathObject {
         Ok(lowest.into_value())
     }
 
-    fn pow(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn pow(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let base = arguments.get(0);
         let exponent = arguments.get(1);
         if let (Value::Integer(base), Value::Integer(exponent)) = (base, exponent) {
@@ -1104,18 +1261,30 @@ impl MathObject {
                 return Ok(Value::from_f64(agent, result));
             }
         }
-        let base = to_number(agent, base)?;
-        let exponent = to_number(agent, exponent)?;
+        let base = to_number(agent, gc.reborrow(), base)?;
+        let exponent = to_number(agent, gc.reborrow(), exponent)?;
         Ok(Number::exponentiate(agent, base, exponent).into_value())
     }
 
-    fn random(agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn random(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         Ok(Value::from_f64(agent, rand::random::<f64>()))
     }
 
-    fn round(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn round(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is not finite or n is an integral Number, return n.
         if !n.is_finite(agent) || matches!(n, Number::Integer(_)) {
@@ -1138,9 +1307,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.round()))
     }
 
-    fn sign(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn sign(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
         // 2. If n is one of NaN, +0𝔽, or -0𝔽, return n.
         if n.is_nan(agent) || n.is_pos_zero(agent) || n.is_neg_zero(agent) {
             return Ok(n.into_value());
@@ -1153,9 +1328,15 @@ impl MathObject {
         Ok(Value::from(1))
     }
 
-    fn sin(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn sin(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
         // 2. If n is one of NaN, +0𝔽, or -0𝔽, return n.
         if n.is_nan(agent) || n.is_pos_zero(agent) || n.is_neg_zero(agent) {
             return Ok(n.into_value());
@@ -1168,9 +1349,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).sin()))
     }
 
-    fn sinh(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn sinh(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
         // 2. If n is not finite or n is either +0𝔽 or -0𝔽, return n.
         if !n.is_finite(agent) || n.is_pos_zero(agent) || n.is_neg_zero(agent) {
             return Ok(n.into_value());
@@ -1179,9 +1366,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).sinh()))
     }
 
-    fn sqrt(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn sqrt(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
         // 2. If n is one of NaN, +0𝔽, -0𝔽, or +∞𝔽, return n.
         if n.is_nan(agent)
             || n.is_pos_zero(agent)
@@ -1198,9 +1391,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).sqrt()))
     }
 
-    fn tan(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn tan(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
         // 2. If n is one of NaN, +0𝔽, or -0𝔽, return n.
         if n.is_nan(agent) || n.is_pos_zero(agent) || n.is_neg_zero(agent) {
             return Ok(n.into_value());
@@ -1213,9 +1412,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).tan()))
     }
 
-    fn tanh(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn tanh(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
         // 2. If n is one of NaN, +0𝔽, or -0𝔽, return n.
         if n.is_nan(agent) || n.is_pos_zero(agent) || n.is_neg_zero(agent) {
             return Ok(n.into_value());
@@ -1232,9 +1437,15 @@ impl MathObject {
         Ok(Value::from_f64(agent, n.into_f64(agent).tanh()))
     }
 
-    fn trunc(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn trunc(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let n be ? ToNumber(x).
-        let n = to_number(agent, arguments.get(0))?;
+        let n = to_number(agent, gc.reborrow(), arguments.get(0))?;
 
         // 2. If n is not finite or n is either +0𝔽 or -0𝔽, return n.
         if !n.is_finite(agent) || n.is_pos_zero(agent) || n.is_neg_zero(agent) {

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/number_objects/number_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/number_objects/number_constructor.rs
@@ -26,6 +26,7 @@ use crate::ecmascript::types::Object;
 
 use crate::ecmascript::types::BUILTIN_STRING_MEMORY;
 use crate::ecmascript::types::{String, Value};
+use crate::engine::context::GcScope;
 use crate::heap::CreateHeapData;
 use crate::heap::IntrinsicConstructorIndexes;
 use crate::SmallInteger;
@@ -70,6 +71,8 @@ impl Builtin for NumberIsSafeInteger {
 impl NumberConstructor {
     fn behaviour(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
         new_target: Option<Object>,
@@ -79,7 +82,7 @@ impl NumberConstructor {
         // 1. If value is present, then
         let n = if !value.is_undefined() {
             // a. Let prim be ? ToNumeric(value).
-            let prim = value.to_numeric(agent)?;
+            let prim = value.to_numeric(agent, gc.reborrow())?;
 
             // b. If prim is a BigInt, let n be 𝔽(ℝ(prim)).
             if prim.is_bigint() {
@@ -106,6 +109,7 @@ impl NumberConstructor {
         // 4. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%Number.prototype%", « [[NumberData]] »).
         let o = PrimitiveObject::try_from(ordinary_create_from_constructor(
             agent,
+            gc.reborrow(),
             new_target,
             ProtoIntrinsics::Number,
         )?)
@@ -124,6 +128,8 @@ impl NumberConstructor {
     /// ### [21.1.2.2 Number.isFinite ( number )](https://tc39.es/ecma262/#sec-number.isfinite)
     fn is_finite(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -142,17 +148,25 @@ impl NumberConstructor {
     /// ### [21.1.2.3 Number.isInteger ( number )](https://tc39.es/ecma262/#sec-number.isinteger)
     fn is_integer(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
         let maybe_number = arguments.get(0);
 
         // 1. Return IsIntegralNumber(number).
-        Ok(is_integral_number(agent, maybe_number).into())
+        Ok(is_integral_number(agent, gc.reborrow(), maybe_number).into())
     }
 
     /// ### [21.1.2.4 Number.isNaN ( number )](https://tc39.es/ecma262/#sec-number.isnan)
-    fn is_nan(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn is_nan(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let maybe_number = arguments.get(0);
 
         // 1. If number is not a Number, return false.
@@ -168,6 +182,8 @@ impl NumberConstructor {
     /// ### [21.1.2.5 Number.isSafeInteger ( number )](https://tc39.es/ecma262/#sec-number.issafeinteger)
     fn is_safe_integer(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/number_objects/number_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/number_objects/number_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::type_conversion::to_integer_or_infinity,
@@ -81,6 +82,8 @@ impl Builtin for NumberPrototypeValueOf {
 impl NumberPrototype {
     fn to_exponential(
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -88,7 +91,7 @@ impl NumberPrototype {
         // Let x be ? ThisNumberValue(this value).
         let x = this_number_value(agent, this_value)?;
         // 2. Let f be ? ToIntegerOrInfinity(fractionDigits).
-        let f = to_integer_or_infinity(agent, fraction_digits)?;
+        let f = to_integer_or_infinity(agent, gc, fraction_digits)?;
         // 3. Assert: If fractionDigits is undefined, then f is 0.
         debug_assert!(!fraction_digits.is_undefined() || f.is_pos_zero(agent));
         // 4. If x is not finite, return Number::toString(x, 10).
@@ -118,12 +121,18 @@ impl NumberPrototype {
         }
     }
 
-    fn to_fixed(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn to_fixed(
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let fraction_digits = arguments.get(0);
         // Let x be ? ThisNumberValue(this value).
         let x = this_number_value(agent, this_value)?;
         // 2. Let f be ? ToIntegerOrInfinity(fractionDigits).
-        let f = to_integer_or_infinity(agent, fraction_digits)?;
+        let f = to_integer_or_infinity(agent, gc, fraction_digits)?;
         // 3. Assert: If fractionDigits is undefined, then f is 0.
         debug_assert!(!fraction_digits.is_undefined() || f.is_pos_zero(agent));
         // 4. If f is not finite, throw a RangeError exception.
@@ -154,10 +163,12 @@ impl NumberPrototype {
 
     fn to_locale_string(
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
-        Self::to_string(agent, this_value, arguments)
+        Self::to_string(agent, gc, this_value, arguments)
     }
 
     /// ### [21.1.3.5 Number.prototype.toPrecision ( )](https://tc39.es/ecma262/#sec-number.prototype.toprecision)
@@ -166,6 +177,8 @@ impl NumberPrototype {
     /// Copyright (c) 2019 Jason Williams
     fn to_precision(
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -183,7 +196,7 @@ impl NumberPrototype {
         }
 
         // 3. Let p be ? ToIntegerOrInfinity(precision).
-        let p = to_integer_or_infinity(agent, precision)?;
+        let p = to_integer_or_infinity(agent, gc, precision)?;
 
         // 4. If x is not finite, return Number::toString(x, 10).
         if !x.is_finite(agent) {
@@ -401,6 +414,8 @@ impl NumberPrototype {
 
     fn to_string(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -413,7 +428,13 @@ impl NumberPrototype {
         }
     }
 
-    fn value_of(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn value_of(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         this_number_value(agent, this_value).map(|result| result.into_value())
     }
 

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -4,6 +4,7 @@
 
 use std::ops::{Index, IndexMut};
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builtins::ordinary::{
@@ -205,6 +206,8 @@ impl InternalMethods for PrimitiveObject {
     fn internal_get_own_property(
         self,
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         // For non-string primitive objects:
@@ -231,6 +234,8 @@ impl InternalMethods for PrimitiveObject {
     fn internal_define_own_property(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
@@ -255,10 +260,16 @@ impl InternalMethods for PrimitiveObject {
             .get_backing_object(agent)
             .unwrap_or_else(|| self.create_backing_object(agent))
             .into_object();
-        ordinary_define_own_property(agent, backing_object, property_key, property_descriptor)
+        ordinary_define_own_property(agent, gc, backing_object, property_key, property_descriptor)
     }
 
-    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(
+        self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
         if let Ok(string) = String::try_from(agent[self].data) {
             if string
                 .get_property_descriptor(agent, property_key)
@@ -271,16 +282,16 @@ impl InternalMethods for PrimitiveObject {
         // 1. Return ? OrdinaryHasProperty(O, P).
         match self.get_backing_object(agent) {
             Some(backing_object) => {
-                ordinary_has_property(agent, backing_object.into_object(), property_key)
+                ordinary_has_property(agent, gc, backing_object.into_object(), property_key)
             }
             None => {
                 // 3. Let parent be ? O.[[GetPrototypeOf]]().
-                let parent = self.internal_get_prototype_of(agent)?;
+                let parent = self.internal_get_prototype_of(agent, gc.reborrow())?;
 
                 // 4. If parent is not null, then
                 if let Some(parent) = parent {
                     // a. Return ? parent.[[HasProperty]](P).
-                    parent.internal_has_property(agent, property_key)
+                    parent.internal_has_property(agent, gc, property_key)
                 } else {
                     // 5. Return false.
                     Ok(false)
@@ -292,6 +303,8 @@ impl InternalMethods for PrimitiveObject {
     fn internal_get(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         receiver: Value,
     ) -> JsResult<Value> {
@@ -303,18 +316,22 @@ impl InternalMethods for PrimitiveObject {
 
         // 1. Return ? OrdinaryGet(O, P, Receiver).
         match self.get_backing_object(agent) {
-            Some(backing_object) => {
-                ordinary_get(agent, backing_object.into_object(), property_key, receiver)
-            }
+            Some(backing_object) => ordinary_get(
+                agent,
+                gc,
+                backing_object.into_object(),
+                property_key,
+                receiver,
+            ),
             None => {
                 // a. Let parent be ? O.[[GetPrototypeOf]]().
-                let Some(parent) = self.internal_get_prototype_of(agent)? else {
+                let Some(parent) = self.internal_get_prototype_of(agent, gc.reborrow())? else {
                     // b. If parent is null, return undefined.
                     return Ok(Value::Undefined);
                 };
 
                 // c. Return ? parent.[[Get]](P, Receiver).
-                parent.internal_get(agent, property_key, receiver)
+                parent.internal_get(agent, gc, property_key, receiver)
             }
         }
     }
@@ -322,6 +339,8 @@ impl InternalMethods for PrimitiveObject {
     fn internal_set(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         value: Value,
         receiver: Value,
@@ -340,10 +359,16 @@ impl InternalMethods for PrimitiveObject {
             .get_backing_object(agent)
             .unwrap_or_else(|| self.create_backing_object(agent))
             .into_object();
-        ordinary_set(agent, backing_object, property_key, value, receiver)
+        ordinary_set(agent, gc, backing_object, property_key, value, receiver)
     }
 
-    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
         if let Ok(string) = String::try_from(agent[self].data) {
             if string
                 .get_property_descriptor(agent, property_key)
@@ -356,13 +381,17 @@ impl InternalMethods for PrimitiveObject {
         // 1. Return ? OrdinaryDelete(O, P).
         match self.get_backing_object(agent) {
             Some(backing_object) => {
-                ordinary_delete(agent, backing_object.into_object(), property_key)
+                ordinary_delete(agent, gc, backing_object.into_object(), property_key)
             }
             None => Ok(true),
         }
     }
 
-    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(
+        self,
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+    ) -> JsResult<Vec<PropertyKey>> {
         if let Ok(string) = String::try_from(agent[self].data) {
             let len = string.utf16_len(agent);
             let mut keys = Vec::with_capacity(len + 1);

--- a/nova_vm/src/ecmascript/builtins/promise.rs
+++ b/nova_vm/src/ecmascript/builtins/promise.rs
@@ -4,6 +4,7 @@
 
 use std::ops::{Index, IndexMut};
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
@@ -37,7 +38,7 @@ impl Promise {
     }
 
     /// [27.2.4.7.1 PromiseResolve ( C, x )](https://tc39.es/ecma262/#sec-promise-resolve)
-    pub fn resolve(agent: &mut Agent, x: Value) -> Self {
+    pub fn resolve(agent: &mut Agent, gc: GcScope<'_, '_>, x: Value) -> Self {
         // 1. If IsPromise(x) is true, then
         if let Value::Promise(promise) = x {
             // a. Let xConstructor be ? Get(x, "constructor").
@@ -48,7 +49,7 @@ impl Promise {
             // 2. Let promiseCapability be ? NewPromiseCapability(C).
             let promise_capability = PromiseCapability::new(agent);
             // 3. Perform ? Call(promiseCapability.[[Resolve]], undefined, « x »).
-            promise_capability.resolve(agent, x);
+            promise_capability.resolve(agent, gc, x);
             // 4. Return promiseCapability.[[Promise]].
             promise_capability.promise()
         }

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -4,6 +4,7 @@
 
 use std::ops::{Index, IndexMut};
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         execution::{Agent, JsResult},
@@ -104,23 +105,33 @@ impl InternalSlots for Proxy {
 }
 
 impl InternalMethods for Proxy {
-    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+    fn internal_get_prototype_of(
+        self,
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+    ) -> JsResult<Option<Object>> {
         Ok(self.internal_prototype(agent))
     }
 
     fn internal_set_prototype_of(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _prototype: Option<Object>,
     ) -> JsResult<bool> {
         todo!();
     }
 
-    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+    fn internal_is_extensible(self, agent: &mut Agent, _gc: GcScope<'_, '_>) -> JsResult<bool> {
         Ok(self.internal_extensible(agent))
     }
 
-    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+    fn internal_prevent_extensions(
+        self,
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+    ) -> JsResult<bool> {
         self.internal_set_extensible(agent, false);
         Ok(true)
     }
@@ -128,6 +139,8 @@ impl InternalMethods for Proxy {
     fn internal_get_own_property(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         todo!();
@@ -136,6 +149,8 @@ impl InternalMethods for Proxy {
     fn internal_define_own_property(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _property_key: PropertyKey,
         _property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
@@ -145,6 +160,8 @@ impl InternalMethods for Proxy {
     fn internal_has_property(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _property_key: PropertyKey,
     ) -> JsResult<bool> {
         todo!();
@@ -153,6 +170,8 @@ impl InternalMethods for Proxy {
     fn internal_get(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _property_key: PropertyKey,
         _receiver: Value,
     ) -> JsResult<Value> {
@@ -162,6 +181,8 @@ impl InternalMethods for Proxy {
     fn internal_set(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _property_key: PropertyKey,
         _value: Value,
         _receiver: Value,
@@ -169,17 +190,29 @@ impl InternalMethods for Proxy {
         todo!();
     }
 
-    fn internal_delete(self, _agent: &mut Agent, _property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(
+        self,
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _property_key: PropertyKey,
+    ) -> JsResult<bool> {
         todo!();
     }
 
-    fn internal_own_property_keys(self, _agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(
+        self,
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+    ) -> JsResult<Vec<PropertyKey>> {
         todo!();
     }
 
     fn internal_call(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments_list: super::ArgumentsList,
     ) -> JsResult<Value> {
@@ -189,6 +222,8 @@ impl InternalMethods for Proxy {
     fn internal_construct(
         self,
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _arguments_list: super::ArgumentsList,
         _new_target: crate::ecmascript::types::Function,
     ) -> JsResult<Object> {

--- a/nova_vm/src/ecmascript/builtins/reflection/proxy_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/reflection/proxy_constructor.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -36,6 +37,8 @@ impl Builtin for ProxyRevocable {
 impl ProxyConstructor {
     fn behaviour(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -45,6 +48,8 @@ impl ProxyConstructor {
 
     fn revocable(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {

--- a/nova_vm/src/ecmascript/builtins/set.rs
+++ b/nova_vm/src/ecmascript/builtins/set.rs
@@ -8,13 +8,12 @@ use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
         types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, ObjectHeapData,
-            OrdinaryObject, Value,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
     },
     heap::{
         indexes::{BaseIndex, SetIndex},
-        CompactionLists, CreateHeapData, HeapMarkAndSweep, ObjectEntry, WorkQueues,
+        CompactionLists, CreateHeapData, HeapMarkAndSweep, WorkQueues,
     },
     Heap,
 };
@@ -97,20 +96,6 @@ impl TryFrom<Object> for Set {
     }
 }
 
-fn create_set_base_object(agent: &mut Agent, set: Set, entries: &[ObjectEntry]) -> OrdinaryObject {
-    // TODO: An issue crops up if multiple realms are in play:
-    // The prototype should not be dependent on the realm we're operating in
-    // but should instead be bound to the realm the object was created in.
-    // We'll have to cross this bridge at a later point, likely be designating
-    // a "default realm" and making non-default realms always initialize ObjectHeapData.
-    let prototype = agent.current_realm().intrinsics().set_prototype();
-    let object_index = agent
-        .heap
-        .create_object_with_prototype(prototype.into(), entries);
-    agent[set].object_index = Some(object_index);
-    object_index
-}
-
 impl InternalSlots for Set {
     const DEFAULT_PROTOTYPE: ProtoIntrinsics = ProtoIntrinsics::Set;
 
@@ -121,21 +106,6 @@ impl InternalSlots for Set {
 
     fn set_backing_object(self, agent: &mut Agent, backing_object: OrdinaryObject) {
         assert!(agent[self].object_index.replace(backing_object).is_none());
-    }
-
-    fn create_backing_object(self, agent: &mut Agent) -> crate::ecmascript::types::OrdinaryObject {
-        let prototype = agent
-            .current_realm()
-            .intrinsics()
-            .get_intrinsic_default_proto(Self::DEFAULT_PROTOTYPE);
-        let backing_object = agent.heap.create(ObjectHeapData {
-            extensible: true,
-            prototype: Some(prototype),
-            keys: Default::default(),
-            values: Default::default(),
-        });
-        self.set_backing_object(agent, backing_object);
-        backing_object
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/structured_data/array_buffer_objects/array_buffer_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/array_buffer_objects/array_buffer_constructor.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{operations_on_objects::get, type_conversion::to_index},
@@ -56,6 +57,8 @@ impl ArrayBufferConstructor {
     // ### [25.1.4.1 ArrayBuffer ( length \[ , options \] )](https://tc39.es/ecma262/#sec-arraybuffer-constructor)
     fn behaviour(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
         new_target: Option<Object>,
@@ -68,10 +71,10 @@ impl ArrayBufferConstructor {
             ));
         };
         // 2. Let byteLength be ? ToIndex(length).
-        let byte_length = to_index(agent, arguments.get(0))? as u64;
+        let byte_length = to_index(agent, gc.reborrow(), arguments.get(0))? as u64;
         // 3. Let requestedMaxByteLength be ? GetArrayBufferMaxByteLengthOption(options).
         let requested_max_byte_length = if arguments.len() > 1 {
-            get_array_buffer_max_byte_length_option(agent, arguments.get(1))?
+            get_array_buffer_max_byte_length_option(agent, gc, arguments.get(1))?
         } else {
             None
         };
@@ -88,6 +91,8 @@ impl ArrayBufferConstructor {
     /// ### [25.1.5.1 ArrayBuffer.isView ( arg )](https://tc39.es/ecma262/#sec-arraybuffer.isview)
     fn is_view(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -125,6 +130,8 @@ impl ArrayBufferConstructor {
     /// > `%Symbol.species%` property.
     fn species(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -154,6 +161,8 @@ impl ArrayBufferConstructor {
 /// completion.
 fn get_array_buffer_max_byte_length_option(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     options: Value,
 ) -> JsResult<Option<u64>> {
     // 1. If options is not an Object, return empty.
@@ -161,12 +170,17 @@ fn get_array_buffer_max_byte_length_option(
         return Ok(None);
     };
     // 2. Let maxByteLength be ? Get(options, "maxByteLength").
-    let max_byte_length = get(agent, options, BUILTIN_STRING_MEMORY.maxByteLength.into())?;
+    let max_byte_length = get(
+        agent,
+        gc.reborrow(),
+        options,
+        BUILTIN_STRING_MEMORY.maxByteLength.into(),
+    )?;
     // 3. If maxByteLength is undefined, return empty.
     if max_byte_length.is_undefined() {
         Ok(None)
     } else {
         // 4. Return ? ToIndex(maxByteLength).
-        Ok(Some(to_index(agent, max_byte_length)? as u64))
+        Ok(Some(to_index(agent, gc, max_byte_length)? as u64))
     }
 }

--- a/nova_vm/src/ecmascript/builtins/structured_data/array_buffer_objects/array_buffer_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/array_buffer_objects/array_buffer_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -85,7 +86,13 @@ impl ArrayBufferPrototype {
     ///
     /// ArrayBuffer.prototype.byteLength is an accessor property whose set
     /// accessor function is undefined.
-    fn get_byte_length(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_byte_length(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
@@ -102,7 +109,13 @@ impl ArrayBufferPrototype {
     /// ### [25.1.6.3 get ArrayBuffer.prototype.detached](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.detached)
     ///
     /// ArrayBuffer.prototype.detached is an accessor property whose set accessor function is undefined.
-    fn get_detached(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_detached(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
@@ -116,6 +129,8 @@ impl ArrayBufferPrototype {
     /// ArrayBuffer.prototype.maxByteLength is an accessor property whose set accessor function is undefined.
     fn get_max_byte_length(
         agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
@@ -135,7 +150,13 @@ impl ArrayBufferPrototype {
     /// ### [25.1.6.5 get ArrayBuffer.prototype.resizable](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.resizable)
     ///
     /// ArrayBuffer.prototype.resizable is an accessor property whose set accessor function is undefined.
-    fn get_resizable(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_resizable(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.´
@@ -147,7 +168,13 @@ impl ArrayBufferPrototype {
     /// ### [25.1.6.6 ArrayBuffer.prototype.resize ( newLength )](https://tc39.es/ecma262/#sec-arraybuffer.prototype.resize)
     ///
     /// This method performs the following steps when called:
-    fn resize(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn resize(
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferMaxByteLength]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.´
@@ -159,7 +186,7 @@ impl ArrayBufferPrototype {
             ));
         }
         // 4. Let newByteLength be ? ToIndex(newLength).
-        let new_byte_length = to_index(agent, arguments.get(0))? as usize;
+        let new_byte_length = to_index(agent, gc, arguments.get(0))? as usize;
         // 5. If IsDetachedBuffer(O) is true, throw a TypeError exception.
         if is_detached_buffer(agent, o) {
             return Err(agent.throw_exception_with_static_message(
@@ -196,7 +223,13 @@ impl ArrayBufferPrototype {
     /// ### [25.1.6.7 ArrayBuffer.prototype.slice ( start, end )](https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice)
     ///
     /// This method performs the following steps when called:
-    fn slice(agent: &mut Agent, this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn slice(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.´
@@ -212,7 +245,7 @@ impl ArrayBufferPrototype {
         let len = o.byte_length(agent);
 
         // 6. Let relativeStart be ? ToIntegerOrInfinity(start).
-        let relative_start = to_integer_or_infinity(agent, arguments.get(0))?;
+        let relative_start = to_integer_or_infinity(agent, gc.reborrow(), arguments.get(0))?;
         // 7. If relativeStart = -∞, let first be 0.
         let first = if relative_start.is_neg_infinity(agent) {
             0
@@ -230,7 +263,7 @@ impl ArrayBufferPrototype {
             len
         } else {
             // else let relativeEnd be ? ToIntegerOrInfinity(end).
-            let relative_end = to_integer_or_infinity(agent, end)?;
+            let relative_end = to_integer_or_infinity(agent, gc.reborrow(), end)?;
             // 11. If relativeEnd = -∞, let final be 0.
             if relative_end.is_neg_infinity(agent) {
                 0
@@ -250,6 +283,7 @@ impl ArrayBufferPrototype {
         // 16. Let new be ? Construct(ctor, « 𝔽(newLen) »).
         let Object::ArrayBuffer(new) = construct(
             agent,
+            gc,
             ctor.into_function(),
             Some(ArgumentsList(&[(new_len as i64).try_into().unwrap()])),
             None,
@@ -306,7 +340,13 @@ impl ArrayBufferPrototype {
     /// ### [25.1.6.8 ArrayBuffer.prototype.transfer ( [ newLength ] )](https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfer)
     ///
     /// This method performs the following steps when called:
-    fn transfer(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn transfer(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be the this value.
         // 2. Return ? ArrayBufferCopyAndDetach(O, newLength, preserve-resizability).
         todo!()
@@ -317,6 +357,8 @@ impl ArrayBufferPrototype {
     /// This method performs the following steps when called:
     fn transfer_to_fixed_length(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {

--- a/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -134,16 +135,30 @@ impl Builtin for AtomicsObjectXor {
 }
 
 impl AtomicsObject {
-    fn add(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn add(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn and(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn and(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
     fn compare_exchange(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -152,6 +167,8 @@ impl AtomicsObject {
 
     fn exchange(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -160,34 +177,68 @@ impl AtomicsObject {
 
     fn is_lock_free(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {
         todo!();
     }
 
-    fn load(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn load(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn or(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn or(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn store(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn store(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn sub(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn sub(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
-    fn wait(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn wait(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 
     fn wait_async(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -196,13 +247,21 @@ impl AtomicsObject {
 
     fn notify(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {
         todo!();
     }
 
-    fn xor(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn xor(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 

--- a/nova_vm/src/ecmascript/builtins/structured_data/data_view_objects/data_view_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/data_view_objects/data_view_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -175,7 +176,12 @@ impl DataViewPrototype {
     ///
     /// DataView.prototype.buffer is an accessor property whose set accessor
     /// function is undefined.
-    fn get_buffer(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_buffer(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
         let o = require_internal_slot_data_view(agent, this_value)?;
@@ -189,7 +195,12 @@ impl DataViewPrototype {
     ///
     /// DataView.prototype.byteLength is an accessor property whose set accessor
     /// function is undefined.
-    fn get_byte_length(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_byte_length(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
         let o = require_internal_slot_data_view(agent, this_value)?;
@@ -213,7 +224,12 @@ impl DataViewPrototype {
     ///
     /// DataView.prototype.byteOffset is an accessor property whose set accessor
     /// function is undefined.
-    fn get_byte_offset(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_byte_offset(
+        agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
         let o = require_internal_slot_data_view(agent, this_value)?;
@@ -234,85 +250,181 @@ impl DataViewPrototype {
 
     fn get_big_int64(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
         _this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_big_uint64(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_big_uint64(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_float32(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_float32(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_float64(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_float64(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_int8(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_int8(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_int16(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_int16(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_int32(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_int32(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_uint8(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_uint8(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_uint16(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_uint16(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_uint32(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_uint32(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn set_big_int64(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_big_int64(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn set_big_uint64(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_big_uint64(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn set_float32(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_float32(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn set_float64(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_float64(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn set_int8(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_int8(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn set_int16(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_int16(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn set_int32(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_int32(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn set_uint8(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_uint8(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn set_uint16(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_uint16(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn set_uint32(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn set_uint32(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 

--- a/nova_vm/src/ecmascript/builtins/structured_data/json_object.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/json_object.rs
@@ -4,6 +4,7 @@
 
 use sonic_rs::{JsonContainerTrait, JsonValueTrait};
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -82,12 +83,18 @@ impl JSONObject {
     /// > likewise does not apply during JSON.parse, means that not all texts
     /// > accepted by JSON.parse are valid as a PrimaryExpression, despite
     /// > matching the grammar.
-    fn parse(agent: &mut Agent, _this_value: Value, arguments: ArgumentsList) -> JsResult<Value> {
+    fn parse(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         let text = arguments.get(0);
         let reviver = arguments.get(1);
 
         // 1. Let jsonString be ? ToString(text).
-        let json_string = to_string(agent, text)?;
+        let json_string = to_string(agent, gc.reborrow(), text)?;
 
         // 2. Parse StringToCodePoints(jsonString) as a JSON text as specified in ECMA-404. Throw a SyntaxError exception if it is not a valid JSON text as defined in that specification.
         let json_value = match sonic_rs::from_str::<sonic_rs::Value>(json_string.as_str(agent)) {
@@ -102,7 +109,7 @@ impl JSONObject {
         // 5. NOTE: The early error rules defined in 13.2.5.1 have special handling for the above invocation of ParseText.
         // 6. Assert: script is a Parse Node.
         // 7. Let completion be Completion(Evaluation of script).
-        let completion = value_from_json(agent, &json_value);
+        let completion = value_from_json(agent, gc.reborrow(), &json_value);
 
         // 8. NOTE: The PropertyDefinitionEvaluation semantics defined in 13.2.5.5 have special handling for the above evaluation.
         // 9. Let unfiltered be completion.[[Value]].
@@ -127,10 +134,11 @@ impl JSONObject {
             let root_name = String::EMPTY_STRING.to_property_key();
 
             // c. Perform ! CreateDataPropertyOrThrow(root, rootName, unfiltered).
-            create_data_property_or_throw(agent, root, root_name, unfiltered).unwrap();
+            create_data_property_or_throw(agent, gc.reborrow(), root, root_name, unfiltered)
+                .unwrap();
 
             // d. Return ? InternalizeJSONProperty(root, rootName, reviver).
-            return internalize_json_property(agent, root, root_name, reviver);
+            return internalize_json_property(agent, gc.reborrow(), root, root_name, reviver);
         }
 
         // 12. Else,
@@ -140,6 +148,8 @@ impl JSONObject {
 
     fn stringify(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {
@@ -184,19 +194,21 @@ impl JSONObject {
 /// > lexically preceding values for the same key shall be overwritten.
 pub(crate) fn internalize_json_property(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     holder: Object,
     name: PropertyKey,
     reviver: Function,
 ) -> JsResult<Value> {
     // 1. Let val be ? Get(holder, name).
-    let val = get(agent, holder, name)?;
+    let val = get(agent, gc.reborrow(), holder, name)?;
     // 2. If val is an Object, then
     if let Ok(val) = Object::try_from(val) {
         // a. Let isArray be ? IsArray(val).
         // b. If isArray is true, then
         if is_array(agent, val.into_value())? {
             // i. Let len be ? LengthOfArrayLike(val).
-            let len = length_of_array_like(agent, val)?;
+            let len = length_of_array_like(agent, gc.reborrow(), val)?;
             // ii. Let I be 0.
             let mut i = 0;
             // iii. Repeat, while I < len,
@@ -205,16 +217,17 @@ pub(crate) fn internalize_json_property(
                 let prop = PropertyKey::from(SmallInteger::try_from(i).unwrap());
 
                 // 2. Let newElement be ? InternalizeJSONProperty(val, prop, reviver).
-                let new_element = internalize_json_property(agent, val, prop, reviver)?;
+                let new_element =
+                    internalize_json_property(agent, gc.reborrow(), val, prop, reviver)?;
 
                 // 3. If newElement is undefined, then
                 if new_element.is_undefined() {
                     // a. Perform ? val.[[Delete]](prop).
-                    val.internal_delete(agent, prop)?;
+                    val.internal_delete(agent, gc.reborrow(), prop)?;
                 } else {
                     // 4. Else,
                     // a. Perform ? CreateDataProperty(val, prop, newElement).
-                    create_data_property(agent, val, prop, new_element)?;
+                    create_data_property(agent, gc.reborrow(), val, prop, new_element)?;
                 }
 
                 // 5. Set I to I + 1.
@@ -223,23 +236,26 @@ pub(crate) fn internalize_json_property(
         } else {
             // c. Else,
             // i. Let keys be ? EnumerableOwnProperties(val, key).
-            let keys =
-                enumerable_own_properties::<enumerable_properties_kind::EnumerateKeys>(agent, val)?;
+            let keys = enumerable_own_properties::<enumerable_properties_kind::EnumerateKeys>(
+                agent,
+                gc.reborrow(),
+                val,
+            )?;
 
             // ii. For each String P of keys, do
             for p in keys {
                 let p = PropertyKey::try_from(p).unwrap();
                 // 1. Let newElement be ? InternalizeJSONProperty(val, P, reviver).
-                let new_element = internalize_json_property(agent, val, p, reviver)?;
+                let new_element = internalize_json_property(agent, gc.reborrow(), val, p, reviver)?;
 
                 // 2. If newElement is undefined, then
                 if new_element.is_undefined() {
                     // a. Perform ? val.[[Delete]](P).
-                    val.internal_delete(agent, p)?;
+                    val.internal_delete(agent, gc.reborrow(), p)?;
                 } else {
                     // 3. Else,
                     // a. Perform ? CreateDataProperty(val, P, newElement).
-                    create_data_property(agent, val, p, new_element)?;
+                    create_data_property(agent, gc.reborrow(), val, p, new_element)?;
                 }
             }
         }
@@ -248,13 +264,19 @@ pub(crate) fn internalize_json_property(
     // 3. Return ? Call(reviver, holder, « name, val »).
     call_function(
         agent,
+        gc.reborrow(),
         reviver,
         holder.into_value(),
         Some(ArgumentsList(&[name.into_value(), val])),
     )
 }
 
-pub(crate) fn value_from_json(agent: &mut Agent, json: &sonic_rs::Value) -> JsResult<Value> {
+pub(crate) fn value_from_json(
+    agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
+    json: &sonic_rs::Value,
+) -> JsResult<Value> {
     match json.get_type() {
         sonic_rs::JsonType::Null => Ok(Value::Null),
         sonic_rs::JsonType::Boolean => Ok(Value::Boolean(json.is_true())),
@@ -266,8 +288,8 @@ pub(crate) fn value_from_json(agent: &mut Agent, json: &sonic_rs::Value) -> JsRe
             let array_obj = array_create(agent, len, len, None)?;
             for (i, value) in json_array.iter().enumerate() {
                 let prop = PropertyKey::from(SmallInteger::try_from(i as i64).unwrap());
-                let js_value = value_from_json(agent, value)?;
-                create_data_property(agent, array_obj, prop, js_value)?;
+                let js_value = value_from_json(agent, gc.reborrow(), value)?;
+                create_data_property(agent, gc.reborrow(), array_obj, prop, js_value)?;
             }
             Ok(array_obj.into())
         }
@@ -277,8 +299,8 @@ pub(crate) fn value_from_json(agent: &mut Agent, json: &sonic_rs::Value) -> JsRe
                 ordinary_object_create_with_intrinsics(agent, Some(ProtoIntrinsics::Object), None);
             for (key, value) in json_object.iter() {
                 let prop = PropertyKey::from_str(agent, key);
-                let js_value = value_from_json(agent, value)?;
-                create_data_property(agent, object, prop, js_value)?;
+                let js_value = value_from_json(agent, gc.reborrow(), value)?;
+                create_data_property(agent, gc.reborrow(), object, prop, js_value)?;
             }
             Ok(object.into())
         }

--- a/nova_vm/src/ecmascript/builtins/structured_data/shared_array_buffer_objects/shared_array_buffer_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/shared_array_buffer_objects/shared_array_buffer_constructor.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -39,6 +40,8 @@ impl BuiltinGetter for SharedArrayBufferGetSpecies {}
 impl SharedArrayBufferConstructor {
     fn behaviour(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -48,6 +51,8 @@ impl SharedArrayBufferConstructor {
 
     fn species(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
     ) -> JsResult<Value> {

--- a/nova_vm/src/ecmascript/builtins/structured_data/shared_array_buffer_objects/shared_array_buffer_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/shared_array_buffer_objects/shared_array_buffer_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -55,29 +56,51 @@ impl Builtin for SharedArrayBufferPrototypeSlice {
 impl SharedArrayBufferPrototype {
     fn get_byte_length(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
         todo!()
     }
 
-    fn grow(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn grow(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_growable(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_growable(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
     fn get_max_byte_length(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
         todo!()
     }
 
-    fn slice(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn slice(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 

--- a/nova_vm/src/ecmascript/builtins/text_processing/regexp_objects/regexp_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/text_processing/regexp_objects/regexp_constructor.rs
@@ -18,6 +18,7 @@ use crate::ecmascript::types::PropertyKey;
 use crate::ecmascript::types::String;
 use crate::ecmascript::types::Value;
 use crate::ecmascript::types::BUILTIN_STRING_MEMORY;
+use crate::engine::context::GcScope;
 use crate::heap::IntrinsicConstructorIndexes;
 use crate::heap::WellKnownSymbolIndexes;
 
@@ -44,6 +45,8 @@ impl BuiltinGetter for RegExpGetSpecies {}
 impl RegExpConstructor {
     fn behaviour(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _arguments: ArgumentsList,
         _new_target: Option<Object>,
@@ -51,7 +54,13 @@ impl RegExpConstructor {
         todo!();
     }
 
-    fn get_species(_: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_species(
+        _: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         Ok(this_value)
     }
 

--- a/nova_vm/src/ecmascript/builtins/text_processing/regexp_objects/regexp_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/text_processing/regexp_objects/regexp_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{operations_on_objects::get, type_conversion::to_string},
@@ -153,24 +154,50 @@ impl Builtin for RegExpPrototypeGetUnicodeSets {
 impl BuiltinGetter for RegExpPrototypeGetUnicodeSets {}
 
 impl RegExpPrototype {
-    fn exec(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn exec(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_dot_all(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_dot_all(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_flags(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_flags(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_global(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_global(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
     fn get_has_indices(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
@@ -179,45 +206,101 @@ impl RegExpPrototype {
 
     fn get_ignore_case(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {
         todo!()
     }
 
-    fn r#match(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn r#match(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn match_all(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn match_all(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_multiline(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_multiline(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn replace(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn replace(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn search(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn search(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_source(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_source(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn split(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn split(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn get_sticky(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_sticky(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
-    fn test(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn test(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
@@ -228,13 +311,19 @@ impl RegExpPrototype {
     /// > The returned String has the form of a RegularExpressionLiteral that
     /// > evaluates to another RegExp object with the same behaviour as this
     /// > object.
-    fn to_string(agent: &mut Agent, this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn to_string(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         // 1. Let R be the this value.
         // 2. If R is not an Object, throw a TypeError exception.
         let Ok(r) = Object::try_from(this_value) else {
             let error_message = format!(
                 "{} is not an object",
-                this_value.string_repr(agent).as_str(agent)
+                this_value.string_repr(agent, gc.reborrow(),).as_str(agent)
             );
             return Err(agent.throw_exception(ExceptionType::TypeError, error_message));
         };
@@ -255,11 +344,11 @@ impl RegExpPrototype {
             return Ok(String::from_string(agent, regexp_string).into_value());
         }
         // 3. Let pattern be ? ToString(? Get(R, "source")).
-        let pattern = get(agent, r, BUILTIN_STRING_MEMORY.source.into())?;
-        let pattern = to_string(agent, pattern)?;
+        let pattern = get(agent, gc.reborrow(), r, BUILTIN_STRING_MEMORY.source.into())?;
+        let pattern = to_string(agent, gc.reborrow(), pattern)?;
         // 4. Let flags be ? ToString(? Get(R, "flags")).
-        let flags = get(agent, r, BUILTIN_STRING_MEMORY.flags.into())?;
-        let flags = to_string(agent, flags)?;
+        let flags = get(agent, gc.reborrow(), r, BUILTIN_STRING_MEMORY.flags.into())?;
+        let flags = to_string(agent, gc.reborrow(), flags)?;
         // 5. Let result be the string-concatenation of "/", pattern, "/", and flags.
         let result = format!("/{}/{}", pattern.as_str(agent), flags.as_str(agent));
         let result = String::from_string(agent, result);
@@ -267,12 +356,20 @@ impl RegExpPrototype {
         Ok(result.into_value())
     }
 
-    fn get_unicode(_agent: &mut Agent, _this_value: Value, _: ArgumentsList) -> JsResult<Value> {
+    fn get_unicode(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!()
     }
 
     fn get_unicode_sets(
         _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
         _this_value: Value,
         _: ArgumentsList,
     ) -> JsResult<Value> {

--- a/nova_vm/src/ecmascript/builtins/text_processing/regexp_objects/regexp_string_iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/text_processing/regexp_objects/regexp_string_iterator_prototype.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -25,7 +26,13 @@ impl Builtin for RegExpStringIteratorPrototypeNext {
 }
 
 impl RegExpStringIteratorPrototype {
-    fn next(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn next(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 

--- a/nova_vm/src/ecmascript/builtins/text_processing/string_objects/string_iterator_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/text_processing/string_objects/string_iterator_objects.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -25,7 +26,13 @@ impl Builtin for StringIteratorPrototypeNext {
 }
 
 impl StringIteratorPrototype {
-    fn next(_agent: &mut Agent, _this_value: Value, _arguments: ArgumentsList) -> JsResult<Value> {
+    fn next(
+        _agent: &mut Agent,
+        _gc: GcScope<'_, '_>,
+
+        _this_value: Value,
+        _arguments: ArgumentsList,
+    ) -> JsResult<Value> {
         todo!();
     }
 

--- a/nova_vm/src/ecmascript/execution/environments/function_environment.rs
+++ b/nova_vm/src/ecmascript/execution/environments/function_environment.rs
@@ -5,6 +5,7 @@
 use super::{
     DeclarativeEnvironment, DeclarativeEnvironmentIndex, EnvironmentIndex, FunctionEnvironmentIndex,
 };
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builtins::{ECMAScriptFunction, ThisMode},
@@ -429,7 +430,7 @@ impl FunctionEnvironmentIndex {
     /// The GetSuperBase concrete method of a Function Environment Record
     /// envRec takes no arguments and returns either a normal completion
     /// containing either an Object, null, or undefined, or a throw completion.
-    pub(crate) fn get_super_base(self, agent: &mut Agent) -> JsResult<Value> {
+    pub(crate) fn get_super_base(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<Value> {
         let env_rec: &FunctionEnvironment = &agent[self];
 
         // 1. Let home be envRec.[[FunctionObject]].[[HomeObject]].
@@ -450,7 +451,7 @@ impl FunctionEnvironmentIndex {
         // 3. Assert: home is an Object.
         // Type guarantees Objectness.
         // 4. Return ? home.[[GetPrototypeOf]]().
-        home.internal_get_prototype_of(agent)
+        home.internal_get_prototype_of(agent, gc)
             .map(|proto| proto.map_or_else(|| Value::Null, |proto| proto.into_value()))
     }
 }

--- a/nova_vm/src/ecmascript/execution/environments/global_environment.rs
+++ b/nova_vm/src/ecmascript/execution/environments/global_environment.rs
@@ -12,6 +12,7 @@ use crate::ecmascript::execution::agent::ExceptionType;
 use crate::ecmascript::execution::JsResult;
 use crate::ecmascript::types::{Object, PropertyDescriptor, PropertyKey, String, Value};
 use crate::ecmascript::{execution::Agent, types::InternalMethods};
+use crate::engine::context::GcScope;
 use crate::heap::{CompactionLists, HeapMarkAndSweep, WorkQueues};
 
 use super::{
@@ -142,7 +143,13 @@ impl GlobalEnvironmentIndex {
     /// takes argument N (a String) and returns either a normal completion
     /// containing a Boolean or a throw completion. It determines if the
     /// argument identifier is one of the identifiers bound by the record.
-    pub(crate) fn has_binding(self, agent: &mut Agent, name: String) -> JsResult<bool> {
+    pub(crate) fn has_binding(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        name: String,
+    ) -> JsResult<bool> {
         let env_rec = &agent[self];
         // 1. Let DclRec be envRec.[[DeclarativeRecord]].
         // 2. If ! DclRec.HasBinding(N) is true, return true.
@@ -153,7 +160,7 @@ impl GlobalEnvironmentIndex {
         // 3. Let ObjRec be envRec.[[ObjectRecord]].
         let obj_rec = env_rec.object_record;
         // 4. Return ? ObjRec.HasBinding(N).
-        obj_rec.has_binding(agent, name)
+        obj_rec.has_binding(agent, gc, name)
     }
 
     /// ### [9.1.1.4.2 CreateMutableBinding ( N, D )](https://tc39.es/ecma262/#sec-global-environment-records-createmutablebinding-n-d)
@@ -227,6 +234,8 @@ impl GlobalEnvironmentIndex {
     pub(crate) fn initialize_binding(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         name: String,
         value: Value,
     ) -> JsResult<()> {
@@ -243,7 +252,7 @@ impl GlobalEnvironmentIndex {
             // 4. Let ObjRec be envRec.[[ObjectRecord]].
             let obj_rec = env_rec.object_record;
             // 5. Return ? ObjRec.InitializeBinding(N, V).
-            obj_rec.initialize_binding(agent, name, value)
+            obj_rec.initialize_binding(agent, gc, name, value)
         }
     }
 
@@ -260,6 +269,8 @@ impl GlobalEnvironmentIndex {
     pub(crate) fn set_mutable_binding(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         name: String,
         value: Value,
         is_strict: bool,
@@ -275,7 +286,7 @@ impl GlobalEnvironmentIndex {
             // 3. Let ObjRec be envRec.[[ObjectRecord]].
             let obj_rec = env_rec.object_record;
             // 4. Return ? ObjRec.SetMutableBinding(N, V, S).
-            obj_rec.set_mutable_binding(agent, name, value, is_strict)
+            obj_rec.set_mutable_binding(agent, gc, name, value, is_strict)
         }
     }
 
@@ -292,6 +303,8 @@ impl GlobalEnvironmentIndex {
     pub(crate) fn get_binding_value(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         n: String,
         s: bool,
     ) -> JsResult<Value> {
@@ -306,7 +319,7 @@ impl GlobalEnvironmentIndex {
             // 3. Let ObjRec be envRec.[[ObjectRecord]].
             let obj_rec = env_rec.object_record;
             // 4. Return ? ObjRec.GetBindingValue(N, S).
-            obj_rec.get_binding_value(agent, n, s)
+            obj_rec.get_binding_value(agent, gc, n, s)
         }
     }
 
@@ -316,7 +329,13 @@ impl GlobalEnvironmentIndex {
     /// takes argument N (a String) and returns either a normal completion
     /// containing a Boolean or a throw completion. It can only delete bindings
     /// that have been explicitly designated as being subject to deletion.
-    pub(crate) fn delete_binding(self, agent: &mut Agent, name: String) -> JsResult<bool> {
+    pub(crate) fn delete_binding(
+        self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        name: String,
+    ) -> JsResult<bool> {
         let env_rec = &agent[self];
         // 1. Let DclRec be envRec.[[DeclarativeRecord]].
         let dcl_rec = env_rec.declarative_record;
@@ -331,11 +350,11 @@ impl GlobalEnvironmentIndex {
         let global_object = agent[obj_rec].binding_object;
         // 5. Let existingProp be ? HasOwnProperty(globalObject, N).
         let n = PropertyKey::from(name);
-        let existing_prop = has_own_property(agent, global_object, n)?;
+        let existing_prop = has_own_property(agent, gc.reborrow(), global_object, n)?;
         // 6. If existingProp is true, then
         if existing_prop {
             // a. Let status be ? ObjRec.DeleteBinding(N).
-            let status = obj_rec.delete_binding(agent, name)?;
+            let status = obj_rec.delete_binding(agent, gc, name)?;
             // b. If status is true and envRec.[[VarNames]] contains N, then
             if status {
                 let env_rec = &mut agent[self];
@@ -435,6 +454,8 @@ impl GlobalEnvironmentIndex {
     pub(crate) fn has_restricted_global_property(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         name: String,
     ) -> JsResult<bool> {
         let env_rec = &agent[self];
@@ -444,7 +465,7 @@ impl GlobalEnvironmentIndex {
         let global_object = agent[obj_rec].binding_object;
         // 3. Let existingProp be ? globalObject.[[GetOwnProperty]](N).
         let n = PropertyKey::from(name);
-        let existing_prop = global_object.internal_get_own_property(agent, n)?;
+        let existing_prop = global_object.internal_get_own_property(agent, gc, n)?;
         let Some(existing_prop) = existing_prop else {
             // 4. If existingProp is undefined, return false.
             return Ok(false);
@@ -462,7 +483,13 @@ impl GlobalEnvironmentIndex {
     /// a corresponding CreateGlobalVarBinding call would succeed if called for
     /// the same argument N. Redundant var declarations and var declarations
     /// for pre-existing global object properties are allowed.
-    pub(crate) fn can_declare_global_var(self, agent: &mut Agent, name: String) -> JsResult<bool> {
+    pub(crate) fn can_declare_global_var(
+        self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        name: String,
+    ) -> JsResult<bool> {
         let env_rec = &agent[self];
         // 1. Let ObjRec be envRec.[[ObjectRecord]].
         let obj_rec = env_rec.object_record;
@@ -470,13 +497,13 @@ impl GlobalEnvironmentIndex {
         let global_object = agent[obj_rec].binding_object;
         // 3. Let hasProperty be ? HasOwnProperty(globalObject, N).
         let n = PropertyKey::from(name);
-        let has_property = has_own_property(agent, global_object, n)?;
+        let has_property = has_own_property(agent, gc.reborrow(), global_object, n)?;
         // 4. If hasProperty is true, return true.
         if has_property {
             Ok(true)
         } else {
             // 5. Return ? IsExtensible(globalObject).
-            is_extensible(agent, global_object)
+            is_extensible(agent, gc, global_object)
         }
     }
 
@@ -490,6 +517,8 @@ impl GlobalEnvironmentIndex {
     pub(crate) fn can_declare_global_function(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         name: String,
     ) -> JsResult<bool> {
         let env_rec = &agent[self];
@@ -499,10 +528,10 @@ impl GlobalEnvironmentIndex {
         let global_object = agent[obj_rec].binding_object;
         let n = PropertyKey::from(name);
         // 3. Let existingProp be ? globalObject.[[GetOwnProperty]](N).
-        let existing_prop = global_object.internal_get_own_property(agent, n)?;
+        let existing_prop = global_object.internal_get_own_property(agent, gc.reborrow(), n)?;
         // 4. If existingProp is undefined, return ? IsExtensible(globalObject).
         let Some(existing_prop) = existing_prop else {
-            return is_extensible(agent, global_object);
+            return is_extensible(agent, gc, global_object);
         };
         // 5. If existingProp.[[Configurable]] is true, return true.
         if existing_prop.configurable == Some(true)
@@ -530,6 +559,8 @@ impl GlobalEnvironmentIndex {
     pub(crate) fn create_global_var_binding(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         name: String,
         is_deletable: bool,
     ) -> JsResult<()> {
@@ -540,15 +571,15 @@ impl GlobalEnvironmentIndex {
         let global_object = agent[obj_rec].binding_object;
         let n = PropertyKey::from(name);
         // 3. Let hasProperty be ? HasOwnProperty(globalObject, N).
-        let has_property = has_own_property(agent, global_object, n)?;
+        let has_property = has_own_property(agent, gc.reborrow(), global_object, n)?;
         // 4. Let extensible be ? IsExtensible(globalObject).
-        let extensible = is_extensible(agent, global_object).unwrap();
+        let extensible = is_extensible(agent, gc.reborrow(), global_object).unwrap();
         // 5. If hasProperty is false and extensible is true, then
         if !has_property && extensible {
             // a. Perform ? ObjRec.CreateMutableBinding(N, D).
-            obj_rec.create_mutable_binding(agent, name, is_deletable)?;
+            obj_rec.create_mutable_binding(agent, gc.reborrow(), name, is_deletable)?;
             // b. Perform ? ObjRec.InitializeBinding(N, undefined).
-            obj_rec.initialize_binding(agent, name, Value::Undefined)?;
+            obj_rec.initialize_binding(agent, gc, name, Value::Undefined)?;
         }
 
         // 6. If envRec.[[VarNames]] does not contain N, then
@@ -572,6 +603,8 @@ impl GlobalEnvironmentIndex {
     pub(crate) fn create_global_function_binding(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         name: String,
         value: Value,
         d: bool,
@@ -583,7 +616,7 @@ impl GlobalEnvironmentIndex {
         let global_object = agent[obj_rec].binding_object;
         let n = PropertyKey::from(name);
         // 3. Let existingProp be ? globalObject.[[GetOwnProperty]](N).
-        let existing_prop = global_object.internal_get_own_property(agent, n)?;
+        let existing_prop = global_object.internal_get_own_property(agent, gc.reborrow(), n)?;
         // 4. If existingProp is undefined or existingProp.[[Configurable]] is true, then
         let desc = if existing_prop.is_none() || existing_prop.unwrap().configurable == Some(true) {
             // a. Let desc be the PropertyDescriptor { [[Value]]: V, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: D }.
@@ -608,9 +641,9 @@ impl GlobalEnvironmentIndex {
             }
         };
         // 6. Perform ? DefinePropertyOrThrow(globalObject, N, desc).
-        define_property_or_throw(agent, global_object, n, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global_object, n, desc)?;
         // 7. Perform ? Set(globalObject, N, V, false).
-        set(agent, global_object, n, value, false)?;
+        set(agent, gc, global_object, n, value, false)?;
         // 8. If envRec.[[VarNames]] does not contain N, then
         // a. Append N to envRec.[[VarNames]].
         let env_rec = &mut agent[self];

--- a/nova_vm/src/ecmascript/execution/environments/object_environment.rs
+++ b/nova_vm/src/ecmascript/execution/environments/object_environment.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{ObjectEnvironmentIndex, OuterEnv};
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -102,14 +103,20 @@ impl ObjectEnvironmentIndex {
     /// takes argument N (a String) and returns either a normal completion
     /// containing a Boolean or a throw completion. It determines if its
     /// associated binding object has a property whose name is N.
-    pub(crate) fn has_binding(self, agent: &mut Agent, n: String) -> JsResult<bool> {
+    pub(crate) fn has_binding(
+        self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        n: String,
+    ) -> JsResult<bool> {
         let env_rec = &agent[self];
         // 1. Let bindingObject be envRec.[[BindingObject]].
         let binding_object = env_rec.binding_object;
         let is_with_environment = env_rec.is_with_environment;
         let name = PropertyKey::from(n);
         // 2. Let foundBinding be ? HasProperty(bindingObject, N).
-        let found_binding = has_property(agent, binding_object, name)?;
+        let found_binding = has_property(agent, gc.reborrow(), binding_object, name)?;
         // 3. If foundBinding is false, return false.
         if !found_binding {
             return Ok(false);
@@ -121,13 +128,14 @@ impl ObjectEnvironmentIndex {
         // 5. Let unscopables be ? Get(bindingObject, @@unscopables).
         let unscopables = get(
             agent,
+            gc.reborrow(),
             binding_object,
             PropertyKey::Symbol(WellKnownSymbolIndexes::Unscopables.into()),
         )?;
         // 6. If unscopables is an Object, then
         if let Ok(unscopables) = Object::try_from(unscopables) {
             // a. Let blocked be ToBoolean(? Get(unscopables, N)).
-            let blocked = get(agent, unscopables, name)?;
+            let blocked = get(agent, gc.reborrow(), unscopables, name)?;
             let blocked = to_boolean(agent, blocked);
             // b. If blocked is true, return false.
             Ok(!blocked)
@@ -148,6 +156,8 @@ impl ObjectEnvironmentIndex {
     pub(crate) fn create_mutable_binding(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         n: String,
         d: bool,
     ) -> JsResult<()> {
@@ -158,6 +168,7 @@ impl ObjectEnvironmentIndex {
         let n = PropertyKey::from(n);
         define_property_or_throw(
             agent,
+            gc,
             binding_object,
             n,
             PropertyDescriptor {
@@ -189,9 +200,16 @@ impl ObjectEnvironmentIndex {
     /// value) and returns either a normal completion containing UNUSED or a
     /// throw completion. It is used to set the bound value of the current
     /// binding of the identifier whose name is N to the value V.
-    pub(crate) fn initialize_binding(self, agent: &mut Agent, n: String, v: Value) -> JsResult<()> {
+    pub(crate) fn initialize_binding(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        n: String,
+        v: Value,
+    ) -> JsResult<()> {
         // 1. Perform ? envRec.SetMutableBinding(N, V, false).
-        self.set_mutable_binding(agent, n, v, false)?;
+        self.set_mutable_binding(agent, gc, n, v, false)?;
         // 2. Return UNUSED.
         Ok(())
         // NOTE
@@ -215,6 +233,8 @@ impl ObjectEnvironmentIndex {
     pub(crate) fn set_mutable_binding(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         n: String,
         v: Value,
         s: bool,
@@ -224,10 +244,10 @@ impl ObjectEnvironmentIndex {
         let binding_object = env_rec.binding_object;
         // 2. Let stillExists be ? HasProperty(bindingObject, N).
         let n = PropertyKey::from(n);
-        let still_exists = has_property(agent, binding_object, n)?;
+        let still_exists = has_property(agent, gc.reborrow(), binding_object, n)?;
         // 3. If stillExists is false and S is true, throw a ReferenceError exception.
         if !still_exists && s {
-            let binding_object_repr = binding_object.into_value().string_repr(agent);
+            let binding_object_repr = binding_object.into_value().string_repr(agent, gc);
             let error_message = format!(
                 "Property '{}' does not exist in {}.",
                 n.as_display(agent),
@@ -236,7 +256,7 @@ impl ObjectEnvironmentIndex {
             Err(agent.throw_exception(ExceptionType::ReferenceError, error_message))
         } else {
             // 4. Perform ? Set(bindingObject, N, V, S).
-            set(agent, binding_object, n, v, s)?;
+            set(agent, gc, binding_object, n, v, s)?;
             // 5. Return UNUSED.
             Ok(())
         }
@@ -252,6 +272,8 @@ impl ObjectEnvironmentIndex {
     pub(crate) fn get_binding_value(
         self,
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         n: String,
         s: bool,
     ) -> JsResult<Value> {
@@ -260,14 +282,14 @@ impl ObjectEnvironmentIndex {
         let binding_object = env_rec.binding_object;
         let name = PropertyKey::from(n);
         // 2. Let value be ? HasProperty(bindingObject, N).
-        let value = has_property(agent, binding_object, name)?;
+        let value = has_property(agent, gc.reborrow(), binding_object, name)?;
         // 3. If value is false, then
         if !value {
             // a. If S is false, return undefined; otherwise throw a ReferenceError exception.
             if !s {
                 Ok(Value::Undefined)
             } else {
-                let binding_object_repr = binding_object.into_value().string_repr(agent);
+                let binding_object_repr = binding_object.into_value().string_repr(agent, gc);
                 let error_message = format!(
                     "Property '{}' does not exist in {}.",
                     name.as_display(agent),
@@ -277,7 +299,7 @@ impl ObjectEnvironmentIndex {
             }
         } else {
             // 4. Return ? Get(bindingObject, N).
-            get(agent, binding_object, name)
+            get(agent, gc, binding_object, name)
         }
     }
 
@@ -288,13 +310,19 @@ impl ObjectEnvironmentIndex {
     /// completion containing a Boolean or a throw completion. It can only
     /// delete bindings that correspond to properties of the environment
     /// object whose [[Configurable]] attribute have the value true.
-    pub(crate) fn delete_binding(self, agent: &mut Agent, name: String) -> JsResult<bool> {
+    pub(crate) fn delete_binding(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        name: String,
+    ) -> JsResult<bool> {
         let env_rec = &agent[self];
         // 1. Let bindingObject be envRec.[[BindingObject]].
         let binding_boject = env_rec.binding_object;
         let name = PropertyKey::from(name);
         // 2. Return ? bindingObject.[[Delete]](N).
-        binding_boject.internal_delete(agent, name)
+        binding_boject.internal_delete(agent, gc, name)
     }
 
     /// ### [9.1.1.2.8 HasThisBinding ( )](https://tc39.es/ecma262/#sec-object-environment-records-hasthisbinding)

--- a/nova_vm/src/ecmascript/execution/realm.rs
+++ b/nova_vm/src/ecmascript/execution/realm.rs
@@ -7,6 +7,7 @@ mod intrinsics;
 use super::{
     environments::GlobalEnvironmentIndex, Agent, ExecutionContext, GlobalEnvironment, JsResult,
 };
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::operations_on_objects::define_property_or_throw,
@@ -319,6 +320,8 @@ pub(crate) fn set_realm_global_object(
 /// or a throw completion.
 pub(crate) fn set_default_global_bindings(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     realm_id: RealmIdentifier,
 ) -> JsResult<Object> {
     // 1. Let global be realmRec.[[GlobalObject]].
@@ -342,7 +345,7 @@ pub(crate) fn set_default_global_bindings(
             ..Default::default()
         };
 
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Infinity);
         let value = Number::from_f64(agent, f64::INFINITY);
@@ -353,7 +356,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(false),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.NaN);
         let value = Number::from_f64(agent, f64::NAN);
@@ -364,7 +367,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(false),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.undefined);
         let desc = PropertyDescriptor {
@@ -374,7 +377,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(false),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
     }
 
     // 19.2 Function Properties of the Global Object
@@ -389,7 +392,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.2.2 isFinite ( number )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.isFinite);
@@ -401,7 +404,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.2.3 isNaN ( number )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.isNaN);
@@ -413,7 +416,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.2.4 parseFloat ( string )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.parseFloat);
@@ -425,7 +428,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.2.5 parseInt ( string, radix )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.parseInt);
@@ -437,7 +440,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.2.6.1 decodeURI ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.decodeURI);
@@ -449,7 +452,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.2.6.2 decodeURIComponent ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.decodeURIComponent);
@@ -464,7 +467,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.2.6.3 encodeURI ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.encodeURI);
@@ -476,7 +479,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.2.6.4 encodeURIComponent ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.encodeURIComponent);
@@ -491,7 +494,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
     }
 
     // 19.3 Constructor Properties of the Global Object
@@ -506,7 +509,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.2 Array ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Array);
@@ -518,7 +521,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.3 ArrayBuffer ( . . . )
         #[cfg(feature = "array-buffer")]
@@ -532,7 +535,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
         // 19.3.4 BigInt ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.BigInt);
@@ -544,7 +547,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.5 BigInt64Array ( . . . )
         #[cfg(feature = "array-buffer")]
@@ -558,7 +561,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
             // 19.3.6 BigUint64Array ( . . . )
             let name = PropertyKey::from(BUILTIN_STRING_MEMORY.BigUint64Array);
@@ -570,7 +573,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
         // 19.3.7 Boolean ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Boolean);
@@ -582,7 +585,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.8 DataView ( . . . )
         #[cfg(feature = "array-buffer")]
@@ -596,7 +599,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
         #[cfg(feature = "date")]
         {
@@ -610,7 +613,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
         // 19.3.10 Error ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Error);
@@ -622,7 +625,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.11 EvalError ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.EvalError);
@@ -634,7 +637,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.12 FinalizationRegistry ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.FinalizationRegistry);
@@ -649,7 +652,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.13 Float32Array ( . . . )
         #[cfg(feature = "array-buffer")]
@@ -663,7 +666,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
             // 19.3.14 Float64Array ( . . . )
             let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Float64Array);
@@ -675,7 +678,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
         // 19.3.15 Function ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Function);
@@ -687,7 +690,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         // 19.3.16 Int8Array ( . . . )
         #[cfg(feature = "array-buffer")]
         {
@@ -700,7 +703,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
             // 19.3.17 Int16Array ( . . . )
             let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Int16Array);
@@ -712,7 +715,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
             // 19.3.18 Int32Array ( . . . )
             let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Int32Array);
@@ -724,7 +727,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
         // 19.3.19 Map ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Map);
@@ -736,7 +739,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.20 Number ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Number);
@@ -748,7 +751,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.21 Object ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Object);
@@ -760,7 +763,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.22 Promise ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Promise);
@@ -772,7 +775,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.23 Proxy ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Proxy);
@@ -784,7 +787,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.24 RangeError ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.RangeError);
@@ -796,7 +799,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.25 ReferenceError ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.ReferenceError);
@@ -808,7 +811,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.26 RegExp ( . . . )
         #[cfg(feature = "regexp")]
@@ -822,8 +825,9 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
+
         // 19.3.27 Set ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Set);
         let value = agent.get_realm(realm_id).intrinsics().set();
@@ -834,7 +838,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.28 SharedArrayBuffer ( . . . )
         #[cfg(feature = "shared-array-buffer")]
@@ -848,7 +852,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
         // 19.3.29 String ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.String);
@@ -860,7 +864,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.30 Symbol ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Symbol);
@@ -872,7 +876,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.31 SyntaxError ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.SyntaxError);
@@ -884,7 +888,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.32 TypeError ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.TypeError);
@@ -896,7 +900,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.33 Uint8Array ( . . . )
         #[cfg(feature = "array-buffer")]
@@ -910,7 +914,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
             // 19.3.34 Uint8ClampedArray ( . . . )
             let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Uint8ClampedArray);
@@ -922,7 +926,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
             // 19.3.35 Uint16Array ( . . . )
             let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Uint16Array);
@@ -934,7 +938,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
             // 19.3.36 Uint32Array ( . . . )
             let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Uint32Array);
@@ -946,7 +950,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
         // 19.3.37 URIError ( . . . )
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.URIError);
@@ -958,7 +962,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
         // 19.3.38 WeakMap ( . . . )
         #[cfg(feature = "weak-refs")]
@@ -972,7 +976,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
             // 19.3.39 WeakRef ( . . . )
             let name = PropertyKey::from(BUILTIN_STRING_MEMORY.WeakRef);
             let value = agent.get_realm(realm_id).intrinsics().weak_ref();
@@ -983,7 +987,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
 
             // 19.3.40 WeakSet ( . . . )
             let name = PropertyKey::from(BUILTIN_STRING_MEMORY.WeakSet);
@@ -995,7 +999,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
     }
 
@@ -1013,7 +1017,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
         // 19.4.2 JSON
         #[cfg(feature = "json")]
@@ -1027,7 +1031,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
 
         // 19.4.3 Math
@@ -1042,7 +1046,7 @@ pub(crate) fn set_default_global_bindings(
                 configurable: Some(true),
                 ..Default::default()
             };
-            define_property_or_throw(agent, global, name, desc)?;
+            define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
         }
         // 19.4.4 Reflect
         let name = PropertyKey::from(BUILTIN_STRING_MEMORY.Reflect);
@@ -1054,7 +1058,7 @@ pub(crate) fn set_default_global_bindings(
             configurable: Some(true),
             ..Default::default()
         };
-        define_property_or_throw(agent, global, name, desc)?;
+        define_property_or_throw(agent, gc.reborrow(), global, name, desc)?;
     }
 
     // 3. Return global.
@@ -1064,9 +1068,11 @@ pub(crate) fn set_default_global_bindings(
 /// ### [9.6 InitializeHostDefinedRealm ( )](https://tc39.es/ecma262/#sec-initializehostdefinedrealm)
 pub(crate) fn initialize_host_defined_realm(
     agent: &mut Agent,
-    create_global_object: Option<impl FnOnce(&mut Agent) -> Object>,
-    create_global_this_value: Option<impl FnOnce(&mut Agent) -> Object>,
-    initialize_global_object: Option<impl FnOnce(&mut Agent, Object)>,
+    mut gc: GcScope<'_, '_>,
+
+    create_global_object: Option<impl FnOnce(&mut Agent, GcScope<'_, '_>) -> Object>,
+    create_global_this_value: Option<impl FnOnce(&mut Agent, GcScope<'_, '_>) -> Object>,
+    initialize_global_object: Option<impl FnOnce(&mut Agent, GcScope<'_, '_>, Object)>,
 ) {
     // 1. Let realm be CreateRealm().
     let realm = create_realm(agent);
@@ -1093,34 +1099,36 @@ pub(crate) fn initialize_host_defined_realm(
     // 7. If the host requires use of an exotic object to serve as realm's global object,
     // let global be such an object created in a host-defined manner.
     // Otherwise, let global be undefined, indicating that an ordinary object should be created as the global object.
-    let global =
-        create_global_this_value.map(|create_global_this_value| create_global_this_value(agent));
+    let global = create_global_this_value
+        .map(|create_global_this_value| create_global_this_value(agent, gc.reborrow()));
 
     // 8. If the host requires that the this binding in realm's global scope return an object other than the global object,
     // let thisValue be such an object created in a host-defined manner.
     // Otherwise, let thisValue be undefined, indicating that realm's global this binding should be the global object.
-    let this_value = create_global_object.map(|create_global_object| create_global_object(agent));
+    let this_value =
+        create_global_object.map(|create_global_object| create_global_object(agent, gc.reborrow()));
 
     // 9. Perform SetRealmGlobalObject(realm, global, thisValue).
     set_realm_global_object(agent, realm, global, this_value);
 
     // 10. Let globalObj be ? SetDefaultGlobalBindings(realm).
-    let global_object = set_default_global_bindings(agent, realm).unwrap();
+    let global_object = set_default_global_bindings(agent, gc.reborrow(), realm).unwrap();
 
     // 11. Create any host-defined global object properties on globalObj.
     if let Some(initialize_global_object) = initialize_global_object {
-        initialize_global_object(agent, global_object);
+        initialize_global_object(agent, gc.reborrow(), global_object);
     };
 
     // 12. Return UNUSED.
 }
 
-pub(crate) fn initialize_default_realm(agent: &mut Agent) {
-    let create_global_object: Option<fn(&mut Agent) -> Object> = None;
-    let create_global_this_value: Option<fn(&mut Agent) -> Object> = None;
-    let initialize_global_object: Option<fn(&mut Agent, Object)> = None;
+pub(crate) fn initialize_default_realm(agent: &mut Agent, gc: GcScope<'_, '_>) {
+    let create_global_object: Option<fn(&mut Agent, GcScope<'_, '_>) -> Object> = None;
+    let create_global_this_value: Option<fn(&mut Agent, GcScope<'_, '_>) -> Object> = None;
+    let initialize_global_object: Option<fn(&mut Agent, GcScope<'_, '_>, Object)> = None;
     initialize_host_defined_realm(
         agent,
+        gc,
         create_global_object,
         create_global_this_value,
         initialize_global_object,
@@ -1130,10 +1138,13 @@ pub(crate) fn initialize_default_realm(agent: &mut Agent) {
 #[cfg(test)]
 mod test {
     #[allow(unused_imports)]
-    use crate::heap::{
-        IntrinsicConstructorIndexes, IntrinsicFunctionIndexes, IntrinsicObjectIndexes,
-        LAST_INTRINSIC_CONSTRUCTOR_INDEX, LAST_INTRINSIC_FUNCTION_INDEX,
-        LAST_INTRINSIC_OBJECT_INDEX, LAST_WELL_KNOWN_SYMBOL_INDEX,
+    use crate::{
+        engine::context::GcScope,
+        heap::{
+            IntrinsicConstructorIndexes, IntrinsicFunctionIndexes, IntrinsicObjectIndexes,
+            LAST_INTRINSIC_CONSTRUCTOR_INDEX, LAST_INTRINSIC_FUNCTION_INDEX,
+            LAST_INTRINSIC_OBJECT_INDEX, LAST_WELL_KNOWN_SYMBOL_INDEX,
+        },
     };
     fn panic_builtin_function_missing(index: usize) {
         let index = index as u32;
@@ -1185,7 +1196,9 @@ mod test {
         use crate::heap::indexes::ObjectIndex;
 
         let mut agent = Agent::new(Options::default(), &DefaultHostHooks);
-        initialize_default_realm(&mut agent);
+        let (mut gc, mut scope) = unsafe { GcScope::create_root() };
+        let gc = GcScope::new(&mut gc, &mut scope);
+        initialize_default_realm(&mut agent, gc);
         assert_eq!(
             agent.current_realm().intrinsics().object_index_base,
             ObjectIndex::from_index(0)

--- a/nova_vm/src/ecmascript/syntax_directed_operations/function_definitions.rs
+++ b/nova_vm/src/ecmascript/syntax_directed_operations/function_definitions.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::operations_on_objects::define_property_or_throw,
@@ -94,6 +95,8 @@ impl ContainsExpression for ast::ArrayPattern<'_> {
 /// Record or null) and returns an ECMAScript function object.
 pub(crate) fn instantiate_ordinary_function_object(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     function: &ast::Function<'_>,
     env: EnvironmentIndex,
     private_env: Option<PrivateEnvironmentIndex>,
@@ -153,6 +156,7 @@ pub(crate) fn instantiate_ordinary_function_object(
         // 6. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
         define_property_or_throw(
             agent,
+            gc,
             f,
             BUILTIN_STRING_MEMORY.prototype.to_property_key(),
             PropertyDescriptor {
@@ -261,6 +265,8 @@ impl CompileFunctionBodyData<'static> {
 /// containing an ECMAScript language value or an abrupt completion.
 pub(crate) fn evaluate_function_body(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     function_object: ECMAScriptFunction,
     arguments_list: ArgumentsList,
 ) -> JsResult<Value> {
@@ -275,12 +281,14 @@ pub(crate) fn evaluate_function_body(
         agent[function_object].compiled_bytecode = Some(exe);
         exe
     };
-    Vm::execute(agent, exe, Some(arguments_list.0)).into_js_result()
+    Vm::execute(agent, gc, exe, Some(arguments_list.0)).into_js_result()
 }
 
 /// ### [15.8.4 Runtime Semantics: EvaluateAsyncFunctionBody](https://tc39.es/ecma262/#sec-runtime-semantics-evaluateasyncfunctionbody)
 pub(crate) fn evaluate_async_function_body(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     function_object: ECMAScriptFunction,
     arguments_list: ArgumentsList,
 ) -> Promise {
@@ -305,14 +313,14 @@ pub(crate) fn evaluate_async_function_body(
 
     // AsyncFunctionStart will run the function until it returns, throws or gets suspended with
     // an await.
-    match Vm::execute(agent, exe, Some(arguments_list.0)) {
+    match Vm::execute(agent, gc.reborrow(), exe, Some(arguments_list.0)) {
         ExecutionResult::Return(result) => {
             // [27.7.5.2 AsyncBlockStart ( promiseCapability, asyncBody, asyncContext )](https://tc39.es/ecma262/#sec-asyncblockstart)
             // 2. e. If result is a normal completion, then
             //       i. Perform ! Call(promiseCapability.[[Resolve]], undefined, « undefined »).
             //    f. Else if result is a return completion, then
             //       i. Perform ! Call(promiseCapability.[[Resolve]], undefined, « result.[[Value]] »).
-            promise_capability.resolve(agent, result);
+            promise_capability.resolve(agent, gc, result);
         }
         ExecutionResult::Throw(err) => {
             // [27.7.5.2 AsyncBlockStart ( promiseCapability, asyncBody, asyncContext )](https://tc39.es/ecma262/#sec-asyncblockstart)
@@ -334,7 +342,7 @@ pub(crate) fn evaluate_async_function_body(
                 return_promise_capability: promise_capability,
             }));
             // 2. Let promise be ? PromiseResolve(%Promise%, value).
-            let promise = Promise::resolve(agent, awaited_value);
+            let promise = Promise::resolve(agent, gc, awaited_value);
             // 7. Perform PerformPromiseThen(promise, onFulfilled, onRejected).
             inner_promise_then(agent, promise, handler, handler, None);
         }
@@ -353,6 +361,8 @@ pub(crate) fn evaluate_async_function_body(
 /// completion.
 pub(crate) fn evaluate_generator_body(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     function_object: ECMAScriptFunction,
     arguments_list: ArgumentsList,
 ) -> JsResult<Value> {
@@ -365,6 +375,7 @@ pub(crate) fn evaluate_generator_body(
     // 3. Set G.[[GeneratorBrand]] to empty.
     let generator = ordinary_create_from_constructor(
         agent,
+        gc,
         function_object.into_function(),
         ProtoIntrinsics::Generator,
     )?;

--- a/nova_vm/src/ecmascript/syntax_directed_operations/miscellaneous.rs
+++ b/nova_vm/src/ecmascript/syntax_directed_operations/miscellaneous.rs
@@ -6,10 +6,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::{
-    builtins::ECMAScriptFunction,
-    execution::{Agent, EnvironmentIndex, PrivateEnvironmentIndex},
-    syntax_directed_operations::function_definitions::instantiate_ordinary_function_object,
+use crate::{
+    ecmascript::{
+        builtins::ECMAScriptFunction,
+        execution::{Agent, EnvironmentIndex, PrivateEnvironmentIndex},
+        syntax_directed_operations::function_definitions::instantiate_ordinary_function_object,
+    },
+    engine::context::GcScope,
 };
 use oxc_ast::ast;
 
@@ -20,6 +23,8 @@ use oxc_ast::ast;
 /// null) and returns an ECMAScript function object.
 pub(crate) fn instantiate_function_object(
     agent: &mut Agent,
+    gc: GcScope<'_, '_>,
+
     function: &ast::Function<'_>,
     env: EnvironmentIndex,
     private_env: Option<PrivateEnvironmentIndex>,
@@ -29,14 +34,14 @@ pub(crate) fn instantiate_function_object(
     // function ( FormalParameters ) { FunctionBody }
     if !function.r#async && !function.generator {
         // 1. Return InstantiateOrdinaryFunctionObject of FunctionDeclaration with arguments env and privateEnv.
-        return instantiate_ordinary_function_object(agent, function, env, private_env);
+        return instantiate_ordinary_function_object(agent, gc, function, env, private_env);
     }
     // GeneratorDeclaration :
     // function * BindingIdentifier ( FormalParameters ) { GeneratorBody }
     // function * ( FormalParameters ) { GeneratorBody }
     if !function.r#async && function.generator {
         // 1. Return InstantiateGeneratorFunctionObject of GeneratorDeclaration with arguments env and privateEnv.
-        return instantiate_ordinary_function_object(agent, function, env, private_env);
+        return instantiate_ordinary_function_object(agent, gc, function, env, private_env);
     }
     // AsyncGeneratorDeclaration :
     // async function * BindingIdentifier ( FormalParameters ) { AsyncGeneratorBody }
@@ -50,7 +55,7 @@ pub(crate) fn instantiate_function_object(
     // async function ( FormalParameters ) { AsyncFunctionBody }
     if function.r#async && !function.generator {
         // 1. Return InstantiateAsyncFunctionObject of AsyncFunctionDeclaration with arguments env and privateEnv.
-        return instantiate_ordinary_function_object(agent, function, env, private_env);
+        return instantiate_ordinary_function_object(agent, gc, function, env, private_env);
     }
     unreachable!();
 }

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -14,6 +14,7 @@ use super::{
         ECMASCRIPT_FUNCTION_DISCRIMINANT,
     }, InternalMethods, IntoObject, IntoValue, Object, OrdinaryObject, InternalSlots, PropertyKey, Value
 };
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builtins::{
@@ -243,14 +244,18 @@ impl InternalSlots for Function {
 }
 
 impl InternalMethods for Function {
-    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+    fn internal_get_prototype_of(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+    ) -> JsResult<Option<Object>> {
         match self {
-            Function::BoundFunction(x) => x.internal_get_prototype_of(agent),
-            Function::BuiltinFunction(x) => x.internal_get_prototype_of(agent),
-            Function::ECMAScriptFunction(x) => x.internal_get_prototype_of(agent),
+            Function::BoundFunction(x) => x.internal_get_prototype_of(agent, gc),
+            Function::BuiltinFunction(x) => x.internal_get_prototype_of(agent, gc),
+            Function::ECMAScriptFunction(x) => x.internal_get_prototype_of(agent, gc),
             Function::BuiltinGeneratorFunction => todo!(),
-            Function::BuiltinConstructorFunction(x) => x.internal_get_prototype_of(agent),
-            Function::BuiltinPromiseResolvingFunction(x) => x.internal_get_prototype_of(agent),
+            Function::BuiltinConstructorFunction(x) => x.internal_get_prototype_of(agent, gc),
+            Function::BuiltinPromiseResolvingFunction(x) => x.internal_get_prototype_of(agent, gc),
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
         }
@@ -259,45 +264,49 @@ impl InternalMethods for Function {
     fn internal_set_prototype_of(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         prototype: Option<Object>,
     ) -> JsResult<bool> {
         match self {
-            Function::BoundFunction(x) => x.internal_set_prototype_of(agent, prototype),
-            Function::BuiltinFunction(x) => x.internal_set_prototype_of(agent, prototype),
-            Function::ECMAScriptFunction(x) => x.internal_set_prototype_of(agent, prototype),
+            Function::BoundFunction(x) => x.internal_set_prototype_of(agent, gc, prototype),
+            Function::BuiltinFunction(x) => x.internal_set_prototype_of(agent, gc, prototype),
+            Function::ECMAScriptFunction(x) => x.internal_set_prototype_of(agent, gc, prototype),
             Function::BuiltinGeneratorFunction => todo!(),
             Function::BuiltinConstructorFunction(x) => {
-                x.internal_set_prototype_of(agent, prototype)
+                x.internal_set_prototype_of(agent, gc, prototype)
             }
             Function::BuiltinPromiseResolvingFunction(x) => {
-                x.internal_set_prototype_of(agent, prototype)
+                x.internal_set_prototype_of(agent, gc, prototype)
             }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
         }
     }
 
-    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+    fn internal_is_extensible(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<bool> {
         match self {
-            Function::BoundFunction(x) => x.internal_is_extensible(agent),
-            Function::BuiltinFunction(x) => x.internal_is_extensible(agent),
-            Function::ECMAScriptFunction(x) => x.internal_is_extensible(agent),
+            Function::BoundFunction(x) => x.internal_is_extensible(agent, gc),
+            Function::BuiltinFunction(x) => x.internal_is_extensible(agent, gc),
+            Function::ECMAScriptFunction(x) => x.internal_is_extensible(agent, gc),
             Function::BuiltinGeneratorFunction => todo!(),
-            Function::BuiltinConstructorFunction(x) => x.internal_is_extensible(agent),
-            Function::BuiltinPromiseResolvingFunction(x) => x.internal_is_extensible(agent),
+            Function::BuiltinConstructorFunction(x) => x.internal_is_extensible(agent, gc),
+            Function::BuiltinPromiseResolvingFunction(x) => x.internal_is_extensible(agent, gc),
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
         }
     }
 
-    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
+    fn internal_prevent_extensions(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<bool> {
         match self {
-            Function::BoundFunction(x) => x.internal_prevent_extensions(agent),
-            Function::BuiltinFunction(x) => x.internal_prevent_extensions(agent),
-            Function::ECMAScriptFunction(x) => x.internal_prevent_extensions(agent),
+            Function::BoundFunction(x) => x.internal_prevent_extensions(agent, gc),
+            Function::BuiltinFunction(x) => x.internal_prevent_extensions(agent, gc),
+            Function::ECMAScriptFunction(x) => x.internal_prevent_extensions(agent, gc),
             Function::BuiltinGeneratorFunction => todo!(),
-            Function::BuiltinConstructorFunction(x) => x.internal_prevent_extensions(agent),
-            Function::BuiltinPromiseResolvingFunction(x) => x.internal_prevent_extensions(agent),
+            Function::BuiltinConstructorFunction(x) => x.internal_prevent_extensions(agent, gc),
+            Function::BuiltinPromiseResolvingFunction(x) => {
+                x.internal_prevent_extensions(agent, gc)
+            }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
         }
@@ -306,18 +315,20 @@ impl InternalMethods for Function {
     fn internal_get_own_property(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         match self {
-            Function::BoundFunction(x) => x.internal_get_own_property(agent, property_key),
-            Function::BuiltinFunction(x) => x.internal_get_own_property(agent, property_key),
-            Function::ECMAScriptFunction(x) => x.internal_get_own_property(agent, property_key),
+            Function::BoundFunction(x) => x.internal_get_own_property(agent, gc, property_key),
+            Function::BuiltinFunction(x) => x.internal_get_own_property(agent, gc, property_key),
+            Function::ECMAScriptFunction(x) => x.internal_get_own_property(agent, gc, property_key),
             Function::BuiltinGeneratorFunction => todo!(),
             Function::BuiltinConstructorFunction(x) => {
-                x.internal_get_own_property(agent, property_key)
+                x.internal_get_own_property(agent, gc, property_key)
             }
             Function::BuiltinPromiseResolvingFunction(x) => {
-                x.internal_get_own_property(agent, property_key)
+                x.internal_get_own_property(agent, gc, property_key)
             }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
@@ -327,40 +338,50 @@ impl InternalMethods for Function {
     fn internal_define_own_property(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         match self {
             Function::BoundFunction(x) => {
-                x.internal_define_own_property(agent, property_key, property_descriptor)
+                x.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Function::BuiltinFunction(x) => {
-                x.internal_define_own_property(agent, property_key, property_descriptor)
+                x.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Function::ECMAScriptFunction(x) => {
-                x.internal_define_own_property(agent, property_key, property_descriptor)
+                x.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Function::BuiltinGeneratorFunction => todo!(),
             Function::BuiltinConstructorFunction(x) => {
-                x.internal_define_own_property(agent, property_key, property_descriptor)
+                x.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Function::BuiltinPromiseResolvingFunction(x) => {
-                x.internal_define_own_property(agent, property_key, property_descriptor)
+                x.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
         }
     }
 
-    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
         match self {
-            Function::BoundFunction(x) => x.internal_has_property(agent, property_key),
-            Function::BuiltinFunction(x) => x.internal_has_property(agent, property_key),
-            Function::ECMAScriptFunction(x) => x.internal_has_property(agent, property_key),
+            Function::BoundFunction(x) => x.internal_has_property(agent, gc, property_key),
+            Function::BuiltinFunction(x) => x.internal_has_property(agent, gc, property_key),
+            Function::ECMAScriptFunction(x) => x.internal_has_property(agent, gc, property_key),
             Function::BuiltinGeneratorFunction => todo!(),
-            Function::BuiltinConstructorFunction(x) => x.internal_has_property(agent, property_key),
+            Function::BuiltinConstructorFunction(x) => {
+                x.internal_has_property(agent, gc, property_key)
+            }
             Function::BuiltinPromiseResolvingFunction(x) => {
-                x.internal_has_property(agent, property_key)
+                x.internal_has_property(agent, gc, property_key)
             }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
@@ -370,19 +391,21 @@ impl InternalMethods for Function {
     fn internal_get(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         receiver: Value,
     ) -> JsResult<Value> {
         match self {
-            Function::BoundFunction(x) => x.internal_get(agent, property_key, receiver),
-            Function::BuiltinFunction(x) => x.internal_get(agent, property_key, receiver),
-            Function::ECMAScriptFunction(x) => x.internal_get(agent, property_key, receiver),
+            Function::BoundFunction(x) => x.internal_get(agent, gc, property_key, receiver),
+            Function::BuiltinFunction(x) => x.internal_get(agent, gc, property_key, receiver),
+            Function::ECMAScriptFunction(x) => x.internal_get(agent, gc, property_key, receiver),
             Function::BuiltinGeneratorFunction => todo!(),
             Function::BuiltinConstructorFunction(x) => {
-                x.internal_get(agent, property_key, receiver)
+                x.internal_get(agent, gc, property_key, receiver)
             }
             Function::BuiltinPromiseResolvingFunction(x) => {
-                x.internal_get(agent, property_key, receiver)
+                x.internal_get(agent, gc, property_key, receiver)
             }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
@@ -392,47 +415,65 @@ impl InternalMethods for Function {
     fn internal_set(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         value: Value,
         receiver: Value,
     ) -> JsResult<bool> {
         match self {
-            Function::BoundFunction(x) => x.internal_set(agent, property_key, value, receiver),
-            Function::BuiltinFunction(x) => x.internal_set(agent, property_key, value, receiver),
-            Function::ECMAScriptFunction(x) => x.internal_set(agent, property_key, value, receiver),
+            Function::BoundFunction(x) => x.internal_set(agent, gc, property_key, value, receiver),
+            Function::BuiltinFunction(x) => {
+                x.internal_set(agent, gc, property_key, value, receiver)
+            }
+            Function::ECMAScriptFunction(x) => {
+                x.internal_set(agent, gc, property_key, value, receiver)
+            }
             Function::BuiltinGeneratorFunction => todo!(),
             Function::BuiltinConstructorFunction(x) => {
-                x.internal_set(agent, property_key, value, receiver)
+                x.internal_set(agent, gc, property_key, value, receiver)
             }
             Function::BuiltinPromiseResolvingFunction(x) => {
-                x.internal_set(agent, property_key, value, receiver)
+                x.internal_set(agent, gc, property_key, value, receiver)
             }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
         }
     }
 
-    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
         match self {
-            Function::BoundFunction(x) => x.internal_delete(agent, property_key),
-            Function::BuiltinFunction(x) => x.internal_delete(agent, property_key),
-            Function::ECMAScriptFunction(x) => x.internal_delete(agent, property_key),
+            Function::BoundFunction(x) => x.internal_delete(agent, gc, property_key),
+            Function::BuiltinFunction(x) => x.internal_delete(agent, gc, property_key),
+            Function::ECMAScriptFunction(x) => x.internal_delete(agent, gc, property_key),
             Function::BuiltinGeneratorFunction => todo!(),
-            Function::BuiltinConstructorFunction(x) => x.internal_delete(agent, property_key),
-            Function::BuiltinPromiseResolvingFunction(x) => x.internal_delete(agent, property_key),
+            Function::BuiltinConstructorFunction(x) => x.internal_delete(agent, gc, property_key),
+            Function::BuiltinPromiseResolvingFunction(x) => {
+                x.internal_delete(agent, gc, property_key)
+            }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
         }
     }
 
-    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+    ) -> JsResult<Vec<PropertyKey>> {
         match self {
-            Function::BoundFunction(x) => x.internal_own_property_keys(agent),
-            Function::BuiltinFunction(x) => x.internal_own_property_keys(agent),
-            Function::ECMAScriptFunction(x) => x.internal_own_property_keys(agent),
+            Function::BoundFunction(x) => x.internal_own_property_keys(agent, gc),
+            Function::BuiltinFunction(x) => x.internal_own_property_keys(agent, gc),
+            Function::ECMAScriptFunction(x) => x.internal_own_property_keys(agent, gc),
             Function::BuiltinGeneratorFunction => todo!(),
-            Function::BuiltinConstructorFunction(x) => x.internal_own_property_keys(agent),
-            Function::BuiltinPromiseResolvingFunction(x) => x.internal_own_property_keys(agent),
+            Function::BuiltinConstructorFunction(x) => x.internal_own_property_keys(agent, gc),
+            Function::BuiltinPromiseResolvingFunction(x) => x.internal_own_property_keys(agent, gc),
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
         }
@@ -441,21 +482,25 @@ impl InternalMethods for Function {
     fn internal_call(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         this_argument: Value,
         arguments_list: ArgumentsList,
     ) -> JsResult<Value> {
         match self {
-            Function::BoundFunction(x) => x.internal_call(agent, this_argument, arguments_list),
-            Function::BuiltinFunction(x) => x.internal_call(agent, this_argument, arguments_list),
+            Function::BoundFunction(x) => x.internal_call(agent, gc, this_argument, arguments_list),
+            Function::BuiltinFunction(x) => {
+                x.internal_call(agent, gc, this_argument, arguments_list)
+            }
             Function::ECMAScriptFunction(x) => {
-                x.internal_call(agent, this_argument, arguments_list)
+                x.internal_call(agent, gc, this_argument, arguments_list)
             }
             Function::BuiltinGeneratorFunction => todo!(),
             Function::BuiltinConstructorFunction(x) => {
-                x.internal_call(agent, this_argument, arguments_list)
+                x.internal_call(agent, gc, this_argument, arguments_list)
             }
             Function::BuiltinPromiseResolvingFunction(x) => {
-                x.internal_call(agent, this_argument, arguments_list)
+                x.internal_call(agent, gc, this_argument, arguments_list)
             }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
@@ -465,21 +510,27 @@ impl InternalMethods for Function {
     fn internal_construct(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         arguments_list: ArgumentsList,
         new_target: Function,
     ) -> JsResult<Object> {
         match self {
-            Function::BoundFunction(x) => x.internal_construct(agent, arguments_list, new_target),
-            Function::BuiltinFunction(x) => x.internal_construct(agent, arguments_list, new_target),
+            Function::BoundFunction(x) => {
+                x.internal_construct(agent, gc, arguments_list, new_target)
+            }
+            Function::BuiltinFunction(x) => {
+                x.internal_construct(agent, gc, arguments_list, new_target)
+            }
             Function::ECMAScriptFunction(x) => {
-                x.internal_construct(agent, arguments_list, new_target)
+                x.internal_construct(agent, gc, arguments_list, new_target)
             }
             Function::BuiltinGeneratorFunction => todo!(),
             Function::BuiltinConstructorFunction(x) => {
-                x.internal_construct(agent, arguments_list, new_target)
+                x.internal_construct(agent, gc, arguments_list, new_target)
             }
             Function::BuiltinPromiseResolvingFunction(x) => {
-                x.internal_construct(agent, arguments_list, new_target)
+                x.internal_construct(agent, gc, arguments_list, new_target)
             }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
@@ -516,8 +567,15 @@ impl HeapMarkAndSweep for Function {
 }
 
 impl Function {
-    pub fn call(self, agent: &mut Agent, this_argument: Value, args: &[Value]) -> JsResult<Value> {
-        self.internal_call(agent, this_argument, ArgumentsList(args))
+    pub fn call(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        this_argument: Value,
+        args: &[Value],
+    ) -> JsResult<Value> {
+        self.internal_call(agent, gc, this_argument, ArgumentsList(args))
     }
 }
 

--- a/nova_vm/src/ecmascript/types/language/numeric.rs
+++ b/nova_vm/src/ecmascript/types/language/numeric.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::type_conversion::to_number,
@@ -83,13 +84,13 @@ impl Numeric {
     }
 
     /// ### [ℝ](https://tc39.es/ecma262/#%E2%84%9D)
-    pub fn to_real(self, agent: &mut Agent) -> JsResult<f64> {
+    pub fn to_real(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<f64> {
         Ok(match self {
             Self::Number(n) => agent[n],
             Self::Integer(i) => i.into_i64() as f64,
             Self::SmallF64(f) => f.into_f64(),
             // NOTE: Converting to a number should give us a nice error message.
-            _ => to_number(agent, self)?.into_f64(agent),
+            _ => to_number(agent, gc, self)?.into_f64(agent),
         })
     }
 }

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -52,6 +52,7 @@ use crate::ecmascript::builtins::shared_array_buffer::SharedArrayBuffer;
 #[cfg(feature = "weak-refs")]
 use crate::ecmascript::builtins::{weak_map::WeakMap, weak_ref::WeakRef, weak_set::WeakSet};
 #[cfg(feature = "array-buffer")]
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::builtins::{data_view::DataView, typed_array::TypedArray, ArrayBuffer},
     heap::indexes::TypedArrayIndex,
@@ -970,1141 +971,1243 @@ impl InternalSlots for Object {
 }
 
 impl InternalMethods for Object {
-    fn internal_get_prototype_of(self, agent: &mut Agent) -> JsResult<Option<Object>> {
+    fn internal_get_prototype_of(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+    ) -> JsResult<Option<Object>> {
         match self {
-            Object::Object(data) => data.internal_get_prototype_of(agent),
-            Object::Array(data) => data.internal_get_prototype_of(agent),
+            Object::Object(data) => data.internal_get_prototype_of(agent, gc),
+            Object::Array(data) => data.internal_get_prototype_of(agent, gc),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.internal_get_prototype_of(agent),
+            Object::ArrayBuffer(data) => data.internal_get_prototype_of(agent, gc),
             #[cfg(feature = "date")]
-            Object::Date(data) => data.internal_get_prototype_of(agent),
-            Object::Error(data) => data.internal_get_prototype_of(agent),
-            Object::BoundFunction(data) => data.internal_get_prototype_of(agent),
-            Object::BuiltinFunction(data) => data.internal_get_prototype_of(agent),
-            Object::ECMAScriptFunction(data) => data.internal_get_prototype_of(agent),
+            Object::Date(data) => data.internal_get_prototype_of(agent, gc),
+            Object::Error(data) => data.internal_get_prototype_of(agent, gc),
+            Object::BoundFunction(data) => data.internal_get_prototype_of(agent, gc),
+            Object::BuiltinFunction(data) => data.internal_get_prototype_of(agent, gc),
+            Object::ECMAScriptFunction(data) => data.internal_get_prototype_of(agent, gc),
             Object::BuiltinGeneratorFunction => todo!(),
-            Object::BuiltinConstructorFunction(data) => data.internal_get_prototype_of(agent),
-            Object::BuiltinPromiseResolvingFunction(data) => data.internal_get_prototype_of(agent),
+            Object::BuiltinConstructorFunction(data) => data.internal_get_prototype_of(agent, gc),
+            Object::BuiltinPromiseResolvingFunction(data) => {
+                data.internal_get_prototype_of(agent, gc)
+            }
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => data.internal_get_prototype_of(agent),
-            Object::Arguments(data) => data.internal_get_prototype_of(agent),
+            Object::PrimitiveObject(data) => data.internal_get_prototype_of(agent, gc),
+            Object::Arguments(data) => data.internal_get_prototype_of(agent, gc),
             #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.internal_get_prototype_of(agent),
-            Object::FinalizationRegistry(data) => data.internal_get_prototype_of(agent),
-            Object::Map(data) => data.internal_get_prototype_of(agent),
-            Object::Promise(data) => data.internal_get_prototype_of(agent),
-            Object::Proxy(data) => data.internal_get_prototype_of(agent),
+            Object::DataView(data) => data.internal_get_prototype_of(agent, gc),
+            Object::FinalizationRegistry(data) => data.internal_get_prototype_of(agent, gc),
+            Object::Map(data) => data.internal_get_prototype_of(agent, gc),
+            Object::Promise(data) => data.internal_get_prototype_of(agent, gc),
+            Object::Proxy(data) => data.internal_get_prototype_of(agent, gc),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.internal_get_prototype_of(agent),
-            Object::Set(data) => data.internal_get_prototype_of(agent),
+            Object::RegExp(data) => data.internal_get_prototype_of(agent, gc),
+            Object::Set(data) => data.internal_get_prototype_of(agent, gc),
             #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => data.internal_get_prototype_of(agent),
+            Object::SharedArrayBuffer(data) => data.internal_get_prototype_of(agent, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.internal_get_prototype_of(agent),
+            Object::WeakMap(data) => data.internal_get_prototype_of(agent, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.internal_get_prototype_of(agent),
+            Object::WeakRef(data) => data.internal_get_prototype_of(agent, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.internal_get_prototype_of(agent),
+            Object::WeakSet(data) => data.internal_get_prototype_of(agent, gc),
             #[cfg(feature = "array-buffer")]
-            Object::Int8Array(data) => TypedArray::Int8Array(data).internal_get_prototype_of(agent),
+            Object::Int8Array(data) => {
+                TypedArray::Int8Array(data).internal_get_prototype_of(agent, gc)
+            }
             #[cfg(feature = "array-buffer")]
             Object::Uint8Array(data) => {
-                TypedArray::Uint8Array(data).internal_get_prototype_of(agent)
+                TypedArray::Uint8Array(data).internal_get_prototype_of(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8ClampedArray(data) => {
-                TypedArray::Uint8ClampedArray(data).internal_get_prototype_of(agent)
+                TypedArray::Uint8ClampedArray(data).internal_get_prototype_of(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int16Array(data) => {
-                TypedArray::Int16Array(data).internal_get_prototype_of(agent)
+                TypedArray::Int16Array(data).internal_get_prototype_of(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).internal_get_prototype_of(agent)
+                TypedArray::Uint16Array(data).internal_get_prototype_of(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int32Array(data) => {
-                TypedArray::Int32Array(data).internal_get_prototype_of(agent)
+                TypedArray::Int32Array(data).internal_get_prototype_of(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).internal_get_prototype_of(agent)
+                TypedArray::Uint32Array(data).internal_get_prototype_of(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).internal_get_prototype_of(agent)
+                TypedArray::BigInt64Array(data).internal_get_prototype_of(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigUint64Array(data) => {
-                TypedArray::BigUint64Array(data).internal_get_prototype_of(agent)
+                TypedArray::BigUint64Array(data).internal_get_prototype_of(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).internal_get_prototype_of(agent)
+                TypedArray::Float32Array(data).internal_get_prototype_of(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).internal_get_prototype_of(agent)
+                TypedArray::Float64Array(data).internal_get_prototype_of(agent, gc)
             }
             Object::AsyncFromSyncIterator => todo!(),
             Object::AsyncIterator => todo!(),
             Object::Iterator => todo!(),
-            Object::ArrayIterator(data) => data.internal_get_prototype_of(agent),
-            Object::SetIterator(data) => data.internal_get_prototype_of(agent),
-            Object::MapIterator(data) => data.internal_get_prototype_of(agent),
-            Object::Generator(data) => data.internal_get_prototype_of(agent),
-            Object::Module(data) => data.internal_get_prototype_of(agent),
-            Object::EmbedderObject(data) => data.internal_get_prototype_of(agent),
+            Object::ArrayIterator(data) => data.internal_get_prototype_of(agent, gc),
+            Object::SetIterator(data) => data.internal_get_prototype_of(agent, gc),
+            Object::MapIterator(data) => data.internal_get_prototype_of(agent, gc),
+            Object::Generator(data) => data.internal_get_prototype_of(agent, gc),
+            Object::Module(data) => data.internal_get_prototype_of(agent, gc),
+            Object::EmbedderObject(data) => data.internal_get_prototype_of(agent, gc),
         }
     }
 
     fn internal_set_prototype_of(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         prototype: Option<Object>,
     ) -> JsResult<bool> {
         match self {
-            Object::Object(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::Array(data) => data.internal_set_prototype_of(agent, prototype),
+            Object::Object(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::Array(data) => data.internal_set_prototype_of(agent, gc, prototype),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.internal_set_prototype_of(agent, prototype),
+            Object::ArrayBuffer(data) => data.internal_set_prototype_of(agent, gc, prototype),
             #[cfg(feature = "date")]
-            Object::Date(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::Error(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::BoundFunction(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::BuiltinFunction(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::ECMAScriptFunction(data) => data.internal_set_prototype_of(agent, prototype),
+            Object::Date(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::Error(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::BoundFunction(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::BuiltinFunction(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::ECMAScriptFunction(data) => {
+                data.internal_set_prototype_of(agent, gc, prototype)
+            }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction(data) => {
-                data.internal_set_prototype_of(agent, prototype)
+                data.internal_set_prototype_of(agent, gc, prototype)
             }
             Object::BuiltinPromiseResolvingFunction(data) => {
-                data.internal_set_prototype_of(agent, prototype)
+                data.internal_set_prototype_of(agent, gc, prototype)
             }
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::Arguments(data) => data.internal_set_prototype_of(agent, prototype),
+            Object::PrimitiveObject(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::Arguments(data) => data.internal_set_prototype_of(agent, gc, prototype),
             #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::FinalizationRegistry(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::Map(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::Promise(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::Proxy(data) => data.internal_set_prototype_of(agent, prototype),
+            Object::DataView(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::FinalizationRegistry(data) => {
+                data.internal_set_prototype_of(agent, gc, prototype)
+            }
+            Object::Map(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::Promise(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::Proxy(data) => data.internal_set_prototype_of(agent, gc, prototype),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::Set(data) => data.internal_set_prototype_of(agent, prototype),
+            Object::RegExp(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::Set(data) => data.internal_set_prototype_of(agent, gc, prototype),
             #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => data.internal_set_prototype_of(agent, prototype),
+            Object::SharedArrayBuffer(data) => data.internal_set_prototype_of(agent, gc, prototype),
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.internal_set_prototype_of(agent, prototype),
+            Object::WeakMap(data) => data.internal_set_prototype_of(agent, gc, prototype),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.internal_set_prototype_of(agent, prototype),
+            Object::WeakRef(data) => data.internal_set_prototype_of(agent, gc, prototype),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.internal_set_prototype_of(agent, prototype),
+            Object::WeakSet(data) => data.internal_set_prototype_of(agent, gc, prototype),
             #[cfg(feature = "array-buffer")]
             Object::Int8Array(data) => {
-                TypedArray::Int8Array(data).internal_set_prototype_of(agent, prototype)
+                TypedArray::Int8Array(data).internal_set_prototype_of(agent, gc, prototype)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8Array(data) => {
-                TypedArray::Uint8Array(data).internal_set_prototype_of(agent, prototype)
+                TypedArray::Uint8Array(data).internal_set_prototype_of(agent, gc, prototype)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8ClampedArray(data) => {
-                TypedArray::Uint8ClampedArray(data).internal_set_prototype_of(agent, prototype)
+                TypedArray::Uint8ClampedArray(data).internal_set_prototype_of(agent, gc, prototype)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int16Array(data) => {
-                TypedArray::Int16Array(data).internal_set_prototype_of(agent, prototype)
+                TypedArray::Int16Array(data).internal_set_prototype_of(agent, gc, prototype)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).internal_set_prototype_of(agent, prototype)
+                TypedArray::Uint16Array(data).internal_set_prototype_of(agent, gc, prototype)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int32Array(data) => {
-                TypedArray::Int32Array(data).internal_set_prototype_of(agent, prototype)
+                TypedArray::Int32Array(data).internal_set_prototype_of(agent, gc, prototype)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).internal_set_prototype_of(agent, prototype)
+                TypedArray::Uint32Array(data).internal_set_prototype_of(agent, gc, prototype)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).internal_set_prototype_of(agent, prototype)
+                TypedArray::BigInt64Array(data).internal_set_prototype_of(agent, gc, prototype)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigUint64Array(data) => {
-                TypedArray::BigUint64Array(data).internal_set_prototype_of(agent, prototype)
+                TypedArray::BigUint64Array(data).internal_set_prototype_of(agent, gc, prototype)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).internal_set_prototype_of(agent, prototype)
+                TypedArray::Float32Array(data).internal_set_prototype_of(agent, gc, prototype)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).internal_set_prototype_of(agent, prototype)
+                TypedArray::Float64Array(data).internal_set_prototype_of(agent, gc, prototype)
             }
             Object::AsyncFromSyncIterator => todo!(),
             Object::AsyncIterator => todo!(),
             Object::Iterator => todo!(),
-            Object::ArrayIterator(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::SetIterator(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::MapIterator(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::Generator(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::Module(data) => data.internal_set_prototype_of(agent, prototype),
-            Object::EmbedderObject(data) => data.internal_set_prototype_of(agent, prototype),
+            Object::ArrayIterator(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::SetIterator(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::MapIterator(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::Generator(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::Module(data) => data.internal_set_prototype_of(agent, gc, prototype),
+            Object::EmbedderObject(data) => data.internal_set_prototype_of(agent, gc, prototype),
         }
     }
 
-    fn internal_is_extensible(self, agent: &mut Agent) -> JsResult<bool> {
+    fn internal_is_extensible(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<bool> {
         match self {
-            Object::Object(data) => data.internal_is_extensible(agent),
-            Object::Array(data) => data.internal_is_extensible(agent),
+            Object::Object(data) => data.internal_is_extensible(agent, gc),
+            Object::Array(data) => data.internal_is_extensible(agent, gc),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.internal_is_extensible(agent),
+            Object::ArrayBuffer(data) => data.internal_is_extensible(agent, gc),
             #[cfg(feature = "date")]
-            Object::Date(data) => data.internal_is_extensible(agent),
-            Object::Error(data) => data.internal_is_extensible(agent),
-            Object::BoundFunction(data) => data.internal_is_extensible(agent),
-            Object::BuiltinFunction(data) => data.internal_is_extensible(agent),
-            Object::ECMAScriptFunction(data) => data.internal_is_extensible(agent),
+            Object::Date(data) => data.internal_is_extensible(agent, gc),
+            Object::Error(data) => data.internal_is_extensible(agent, gc),
+            Object::BoundFunction(data) => data.internal_is_extensible(agent, gc),
+            Object::BuiltinFunction(data) => data.internal_is_extensible(agent, gc),
+            Object::ECMAScriptFunction(data) => data.internal_is_extensible(agent, gc),
             Object::BuiltinGeneratorFunction => todo!(),
-            Object::BuiltinConstructorFunction(data) => data.internal_is_extensible(agent),
-            Object::BuiltinPromiseResolvingFunction(data) => data.internal_is_extensible(agent),
+            Object::BuiltinConstructorFunction(data) => data.internal_is_extensible(agent, gc),
+            Object::BuiltinPromiseResolvingFunction(data) => data.internal_is_extensible(agent, gc),
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => data.internal_is_extensible(agent),
-            Object::Arguments(data) => data.internal_is_extensible(agent),
+            Object::PrimitiveObject(data) => data.internal_is_extensible(agent, gc),
+            Object::Arguments(data) => data.internal_is_extensible(agent, gc),
             #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.internal_is_extensible(agent),
-            Object::FinalizationRegistry(data) => data.internal_is_extensible(agent),
-            Object::Map(data) => data.internal_is_extensible(agent),
-            Object::Promise(data) => data.internal_is_extensible(agent),
-            Object::Proxy(data) => data.internal_is_extensible(agent),
+            Object::DataView(data) => data.internal_is_extensible(agent, gc),
+            Object::FinalizationRegistry(data) => data.internal_is_extensible(agent, gc),
+            Object::Map(data) => data.internal_is_extensible(agent, gc),
+            Object::Promise(data) => data.internal_is_extensible(agent, gc),
+            Object::Proxy(data) => data.internal_is_extensible(agent, gc),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.internal_is_extensible(agent),
-            Object::Set(data) => data.internal_is_extensible(agent),
+            Object::RegExp(data) => data.internal_is_extensible(agent, gc),
+            Object::Set(data) => data.internal_is_extensible(agent, gc),
             #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => data.internal_is_extensible(agent),
+            Object::SharedArrayBuffer(data) => data.internal_is_extensible(agent, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.internal_is_extensible(agent),
+            Object::WeakMap(data) => data.internal_is_extensible(agent, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.internal_is_extensible(agent),
+            Object::WeakRef(data) => data.internal_is_extensible(agent, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.internal_is_extensible(agent),
-            #[cfg(feature = "array-buffer")]
-            Object::Int8Array(data) => TypedArray::Int8Array(data).internal_is_extensible(agent),
-            #[cfg(feature = "array-buffer")]
-            Object::Uint8Array(data) => TypedArray::Uint8Array(data).internal_is_extensible(agent),
-            #[cfg(feature = "array-buffer")]
-            Object::Uint8ClampedArray(data) => {
-                TypedArray::Uint8ClampedArray(data).internal_is_extensible(agent)
-            }
-            #[cfg(feature = "array-buffer")]
-            Object::Int16Array(data) => TypedArray::Int16Array(data).internal_is_extensible(agent),
-            #[cfg(feature = "array-buffer")]
-            Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).internal_is_extensible(agent)
-            }
-            #[cfg(feature = "array-buffer")]
-            Object::Int32Array(data) => TypedArray::Int32Array(data).internal_is_extensible(agent),
-            #[cfg(feature = "array-buffer")]
-            Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).internal_is_extensible(agent)
-            }
-            #[cfg(feature = "array-buffer")]
-            Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).internal_is_extensible(agent)
-            }
-            #[cfg(feature = "array-buffer")]
-            Object::BigUint64Array(data) => {
-                TypedArray::BigUint64Array(data).internal_is_extensible(agent)
-            }
-            #[cfg(feature = "array-buffer")]
-            Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).internal_is_extensible(agent)
-            }
-            #[cfg(feature = "array-buffer")]
-            Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).internal_is_extensible(agent)
-            }
-            Object::AsyncFromSyncIterator => todo!(),
-            Object::AsyncIterator => todo!(),
-            Object::Iterator => todo!(),
-            Object::ArrayIterator(data) => data.internal_is_extensible(agent),
-            Object::SetIterator(data) => data.internal_is_extensible(agent),
-            Object::MapIterator(data) => data.internal_is_extensible(agent),
-            Object::Generator(data) => data.internal_is_extensible(agent),
-            Object::Module(data) => data.internal_is_extensible(agent),
-            Object::EmbedderObject(data) => data.internal_is_extensible(agent),
-        }
-    }
-
-    fn internal_prevent_extensions(self, agent: &mut Agent) -> JsResult<bool> {
-        match self {
-            Object::Object(data) => data.internal_prevent_extensions(agent),
-            Object::Array(data) => data.internal_prevent_extensions(agent),
-            #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.internal_prevent_extensions(agent),
-            #[cfg(feature = "date")]
-            Object::Date(data) => data.internal_prevent_extensions(agent),
-            Object::Error(data) => data.internal_prevent_extensions(agent),
-            Object::BoundFunction(data) => data.internal_prevent_extensions(agent),
-            Object::BuiltinFunction(data) => data.internal_prevent_extensions(agent),
-            Object::ECMAScriptFunction(data) => data.internal_prevent_extensions(agent),
-            Object::BuiltinGeneratorFunction => todo!(),
-            Object::BuiltinConstructorFunction(data) => data.internal_prevent_extensions(agent),
-            Object::BuiltinPromiseResolvingFunction(data) => {
-                data.internal_prevent_extensions(agent)
-            }
-            Object::BuiltinPromiseCollectorFunction => todo!(),
-            Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => data.internal_prevent_extensions(agent),
-            Object::Arguments(data) => data.internal_prevent_extensions(agent),
-            #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.internal_prevent_extensions(agent),
-            Object::FinalizationRegistry(data) => data.internal_prevent_extensions(agent),
-            Object::Map(data) => data.internal_prevent_extensions(agent),
-            Object::Promise(data) => data.internal_prevent_extensions(agent),
-            Object::Proxy(data) => data.internal_prevent_extensions(agent),
-            #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.internal_prevent_extensions(agent),
-            Object::Set(data) => data.internal_prevent_extensions(agent),
-            #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => data.internal_prevent_extensions(agent),
-            #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.internal_prevent_extensions(agent),
-            #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.internal_prevent_extensions(agent),
-            #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.internal_prevent_extensions(agent),
+            Object::WeakSet(data) => data.internal_is_extensible(agent, gc),
             #[cfg(feature = "array-buffer")]
             Object::Int8Array(data) => {
-                TypedArray::Int8Array(data).internal_prevent_extensions(agent)
+                TypedArray::Int8Array(data).internal_is_extensible(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8Array(data) => {
-                TypedArray::Uint8Array(data).internal_prevent_extensions(agent)
+                TypedArray::Uint8Array(data).internal_is_extensible(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8ClampedArray(data) => {
-                TypedArray::Uint8ClampedArray(data).internal_prevent_extensions(agent)
+                TypedArray::Uint8ClampedArray(data).internal_is_extensible(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int16Array(data) => {
-                TypedArray::Int16Array(data).internal_prevent_extensions(agent)
+                TypedArray::Int16Array(data).internal_is_extensible(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).internal_prevent_extensions(agent)
+                TypedArray::Uint16Array(data).internal_is_extensible(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int32Array(data) => {
-                TypedArray::Int32Array(data).internal_prevent_extensions(agent)
+                TypedArray::Int32Array(data).internal_is_extensible(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).internal_prevent_extensions(agent)
+                TypedArray::Uint32Array(data).internal_is_extensible(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).internal_prevent_extensions(agent)
+                TypedArray::BigInt64Array(data).internal_is_extensible(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigUint64Array(data) => {
-                TypedArray::BigUint64Array(data).internal_prevent_extensions(agent)
+                TypedArray::BigUint64Array(data).internal_is_extensible(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).internal_prevent_extensions(agent)
+                TypedArray::Float32Array(data).internal_is_extensible(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).internal_prevent_extensions(agent)
+                TypedArray::Float64Array(data).internal_is_extensible(agent, gc)
             }
             Object::AsyncFromSyncIterator => todo!(),
             Object::AsyncIterator => todo!(),
             Object::Iterator => todo!(),
-            Object::ArrayIterator(data) => data.internal_prevent_extensions(agent),
-            Object::SetIterator(data) => data.internal_prevent_extensions(agent),
-            Object::MapIterator(data) => data.internal_prevent_extensions(agent),
-            Object::Generator(data) => data.internal_prevent_extensions(agent),
-            Object::Module(data) => data.internal_prevent_extensions(agent),
-            Object::EmbedderObject(data) => data.internal_prevent_extensions(agent),
+            Object::ArrayIterator(data) => data.internal_is_extensible(agent, gc),
+            Object::SetIterator(data) => data.internal_is_extensible(agent, gc),
+            Object::MapIterator(data) => data.internal_is_extensible(agent, gc),
+            Object::Generator(data) => data.internal_is_extensible(agent, gc),
+            Object::Module(data) => data.internal_is_extensible(agent, gc),
+            Object::EmbedderObject(data) => data.internal_is_extensible(agent, gc),
+        }
+    }
+
+    fn internal_prevent_extensions(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<bool> {
+        match self {
+            Object::Object(data) => data.internal_prevent_extensions(agent, gc),
+            Object::Array(data) => data.internal_prevent_extensions(agent, gc),
+            #[cfg(feature = "array-buffer")]
+            Object::ArrayBuffer(data) => data.internal_prevent_extensions(agent, gc),
+            #[cfg(feature = "date")]
+            Object::Date(data) => data.internal_prevent_extensions(agent, gc),
+            Object::Error(data) => data.internal_prevent_extensions(agent, gc),
+            Object::BoundFunction(data) => data.internal_prevent_extensions(agent, gc),
+            Object::BuiltinFunction(data) => data.internal_prevent_extensions(agent, gc),
+            Object::ECMAScriptFunction(data) => data.internal_prevent_extensions(agent, gc),
+            Object::BuiltinGeneratorFunction => todo!(),
+            Object::BuiltinConstructorFunction(data) => data.internal_prevent_extensions(agent, gc),
+            Object::BuiltinPromiseResolvingFunction(data) => {
+                data.internal_prevent_extensions(agent, gc)
+            }
+            Object::BuiltinPromiseCollectorFunction => todo!(),
+            Object::BuiltinProxyRevokerFunction => todo!(),
+            Object::PrimitiveObject(data) => data.internal_prevent_extensions(agent, gc),
+            Object::Arguments(data) => data.internal_prevent_extensions(agent, gc),
+            #[cfg(feature = "array-buffer")]
+            Object::DataView(data) => data.internal_prevent_extensions(agent, gc),
+            Object::FinalizationRegistry(data) => data.internal_prevent_extensions(agent, gc),
+            Object::Map(data) => data.internal_prevent_extensions(agent, gc),
+            Object::Promise(data) => data.internal_prevent_extensions(agent, gc),
+            Object::Proxy(data) => data.internal_prevent_extensions(agent, gc),
+            #[cfg(feature = "regexp")]
+            Object::RegExp(data) => data.internal_prevent_extensions(agent, gc),
+            Object::Set(data) => data.internal_prevent_extensions(agent, gc),
+            #[cfg(feature = "shared-array-buffer")]
+            Object::SharedArrayBuffer(data) => data.internal_prevent_extensions(agent, gc),
+            #[cfg(feature = "weak-refs")]
+            Object::WeakMap(data) => data.internal_prevent_extensions(agent, gc),
+            #[cfg(feature = "weak-refs")]
+            Object::WeakRef(data) => data.internal_prevent_extensions(agent, gc),
+            #[cfg(feature = "weak-refs")]
+            Object::WeakSet(data) => data.internal_prevent_extensions(agent, gc),
+            #[cfg(feature = "array-buffer")]
+            Object::Int8Array(data) => {
+                TypedArray::Int8Array(data).internal_prevent_extensions(agent, gc)
+            }
+            #[cfg(feature = "array-buffer")]
+            Object::Uint8Array(data) => {
+                TypedArray::Uint8Array(data).internal_prevent_extensions(agent, gc)
+            }
+            #[cfg(feature = "array-buffer")]
+            Object::Uint8ClampedArray(data) => {
+                TypedArray::Uint8ClampedArray(data).internal_prevent_extensions(agent, gc)
+            }
+            #[cfg(feature = "array-buffer")]
+            Object::Int16Array(data) => {
+                TypedArray::Int16Array(data).internal_prevent_extensions(agent, gc)
+            }
+            #[cfg(feature = "array-buffer")]
+            Object::Uint16Array(data) => {
+                TypedArray::Uint16Array(data).internal_prevent_extensions(agent, gc)
+            }
+            #[cfg(feature = "array-buffer")]
+            Object::Int32Array(data) => {
+                TypedArray::Int32Array(data).internal_prevent_extensions(agent, gc)
+            }
+            #[cfg(feature = "array-buffer")]
+            Object::Uint32Array(data) => {
+                TypedArray::Uint32Array(data).internal_prevent_extensions(agent, gc)
+            }
+            #[cfg(feature = "array-buffer")]
+            Object::BigInt64Array(data) => {
+                TypedArray::BigInt64Array(data).internal_prevent_extensions(agent, gc)
+            }
+            #[cfg(feature = "array-buffer")]
+            Object::BigUint64Array(data) => {
+                TypedArray::BigUint64Array(data).internal_prevent_extensions(agent, gc)
+            }
+            #[cfg(feature = "array-buffer")]
+            Object::Float32Array(data) => {
+                TypedArray::Float32Array(data).internal_prevent_extensions(agent, gc)
+            }
+            #[cfg(feature = "array-buffer")]
+            Object::Float64Array(data) => {
+                TypedArray::Float64Array(data).internal_prevent_extensions(agent, gc)
+            }
+            Object::AsyncFromSyncIterator => todo!(),
+            Object::AsyncIterator => todo!(),
+            Object::Iterator => todo!(),
+            Object::ArrayIterator(data) => data.internal_prevent_extensions(agent, gc),
+            Object::SetIterator(data) => data.internal_prevent_extensions(agent, gc),
+            Object::MapIterator(data) => data.internal_prevent_extensions(agent, gc),
+            Object::Generator(data) => data.internal_prevent_extensions(agent, gc),
+            Object::Module(data) => data.internal_prevent_extensions(agent, gc),
+            Object::EmbedderObject(data) => data.internal_prevent_extensions(agent, gc),
         }
     }
 
     fn internal_get_own_property(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
     ) -> JsResult<Option<PropertyDescriptor>> {
         match self {
-            Object::Object(data) => data.internal_get_own_property(agent, property_key),
-            Object::Array(data) => data.internal_get_own_property(agent, property_key),
+            Object::Object(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::Array(data) => data.internal_get_own_property(agent, gc, property_key),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.internal_get_own_property(agent, property_key),
+            Object::ArrayBuffer(data) => data.internal_get_own_property(agent, gc, property_key),
             #[cfg(feature = "date")]
-            Object::Date(data) => data.internal_get_own_property(agent, property_key),
-            Object::Error(data) => data.internal_get_own_property(agent, property_key),
-            Object::BoundFunction(data) => data.internal_get_own_property(agent, property_key),
-            Object::BuiltinFunction(data) => data.internal_get_own_property(agent, property_key),
-            Object::ECMAScriptFunction(data) => data.internal_get_own_property(agent, property_key),
+            Object::Date(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::Error(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::BoundFunction(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::BuiltinFunction(data) => {
+                data.internal_get_own_property(agent, gc, property_key)
+            }
+            Object::ECMAScriptFunction(data) => {
+                data.internal_get_own_property(agent, gc, property_key)
+            }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction(data) => {
-                data.internal_get_own_property(agent, property_key)
+                data.internal_get_own_property(agent, gc, property_key)
             }
             Object::BuiltinPromiseResolvingFunction(data) => {
-                data.internal_get_own_property(agent, property_key)
+                data.internal_get_own_property(agent, gc, property_key)
             }
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => data.internal_get_own_property(agent, property_key),
-            Object::Arguments(data) => data.internal_get_own_property(agent, property_key),
-            #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.internal_get_own_property(agent, property_key),
-            Object::FinalizationRegistry(data) => {
-                data.internal_get_own_property(agent, property_key)
+            Object::PrimitiveObject(data) => {
+                data.internal_get_own_property(agent, gc, property_key)
             }
-            Object::Map(data) => data.internal_get_own_property(agent, property_key),
-            Object::Promise(data) => data.internal_get_own_property(agent, property_key),
-            Object::Proxy(data) => data.internal_get_own_property(agent, property_key),
+            Object::Arguments(data) => data.internal_get_own_property(agent, gc, property_key),
+            #[cfg(feature = "array-buffer")]
+            Object::DataView(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::FinalizationRegistry(data) => {
+                data.internal_get_own_property(agent, gc, property_key)
+            }
+            Object::Map(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::Promise(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::Proxy(data) => data.internal_get_own_property(agent, gc, property_key),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.internal_get_own_property(agent, property_key),
-            Object::Set(data) => data.internal_get_own_property(agent, property_key),
+            Object::RegExp(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::Set(data) => data.internal_get_own_property(agent, gc, property_key),
             #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => data.internal_get_own_property(agent, property_key),
+            Object::SharedArrayBuffer(data) => {
+                data.internal_get_own_property(agent, gc, property_key)
+            }
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.internal_get_own_property(agent, property_key),
+            Object::WeakMap(data) => data.internal_get_own_property(agent, gc, property_key),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.internal_get_own_property(agent, property_key),
+            Object::WeakRef(data) => data.internal_get_own_property(agent, gc, property_key),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.internal_get_own_property(agent, property_key),
+            Object::WeakSet(data) => data.internal_get_own_property(agent, gc, property_key),
             #[cfg(feature = "array-buffer")]
             Object::Int8Array(data) => {
-                TypedArray::Int8Array(data).internal_get_own_property(agent, property_key)
+                TypedArray::Int8Array(data).internal_get_own_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8Array(data) => {
-                TypedArray::Uint8Array(data).internal_get_own_property(agent, property_key)
+                TypedArray::Uint8Array(data).internal_get_own_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
-            Object::Uint8ClampedArray(data) => {
-                TypedArray::Uint8ClampedArray(data).internal_get_own_property(agent, property_key)
-            }
+            Object::Uint8ClampedArray(data) => TypedArray::Uint8ClampedArray(data)
+                .internal_get_own_property(agent, gc, property_key),
             #[cfg(feature = "array-buffer")]
             Object::Int16Array(data) => {
-                TypedArray::Int16Array(data).internal_get_own_property(agent, property_key)
+                TypedArray::Int16Array(data).internal_get_own_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).internal_get_own_property(agent, property_key)
+                TypedArray::Uint16Array(data).internal_get_own_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int32Array(data) => {
-                TypedArray::Int32Array(data).internal_get_own_property(agent, property_key)
+                TypedArray::Int32Array(data).internal_get_own_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).internal_get_own_property(agent, property_key)
+                TypedArray::Uint32Array(data).internal_get_own_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).internal_get_own_property(agent, property_key)
+                TypedArray::BigInt64Array(data).internal_get_own_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigUint64Array(data) => {
-                TypedArray::BigUint64Array(data).internal_get_own_property(agent, property_key)
+                TypedArray::BigUint64Array(data).internal_get_own_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).internal_get_own_property(agent, property_key)
+                TypedArray::Float32Array(data).internal_get_own_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).internal_get_own_property(agent, property_key)
+                TypedArray::Float64Array(data).internal_get_own_property(agent, gc, property_key)
             }
             Object::AsyncFromSyncIterator => todo!(),
             Object::AsyncIterator => todo!(),
             Object::Iterator => todo!(),
-            Object::ArrayIterator(data) => data.internal_get_own_property(agent, property_key),
-            Object::SetIterator(data) => data.internal_get_own_property(agent, property_key),
-            Object::MapIterator(data) => data.internal_get_own_property(agent, property_key),
-            Object::Generator(data) => data.internal_get_own_property(agent, property_key),
-            Object::Module(data) => data.internal_get_own_property(agent, property_key),
-            Object::EmbedderObject(data) => data.internal_get_own_property(agent, property_key),
+            Object::ArrayIterator(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::SetIterator(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::MapIterator(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::Generator(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::Module(data) => data.internal_get_own_property(agent, gc, property_key),
+            Object::EmbedderObject(data) => data.internal_get_own_property(agent, gc, property_key),
         }
     }
 
     fn internal_define_own_property(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         property_descriptor: PropertyDescriptor,
     ) -> JsResult<bool> {
         match self {
             Object::Object(idx) => {
-                idx.internal_define_own_property(agent, property_key, property_descriptor)
+                idx.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::Array(idx) => {
-                idx.internal_define_own_property(agent, property_key, property_descriptor)
+                idx.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             #[cfg(feature = "array-buffer")]
             Object::ArrayBuffer(idx) => {
-                idx.internal_define_own_property(agent, property_key, property_descriptor)
+                idx.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             #[cfg(feature = "date")]
             Object::Date(idx) => {
-                idx.internal_define_own_property(agent, property_key, property_descriptor)
+                idx.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::Error(idx) => {
-                idx.internal_define_own_property(agent, property_key, property_descriptor)
+                idx.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::BoundFunction(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::BuiltinFunction(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::ECMAScriptFunction(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::BuiltinPromiseResolvingFunction(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
             Object::PrimitiveObject(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::Arguments(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             #[cfg(feature = "array-buffer")]
             Object::DataView(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::FinalizationRegistry(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::Map(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::Promise(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::Proxy(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             #[cfg(feature = "regexp")]
             Object::RegExp(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::Set(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             #[cfg(feature = "shared-array-buffer")]
             Object::SharedArrayBuffer(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             #[cfg(feature = "weak-refs")]
             Object::WeakMap(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             #[cfg(feature = "weak-refs")]
             Object::WeakRef(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             #[cfg(feature = "weak-refs")]
             Object::WeakSet(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int8Array(data) => TypedArray::Int8Array(data).internal_define_own_property(
                 agent,
+                gc,
                 property_key,
                 property_descriptor,
             ),
             #[cfg(feature = "array-buffer")]
             Object::Uint8Array(data) => TypedArray::Uint8Array(data).internal_define_own_property(
                 agent,
+                gc,
                 property_key,
                 property_descriptor,
             ),
             #[cfg(feature = "array-buffer")]
             Object::Uint8ClampedArray(data) => TypedArray::Uint8ClampedArray(data)
-                .internal_define_own_property(agent, property_key, property_descriptor),
+                .internal_define_own_property(agent, gc, property_key, property_descriptor),
             #[cfg(feature = "array-buffer")]
             Object::Int16Array(data) => TypedArray::Int16Array(data).internal_define_own_property(
                 agent,
+                gc,
                 property_key,
                 property_descriptor,
             ),
             #[cfg(feature = "array-buffer")]
             Object::Uint16Array(data) => TypedArray::Uint16Array(data)
-                .internal_define_own_property(agent, property_key, property_descriptor),
+                .internal_define_own_property(agent, gc, property_key, property_descriptor),
             #[cfg(feature = "array-buffer")]
             Object::Int32Array(data) => TypedArray::Int32Array(data).internal_define_own_property(
                 agent,
+                gc,
                 property_key,
                 property_descriptor,
             ),
             #[cfg(feature = "array-buffer")]
             Object::Uint32Array(data) => TypedArray::Uint32Array(data)
-                .internal_define_own_property(agent, property_key, property_descriptor),
+                .internal_define_own_property(agent, gc, property_key, property_descriptor),
             #[cfg(feature = "array-buffer")]
             Object::BigInt64Array(data) => TypedArray::BigInt64Array(data)
-                .internal_define_own_property(agent, property_key, property_descriptor),
+                .internal_define_own_property(agent, gc, property_key, property_descriptor),
             #[cfg(feature = "array-buffer")]
             Object::BigUint64Array(data) => TypedArray::BigUint64Array(data)
-                .internal_define_own_property(agent, property_key, property_descriptor),
+                .internal_define_own_property(agent, gc, property_key, property_descriptor),
             #[cfg(feature = "array-buffer")]
             Object::Float32Array(data) => TypedArray::Float32Array(data)
-                .internal_define_own_property(agent, property_key, property_descriptor),
+                .internal_define_own_property(agent, gc, property_key, property_descriptor),
             #[cfg(feature = "array-buffer")]
             Object::Float64Array(data) => TypedArray::Float64Array(data)
-                .internal_define_own_property(agent, property_key, property_descriptor),
+                .internal_define_own_property(agent, gc, property_key, property_descriptor),
             Object::AsyncFromSyncIterator => todo!(),
             Object::AsyncIterator => todo!(),
             Object::Iterator => todo!(),
             Object::ArrayIterator(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::SetIterator(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::MapIterator(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::Generator(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::Module(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
             Object::EmbedderObject(data) => {
-                data.internal_define_own_property(agent, property_key, property_descriptor)
+                data.internal_define_own_property(agent, gc, property_key, property_descriptor)
             }
         }
     }
 
-    fn internal_has_property(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_has_property(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
         match self {
-            Object::Object(data) => data.internal_has_property(agent, property_key),
-            Object::Array(data) => data.internal_has_property(agent, property_key),
+            Object::Object(data) => data.internal_has_property(agent, gc, property_key),
+            Object::Array(data) => data.internal_has_property(agent, gc, property_key),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.internal_has_property(agent, property_key),
+            Object::ArrayBuffer(data) => data.internal_has_property(agent, gc, property_key),
             #[cfg(feature = "date")]
-            Object::Date(data) => data.internal_has_property(agent, property_key),
-            Object::Error(data) => data.internal_has_property(agent, property_key),
-            Object::BoundFunction(data) => data.internal_has_property(agent, property_key),
-            Object::BuiltinFunction(data) => data.internal_has_property(agent, property_key),
-            Object::ECMAScriptFunction(data) => data.internal_has_property(agent, property_key),
+            Object::Date(data) => data.internal_has_property(agent, gc, property_key),
+            Object::Error(data) => data.internal_has_property(agent, gc, property_key),
+            Object::BoundFunction(data) => data.internal_has_property(agent, gc, property_key),
+            Object::BuiltinFunction(data) => data.internal_has_property(agent, gc, property_key),
+            Object::ECMAScriptFunction(data) => data.internal_has_property(agent, gc, property_key),
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction(data) => {
-                data.internal_has_property(agent, property_key)
+                data.internal_has_property(agent, gc, property_key)
             }
             Object::BuiltinPromiseResolvingFunction(data) => {
-                data.internal_has_property(agent, property_key)
+                data.internal_has_property(agent, gc, property_key)
             }
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => data.internal_has_property(agent, property_key),
-            Object::Arguments(data) => data.internal_has_property(agent, property_key),
+            Object::PrimitiveObject(data) => data.internal_has_property(agent, gc, property_key),
+            Object::Arguments(data) => data.internal_has_property(agent, gc, property_key),
             #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.internal_has_property(agent, property_key),
-            Object::FinalizationRegistry(data) => data.internal_has_property(agent, property_key),
-            Object::Map(data) => data.internal_has_property(agent, property_key),
-            Object::Promise(data) => data.internal_has_property(agent, property_key),
-            Object::Proxy(data) => data.internal_has_property(agent, property_key),
+            Object::DataView(data) => data.internal_has_property(agent, gc, property_key),
+            Object::FinalizationRegistry(data) => {
+                data.internal_has_property(agent, gc, property_key)
+            }
+            Object::Map(data) => data.internal_has_property(agent, gc, property_key),
+            Object::Promise(data) => data.internal_has_property(agent, gc, property_key),
+            Object::Proxy(data) => data.internal_has_property(agent, gc, property_key),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.internal_has_property(agent, property_key),
-            Object::Set(data) => data.internal_has_property(agent, property_key),
+            Object::RegExp(data) => data.internal_has_property(agent, gc, property_key),
+            Object::Set(data) => data.internal_has_property(agent, gc, property_key),
             #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => data.internal_has_property(agent, property_key),
+            Object::SharedArrayBuffer(data) => data.internal_has_property(agent, gc, property_key),
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.internal_has_property(agent, property_key),
+            Object::WeakMap(data) => data.internal_has_property(agent, gc, property_key),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.internal_has_property(agent, property_key),
+            Object::WeakRef(data) => data.internal_has_property(agent, gc, property_key),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.internal_has_property(agent, property_key),
+            Object::WeakSet(data) => data.internal_has_property(agent, gc, property_key),
             #[cfg(feature = "array-buffer")]
             Object::Int8Array(data) => {
-                TypedArray::Int8Array(data).internal_has_property(agent, property_key)
+                TypedArray::Int8Array(data).internal_has_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8Array(data) => {
-                TypedArray::Uint8Array(data).internal_has_property(agent, property_key)
+                TypedArray::Uint8Array(data).internal_has_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8ClampedArray(data) => {
-                TypedArray::Uint8ClampedArray(data).internal_has_property(agent, property_key)
+                TypedArray::Uint8ClampedArray(data).internal_has_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int16Array(data) => {
-                TypedArray::Int16Array(data).internal_has_property(agent, property_key)
+                TypedArray::Int16Array(data).internal_has_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).internal_has_property(agent, property_key)
+                TypedArray::Uint16Array(data).internal_has_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int32Array(data) => {
-                TypedArray::Int32Array(data).internal_has_property(agent, property_key)
+                TypedArray::Int32Array(data).internal_has_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).internal_has_property(agent, property_key)
+                TypedArray::Uint32Array(data).internal_has_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).internal_has_property(agent, property_key)
+                TypedArray::BigInt64Array(data).internal_has_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigUint64Array(data) => {
-                TypedArray::BigUint64Array(data).internal_has_property(agent, property_key)
+                TypedArray::BigUint64Array(data).internal_has_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).internal_has_property(agent, property_key)
+                TypedArray::Float32Array(data).internal_has_property(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).internal_has_property(agent, property_key)
+                TypedArray::Float64Array(data).internal_has_property(agent, gc, property_key)
             }
             Object::AsyncFromSyncIterator => todo!(),
             Object::AsyncIterator => todo!(),
             Object::Iterator => todo!(),
-            Object::ArrayIterator(data) => data.internal_has_property(agent, property_key),
-            Object::SetIterator(data) => data.internal_has_property(agent, property_key),
-            Object::MapIterator(data) => data.internal_has_property(agent, property_key),
-            Object::Generator(data) => data.internal_has_property(agent, property_key),
-            Object::Module(data) => data.internal_has_property(agent, property_key),
-            Object::EmbedderObject(data) => data.internal_has_property(agent, property_key),
+            Object::ArrayIterator(data) => data.internal_has_property(agent, gc, property_key),
+            Object::SetIterator(data) => data.internal_has_property(agent, gc, property_key),
+            Object::MapIterator(data) => data.internal_has_property(agent, gc, property_key),
+            Object::Generator(data) => data.internal_has_property(agent, gc, property_key),
+            Object::Module(data) => data.internal_has_property(agent, gc, property_key),
+            Object::EmbedderObject(data) => data.internal_has_property(agent, gc, property_key),
         }
     }
 
     fn internal_get(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         receiver: Value,
     ) -> JsResult<Value> {
         match self {
-            Object::Object(data) => data.internal_get(agent, property_key, receiver),
-            Object::Array(data) => data.internal_get(agent, property_key, receiver),
+            Object::Object(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::Array(data) => data.internal_get(agent, gc, property_key, receiver),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.internal_get(agent, property_key, receiver),
+            Object::ArrayBuffer(data) => data.internal_get(agent, gc, property_key, receiver),
             #[cfg(feature = "date")]
-            Object::Date(data) => data.internal_get(agent, property_key, receiver),
-            Object::Error(data) => data.internal_get(agent, property_key, receiver),
-            Object::BoundFunction(data) => data.internal_get(agent, property_key, receiver),
-            Object::BuiltinFunction(data) => data.internal_get(agent, property_key, receiver),
-            Object::ECMAScriptFunction(data) => data.internal_get(agent, property_key, receiver),
+            Object::Date(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::Error(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::BoundFunction(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::BuiltinFunction(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::ECMAScriptFunction(data) => {
+                data.internal_get(agent, gc, property_key, receiver)
+            }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction(data) => {
-                data.internal_get(agent, property_key, receiver)
+                data.internal_get(agent, gc, property_key, receiver)
             }
             Object::BuiltinPromiseResolvingFunction(data) => {
-                data.internal_get(agent, property_key, receiver)
+                data.internal_get(agent, gc, property_key, receiver)
             }
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => data.internal_get(agent, property_key, receiver),
-            Object::Arguments(data) => data.internal_get(agent, property_key, receiver),
+            Object::PrimitiveObject(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::Arguments(data) => data.internal_get(agent, gc, property_key, receiver),
             #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.internal_get(agent, property_key, receiver),
-            Object::FinalizationRegistry(data) => data.internal_get(agent, property_key, receiver),
-            Object::Map(data) => data.internal_get(agent, property_key, receiver),
-            Object::Promise(data) => data.internal_get(agent, property_key, receiver),
-            Object::Proxy(data) => data.internal_get(agent, property_key, receiver),
+            Object::DataView(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::FinalizationRegistry(data) => {
+                data.internal_get(agent, gc, property_key, receiver)
+            }
+            Object::Map(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::Promise(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::Proxy(data) => data.internal_get(agent, gc, property_key, receiver),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.internal_get(agent, property_key, receiver),
-            Object::Set(data) => data.internal_get(agent, property_key, receiver),
+            Object::RegExp(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::Set(data) => data.internal_get(agent, gc, property_key, receiver),
             #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => data.internal_get(agent, property_key, receiver),
+            Object::SharedArrayBuffer(data) => data.internal_get(agent, gc, property_key, receiver),
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.internal_get(agent, property_key, receiver),
+            Object::WeakMap(data) => data.internal_get(agent, gc, property_key, receiver),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.internal_get(agent, property_key, receiver),
+            Object::WeakRef(data) => data.internal_get(agent, gc, property_key, receiver),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.internal_get(agent, property_key, receiver),
+            Object::WeakSet(data) => data.internal_get(agent, gc, property_key, receiver),
             #[cfg(feature = "array-buffer")]
             Object::Int8Array(data) => {
-                TypedArray::Int8Array(data).internal_get(agent, property_key, receiver)
+                TypedArray::Int8Array(data).internal_get(agent, gc, property_key, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8Array(data) => {
-                TypedArray::Uint8Array(data).internal_get(agent, property_key, receiver)
+                TypedArray::Uint8Array(data).internal_get(agent, gc, property_key, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8ClampedArray(data) => {
-                TypedArray::Uint8ClampedArray(data).internal_get(agent, property_key, receiver)
+                TypedArray::Uint8ClampedArray(data).internal_get(agent, gc, property_key, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int16Array(data) => {
-                TypedArray::Int16Array(data).internal_get(agent, property_key, receiver)
+                TypedArray::Int16Array(data).internal_get(agent, gc, property_key, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).internal_get(agent, property_key, receiver)
+                TypedArray::Uint16Array(data).internal_get(agent, gc, property_key, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int32Array(data) => {
-                TypedArray::Int32Array(data).internal_get(agent, property_key, receiver)
+                TypedArray::Int32Array(data).internal_get(agent, gc, property_key, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).internal_get(agent, property_key, receiver)
+                TypedArray::Uint32Array(data).internal_get(agent, gc, property_key, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).internal_get(agent, property_key, receiver)
+                TypedArray::BigInt64Array(data).internal_get(agent, gc, property_key, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigUint64Array(data) => {
-                TypedArray::BigUint64Array(data).internal_get(agent, property_key, receiver)
+                TypedArray::BigUint64Array(data).internal_get(agent, gc, property_key, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).internal_get(agent, property_key, receiver)
+                TypedArray::Float32Array(data).internal_get(agent, gc, property_key, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).internal_get(agent, property_key, receiver)
+                TypedArray::Float64Array(data).internal_get(agent, gc, property_key, receiver)
             }
             Object::AsyncFromSyncIterator => todo!(),
             Object::AsyncIterator => todo!(),
             Object::Iterator => todo!(),
-            Object::ArrayIterator(data) => data.internal_get(agent, property_key, receiver),
-            Object::SetIterator(data) => data.internal_get(agent, property_key, receiver),
-            Object::MapIterator(data) => data.internal_get(agent, property_key, receiver),
-            Object::Generator(data) => data.internal_get(agent, property_key, receiver),
-            Object::Module(data) => data.internal_get(agent, property_key, receiver),
-            Object::EmbedderObject(data) => data.internal_get(agent, property_key, receiver),
+            Object::ArrayIterator(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::SetIterator(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::MapIterator(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::Generator(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::Module(data) => data.internal_get(agent, gc, property_key, receiver),
+            Object::EmbedderObject(data) => data.internal_get(agent, gc, property_key, receiver),
         }
     }
 
     fn internal_set(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         property_key: PropertyKey,
         value: Value,
         receiver: Value,
     ) -> JsResult<bool> {
         match self {
-            Object::Object(data) => data.internal_set(agent, property_key, value, receiver),
-            Object::Array(data) => data.internal_set(agent, property_key, value, receiver),
+            Object::Object(data) => data.internal_set(agent, gc, property_key, value, receiver),
+            Object::Array(data) => data.internal_set(agent, gc, property_key, value, receiver),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.internal_set(agent, property_key, value, receiver),
+            Object::ArrayBuffer(data) => {
+                data.internal_set(agent, gc, property_key, value, receiver)
+            }
             #[cfg(feature = "date")]
-            Object::Date(data) => data.internal_set(agent, property_key, value, receiver),
-            Object::Error(data) => data.internal_set(agent, property_key, value, receiver),
-            Object::BoundFunction(data) => data.internal_set(agent, property_key, value, receiver),
+            Object::Date(data) => data.internal_set(agent, gc, property_key, value, receiver),
+            Object::Error(data) => data.internal_set(agent, gc, property_key, value, receiver),
+            Object::BoundFunction(data) => {
+                data.internal_set(agent, gc, property_key, value, receiver)
+            }
             Object::BuiltinFunction(data) => {
-                data.internal_set(agent, property_key, value, receiver)
+                data.internal_set(agent, gc, property_key, value, receiver)
             }
             Object::ECMAScriptFunction(data) => {
-                data.internal_set(agent, property_key, value, receiver)
+                data.internal_set(agent, gc, property_key, value, receiver)
             }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction(data) => {
-                data.internal_set(agent, property_key, value, receiver)
+                data.internal_set(agent, gc, property_key, value, receiver)
             }
             Object::BuiltinPromiseResolvingFunction(data) => {
-                data.internal_set(agent, property_key, value, receiver)
+                data.internal_set(agent, gc, property_key, value, receiver)
             }
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
             Object::PrimitiveObject(data) => {
-                data.internal_set(agent, property_key, value, receiver)
+                data.internal_set(agent, gc, property_key, value, receiver)
             }
-            Object::Arguments(data) => data.internal_set(agent, property_key, value, receiver),
+            Object::Arguments(data) => data.internal_set(agent, gc, property_key, value, receiver),
             #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.internal_set(agent, property_key, value, receiver),
+            Object::DataView(data) => data.internal_set(agent, gc, property_key, value, receiver),
             Object::FinalizationRegistry(data) => {
-                data.internal_set(agent, property_key, value, receiver)
+                data.internal_set(agent, gc, property_key, value, receiver)
             }
-            Object::Map(data) => data.internal_set(agent, property_key, value, receiver),
-            Object::Promise(data) => data.internal_set(agent, property_key, value, receiver),
-            Object::Proxy(data) => data.internal_set(agent, property_key, value, receiver),
+            Object::Map(data) => data.internal_set(agent, gc, property_key, value, receiver),
+            Object::Promise(data) => data.internal_set(agent, gc, property_key, value, receiver),
+            Object::Proxy(data) => data.internal_set(agent, gc, property_key, value, receiver),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.internal_set(agent, property_key, value, receiver),
-            Object::Set(data) => data.internal_set(agent, property_key, value, receiver),
+            Object::RegExp(data) => data.internal_set(agent, gc, property_key, value, receiver),
+            Object::Set(data) => data.internal_set(agent, gc, property_key, value, receiver),
             #[cfg(feature = "shared-array-buffer")]
             Object::SharedArrayBuffer(data) => {
-                data.internal_set(agent, property_key, value, receiver)
+                data.internal_set(agent, gc, property_key, value, receiver)
             }
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.internal_set(agent, property_key, value, receiver),
+            Object::WeakMap(data) => data.internal_set(agent, gc, property_key, value, receiver),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.internal_set(agent, property_key, value, receiver),
+            Object::WeakRef(data) => data.internal_set(agent, gc, property_key, value, receiver),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.internal_set(agent, property_key, value, receiver),
+            Object::WeakSet(data) => data.internal_set(agent, gc, property_key, value, receiver),
             #[cfg(feature = "array-buffer")]
             Object::Int8Array(data) => {
-                TypedArray::Int8Array(data).internal_set(agent, property_key, value, receiver)
+                TypedArray::Int8Array(data).internal_set(agent, gc, property_key, value, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8Array(data) => {
-                TypedArray::Uint8Array(data).internal_set(agent, property_key, value, receiver)
+                TypedArray::Uint8Array(data).internal_set(agent, gc, property_key, value, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8ClampedArray(data) => TypedArray::Uint8ClampedArray(data).internal_set(
                 agent,
+                gc,
                 property_key,
                 value,
                 receiver,
             ),
             #[cfg(feature = "array-buffer")]
             Object::Int16Array(data) => {
-                TypedArray::Int16Array(data).internal_set(agent, property_key, value, receiver)
+                TypedArray::Int16Array(data).internal_set(agent, gc, property_key, value, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).internal_set(agent, property_key, value, receiver)
+                TypedArray::Uint16Array(data).internal_set(agent, gc, property_key, value, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int32Array(data) => {
-                TypedArray::Int32Array(data).internal_set(agent, property_key, value, receiver)
+                TypedArray::Int32Array(data).internal_set(agent, gc, property_key, value, receiver)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).internal_set(agent, property_key, value, receiver)
+                TypedArray::Uint32Array(data).internal_set(agent, gc, property_key, value, receiver)
             }
             #[cfg(feature = "array-buffer")]
-            Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).internal_set(agent, property_key, value, receiver)
-            }
+            Object::BigInt64Array(data) => TypedArray::BigInt64Array(data).internal_set(
+                agent,
+                gc,
+                property_key,
+                value,
+                receiver,
+            ),
             #[cfg(feature = "array-buffer")]
-            Object::BigUint64Array(data) => {
-                TypedArray::BigUint64Array(data).internal_set(agent, property_key, value, receiver)
-            }
+            Object::BigUint64Array(data) => TypedArray::BigUint64Array(data).internal_set(
+                agent,
+                gc,
+                property_key,
+                value,
+                receiver,
+            ),
             #[cfg(feature = "array-buffer")]
-            Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).internal_set(agent, property_key, value, receiver)
-            }
+            Object::Float32Array(data) => TypedArray::Float32Array(data).internal_set(
+                agent,
+                gc,
+                property_key,
+                value,
+                receiver,
+            ),
             #[cfg(feature = "array-buffer")]
-            Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).internal_set(agent, property_key, value, receiver)
-            }
+            Object::Float64Array(data) => TypedArray::Float64Array(data).internal_set(
+                agent,
+                gc,
+                property_key,
+                value,
+                receiver,
+            ),
             Object::AsyncFromSyncIterator => todo!(),
             Object::AsyncIterator => todo!(),
             Object::Iterator => todo!(),
-            Object::ArrayIterator(data) => data.internal_set(agent, property_key, value, receiver),
-            Object::SetIterator(data) => data.internal_set(agent, property_key, value, receiver),
-            Object::MapIterator(data) => data.internal_set(agent, property_key, value, receiver),
-            Object::Generator(data) => data.internal_set(agent, property_key, value, receiver),
-            Object::Module(data) => data.internal_set(agent, property_key, value, receiver),
-            Object::EmbedderObject(data) => data.internal_set(agent, property_key, value, receiver),
+            Object::ArrayIterator(data) => {
+                data.internal_set(agent, gc, property_key, value, receiver)
+            }
+            Object::SetIterator(data) => {
+                data.internal_set(agent, gc, property_key, value, receiver)
+            }
+            Object::MapIterator(data) => {
+                data.internal_set(agent, gc, property_key, value, receiver)
+            }
+            Object::Generator(data) => data.internal_set(agent, gc, property_key, value, receiver),
+            Object::Module(data) => data.internal_set(agent, gc, property_key, value, receiver),
+            Object::EmbedderObject(data) => {
+                data.internal_set(agent, gc, property_key, value, receiver)
+            }
         }
     }
 
-    fn internal_delete(self, agent: &mut Agent, property_key: PropertyKey) -> JsResult<bool> {
+    fn internal_delete(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        property_key: PropertyKey,
+    ) -> JsResult<bool> {
         match self {
-            Object::Object(data) => data.internal_delete(agent, property_key),
-            Object::Array(data) => data.internal_delete(agent, property_key),
+            Object::Object(data) => data.internal_delete(agent, gc, property_key),
+            Object::Array(data) => data.internal_delete(agent, gc, property_key),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.internal_delete(agent, property_key),
+            Object::ArrayBuffer(data) => data.internal_delete(agent, gc, property_key),
             #[cfg(feature = "date")]
-            Object::Date(data) => data.internal_delete(agent, property_key),
-            Object::Error(data) => data.internal_delete(agent, property_key),
-            Object::BoundFunction(data) => data.internal_delete(agent, property_key),
-            Object::BuiltinFunction(data) => data.internal_delete(agent, property_key),
-            Object::ECMAScriptFunction(data) => data.internal_delete(agent, property_key),
+            Object::Date(data) => data.internal_delete(agent, gc, property_key),
+            Object::Error(data) => data.internal_delete(agent, gc, property_key),
+            Object::BoundFunction(data) => data.internal_delete(agent, gc, property_key),
+            Object::BuiltinFunction(data) => data.internal_delete(agent, gc, property_key),
+            Object::ECMAScriptFunction(data) => data.internal_delete(agent, gc, property_key),
             Object::BuiltinGeneratorFunction => todo!(),
-            Object::BuiltinConstructorFunction(data) => data.internal_delete(agent, property_key),
+            Object::BuiltinConstructorFunction(data) => {
+                data.internal_delete(agent, gc, property_key)
+            }
             Object::BuiltinPromiseResolvingFunction(data) => {
-                data.internal_delete(agent, property_key)
+                data.internal_delete(agent, gc, property_key)
             }
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => data.internal_delete(agent, property_key),
-            Object::Arguments(data) => data.internal_delete(agent, property_key),
+            Object::PrimitiveObject(data) => data.internal_delete(agent, gc, property_key),
+            Object::Arguments(data) => data.internal_delete(agent, gc, property_key),
             #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.internal_delete(agent, property_key),
-            Object::FinalizationRegistry(data) => data.internal_delete(agent, property_key),
-            Object::Map(data) => data.internal_delete(agent, property_key),
-            Object::Promise(data) => data.internal_delete(agent, property_key),
-            Object::Proxy(data) => data.internal_delete(agent, property_key),
+            Object::DataView(data) => data.internal_delete(agent, gc, property_key),
+            Object::FinalizationRegistry(data) => data.internal_delete(agent, gc, property_key),
+            Object::Map(data) => data.internal_delete(agent, gc, property_key),
+            Object::Promise(data) => data.internal_delete(agent, gc, property_key),
+            Object::Proxy(data) => data.internal_delete(agent, gc, property_key),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.internal_delete(agent, property_key),
-            Object::Set(data) => data.internal_delete(agent, property_key),
+            Object::RegExp(data) => data.internal_delete(agent, gc, property_key),
+            Object::Set(data) => data.internal_delete(agent, gc, property_key),
             #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => data.internal_delete(agent, property_key),
+            Object::SharedArrayBuffer(data) => data.internal_delete(agent, gc, property_key),
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.internal_delete(agent, property_key),
+            Object::WeakMap(data) => data.internal_delete(agent, gc, property_key),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.internal_delete(agent, property_key),
+            Object::WeakRef(data) => data.internal_delete(agent, gc, property_key),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.internal_delete(agent, property_key),
+            Object::WeakSet(data) => data.internal_delete(agent, gc, property_key),
             #[cfg(feature = "array-buffer")]
             Object::Int8Array(data) => {
-                TypedArray::Int8Array(data).internal_delete(agent, property_key)
+                TypedArray::Int8Array(data).internal_delete(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8Array(data) => {
-                TypedArray::Uint8Array(data).internal_delete(agent, property_key)
+                TypedArray::Uint8Array(data).internal_delete(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8ClampedArray(data) => {
-                TypedArray::Uint8ClampedArray(data).internal_delete(agent, property_key)
+                TypedArray::Uint8ClampedArray(data).internal_delete(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int16Array(data) => {
-                TypedArray::Int16Array(data).internal_delete(agent, property_key)
+                TypedArray::Int16Array(data).internal_delete(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).internal_delete(agent, property_key)
+                TypedArray::Uint16Array(data).internal_delete(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int32Array(data) => {
-                TypedArray::Int32Array(data).internal_delete(agent, property_key)
+                TypedArray::Int32Array(data).internal_delete(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).internal_delete(agent, property_key)
+                TypedArray::Uint32Array(data).internal_delete(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).internal_delete(agent, property_key)
+                TypedArray::BigInt64Array(data).internal_delete(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigUint64Array(data) => {
-                TypedArray::BigUint64Array(data).internal_delete(agent, property_key)
+                TypedArray::BigUint64Array(data).internal_delete(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).internal_delete(agent, property_key)
+                TypedArray::Float32Array(data).internal_delete(agent, gc, property_key)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).internal_delete(agent, property_key)
+                TypedArray::Float64Array(data).internal_delete(agent, gc, property_key)
             }
             Object::AsyncFromSyncIterator => todo!(),
             Object::AsyncIterator => todo!(),
             Object::Iterator => todo!(),
-            Object::ArrayIterator(data) => data.internal_delete(agent, property_key),
-            Object::SetIterator(data) => data.internal_delete(agent, property_key),
-            Object::MapIterator(data) => data.internal_delete(agent, property_key),
-            Object::Generator(data) => data.internal_delete(agent, property_key),
-            Object::Module(data) => data.internal_delete(agent, property_key),
-            Object::EmbedderObject(data) => data.internal_delete(agent, property_key),
+            Object::ArrayIterator(data) => data.internal_delete(agent, gc, property_key),
+            Object::SetIterator(data) => data.internal_delete(agent, gc, property_key),
+            Object::MapIterator(data) => data.internal_delete(agent, gc, property_key),
+            Object::Generator(data) => data.internal_delete(agent, gc, property_key),
+            Object::Module(data) => data.internal_delete(agent, gc, property_key),
+            Object::EmbedderObject(data) => data.internal_delete(agent, gc, property_key),
         }
     }
 
-    fn internal_own_property_keys(self, agent: &mut Agent) -> JsResult<Vec<PropertyKey>> {
+    fn internal_own_property_keys(
+        self,
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+    ) -> JsResult<Vec<PropertyKey>> {
         match self {
-            Object::Object(data) => data.internal_own_property_keys(agent),
-            Object::Array(data) => data.internal_own_property_keys(agent),
+            Object::Object(data) => data.internal_own_property_keys(agent, gc),
+            Object::Array(data) => data.internal_own_property_keys(agent, gc),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.internal_own_property_keys(agent),
+            Object::ArrayBuffer(data) => data.internal_own_property_keys(agent, gc),
             #[cfg(feature = "date")]
-            Object::Date(data) => data.internal_own_property_keys(agent),
-            Object::Error(data) => data.internal_own_property_keys(agent),
-            Object::BoundFunction(data) => data.internal_own_property_keys(agent),
-            Object::BuiltinFunction(data) => data.internal_own_property_keys(agent),
-            Object::ECMAScriptFunction(data) => data.internal_own_property_keys(agent),
+            Object::Date(data) => data.internal_own_property_keys(agent, gc),
+            Object::Error(data) => data.internal_own_property_keys(agent, gc),
+            Object::BoundFunction(data) => data.internal_own_property_keys(agent, gc),
+            Object::BuiltinFunction(data) => data.internal_own_property_keys(agent, gc),
+            Object::ECMAScriptFunction(data) => data.internal_own_property_keys(agent, gc),
             Object::BuiltinGeneratorFunction => todo!(),
-            Object::BuiltinConstructorFunction(data) => data.internal_own_property_keys(agent),
-            Object::BuiltinPromiseResolvingFunction(data) => data.internal_own_property_keys(agent),
+            Object::BuiltinConstructorFunction(data) => data.internal_own_property_keys(agent, gc),
+            Object::BuiltinPromiseResolvingFunction(data) => {
+                data.internal_own_property_keys(agent, gc)
+            }
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => data.internal_own_property_keys(agent),
-            Object::Arguments(data) => data.internal_own_property_keys(agent),
+            Object::PrimitiveObject(data) => data.internal_own_property_keys(agent, gc),
+            Object::Arguments(data) => data.internal_own_property_keys(agent, gc),
             #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.internal_own_property_keys(agent),
-            Object::FinalizationRegistry(data) => data.internal_own_property_keys(agent),
-            Object::Map(data) => data.internal_own_property_keys(agent),
-            Object::Promise(data) => data.internal_own_property_keys(agent),
-            Object::Proxy(data) => data.internal_own_property_keys(agent),
+            Object::DataView(data) => data.internal_own_property_keys(agent, gc),
+            Object::FinalizationRegistry(data) => data.internal_own_property_keys(agent, gc),
+            Object::Map(data) => data.internal_own_property_keys(agent, gc),
+            Object::Promise(data) => data.internal_own_property_keys(agent, gc),
+            Object::Proxy(data) => data.internal_own_property_keys(agent, gc),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.internal_own_property_keys(agent),
-            Object::Set(data) => data.internal_own_property_keys(agent),
+            Object::RegExp(data) => data.internal_own_property_keys(agent, gc),
+            Object::Set(data) => data.internal_own_property_keys(agent, gc),
             #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => data.internal_own_property_keys(agent),
+            Object::SharedArrayBuffer(data) => data.internal_own_property_keys(agent, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.internal_own_property_keys(agent),
+            Object::WeakMap(data) => data.internal_own_property_keys(agent, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.internal_own_property_keys(agent),
+            Object::WeakRef(data) => data.internal_own_property_keys(agent, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.internal_own_property_keys(agent),
+            Object::WeakSet(data) => data.internal_own_property_keys(agent, gc),
             #[cfg(feature = "array-buffer")]
             Object::Int8Array(data) => {
-                TypedArray::Int8Array(data).internal_own_property_keys(agent)
+                TypedArray::Int8Array(data).internal_own_property_keys(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8Array(data) => {
-                TypedArray::Uint8Array(data).internal_own_property_keys(agent)
+                TypedArray::Uint8Array(data).internal_own_property_keys(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8ClampedArray(data) => {
-                TypedArray::Uint8ClampedArray(data).internal_own_property_keys(agent)
+                TypedArray::Uint8ClampedArray(data).internal_own_property_keys(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int16Array(data) => {
-                TypedArray::Int16Array(data).internal_own_property_keys(agent)
+                TypedArray::Int16Array(data).internal_own_property_keys(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).internal_own_property_keys(agent)
+                TypedArray::Uint16Array(data).internal_own_property_keys(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int32Array(data) => {
-                TypedArray::Int32Array(data).internal_own_property_keys(agent)
+                TypedArray::Int32Array(data).internal_own_property_keys(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).internal_own_property_keys(agent)
+                TypedArray::Uint32Array(data).internal_own_property_keys(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).internal_own_property_keys(agent)
+                TypedArray::BigInt64Array(data).internal_own_property_keys(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigUint64Array(data) => {
-                TypedArray::BigUint64Array(data).internal_own_property_keys(agent)
+                TypedArray::BigUint64Array(data).internal_own_property_keys(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).internal_own_property_keys(agent)
+                TypedArray::Float32Array(data).internal_own_property_keys(agent, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).internal_own_property_keys(agent)
+                TypedArray::Float64Array(data).internal_own_property_keys(agent, gc)
             }
             Object::AsyncFromSyncIterator => todo!(),
             Object::AsyncIterator => todo!(),
             Object::Iterator => todo!(),
-            Object::ArrayIterator(data) => data.internal_own_property_keys(agent),
-            Object::SetIterator(data) => data.internal_own_property_keys(agent),
-            Object::MapIterator(data) => data.internal_own_property_keys(agent),
-            Object::Generator(data) => data.internal_own_property_keys(agent),
-            Object::Module(data) => data.internal_own_property_keys(agent),
-            Object::EmbedderObject(data) => data.internal_own_property_keys(agent),
+            Object::ArrayIterator(data) => data.internal_own_property_keys(agent, gc),
+            Object::SetIterator(data) => data.internal_own_property_keys(agent, gc),
+            Object::MapIterator(data) => data.internal_own_property_keys(agent, gc),
+            Object::Generator(data) => data.internal_own_property_keys(agent, gc),
+            Object::Module(data) => data.internal_own_property_keys(agent, gc),
+            Object::EmbedderObject(data) => data.internal_own_property_keys(agent, gc),
         }
     }
 
     fn internal_call(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         this_value: Value,
         arguments_list: ArgumentsList,
     ) -> JsResult<Value> {
         match self {
-            Object::BoundFunction(data) => data.internal_call(agent, this_value, arguments_list),
-            Object::BuiltinFunction(data) => data.internal_call(agent, this_value, arguments_list),
+            Object::BoundFunction(data) => {
+                data.internal_call(agent, gc, this_value, arguments_list)
+            }
+            Object::BuiltinFunction(data) => {
+                data.internal_call(agent, gc, this_value, arguments_list)
+            }
             Object::ECMAScriptFunction(data) => {
-                data.internal_call(agent, this_value, arguments_list)
+                data.internal_call(agent, gc, this_value, arguments_list)
             }
             Object::EmbedderObject(_) => todo!(),
             _ => unreachable!(),
@@ -2114,18 +2217,20 @@ impl InternalMethods for Object {
     fn internal_construct(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         arguments_list: ArgumentsList,
         new_target: Function,
     ) -> JsResult<Object> {
         match self {
             Object::BoundFunction(data) => {
-                data.internal_construct(agent, arguments_list, new_target)
+                data.internal_construct(agent, gc, arguments_list, new_target)
             }
             Object::BuiltinFunction(data) => {
-                data.internal_construct(agent, arguments_list, new_target)
+                data.internal_construct(agent, gc, arguments_list, new_target)
             }
             Object::ECMAScriptFunction(data) => {
-                data.internal_construct(agent, arguments_list, new_target)
+                data.internal_construct(agent, gc, arguments_list, new_target)
             }
             _ => unreachable!(),
         }

--- a/nova_vm/src/ecmascript/types/language/object/property_key.rs
+++ b/nova_vm/src/ecmascript/types/language/object/property_key.rs
@@ -71,7 +71,7 @@ impl PropertyKey {
         s == n.to_string()
     }
 
-    pub fn equals(self, agent: &mut Agent, y: Self) -> bool {
+    pub fn equals(self, agent: &Agent, y: Self) -> bool {
         let x = self;
 
         match (x, y) {

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -53,6 +53,7 @@ use crate::{
         types::BUILTIN_STRING_MEMORY,
     },
     engine::{
+        context::GcScope,
         rootable::{HeapRootData, HeapRootRef, Rootable},
         small_f64::SmallF64,
     },
@@ -474,47 +475,47 @@ impl Value {
         }
     }
 
-    pub fn to_number(self, agent: &mut Agent) -> JsResult<Number> {
-        to_number(agent, self)
+    pub fn to_number(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<Number> {
+        to_number(agent, gc, self)
     }
 
-    pub fn to_bigint(self, agent: &mut Agent) -> JsResult<BigInt> {
-        to_big_int(agent, self)
+    pub fn to_bigint(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<BigInt> {
+        to_big_int(agent, gc, self)
     }
 
-    pub fn to_numeric(self, agent: &mut Agent) -> JsResult<Numeric> {
-        to_numeric(agent, self)
+    pub fn to_numeric(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<Numeric> {
+        to_numeric(agent, gc, self)
     }
 
-    pub fn to_int32(self, agent: &mut Agent) -> JsResult<i32> {
-        to_int32(agent, self)
+    pub fn to_int32(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<i32> {
+        to_int32(agent, gc, self)
     }
 
-    pub fn to_uint32(self, agent: &mut Agent) -> JsResult<u32> {
-        to_uint32(agent, self)
+    pub fn to_uint32(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<u32> {
+        to_uint32(agent, gc, self)
     }
 
-    pub fn to_int16(self, agent: &mut Agent) -> JsResult<i16> {
-        to_int16(agent, self)
+    pub fn to_int16(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<i16> {
+        to_int16(agent, gc, self)
     }
 
-    pub fn to_uint16(self, agent: &mut Agent) -> JsResult<u16> {
-        to_uint16(agent, self)
+    pub fn to_uint16(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<u16> {
+        to_uint16(agent, gc, self)
     }
 
-    pub fn to_string(self, agent: &mut Agent) -> JsResult<String> {
-        to_string(agent, self)
+    pub fn to_string(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<String> {
+        to_string(agent, gc, self)
     }
 
     /// A string conversion that will never throw, meant for things like
     /// displaying exceptions.
-    pub fn string_repr(self, agent: &mut Agent) -> String {
+    pub fn string_repr(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> String {
         if let Value::Symbol(symbol_idx) = self {
             // ToString of a symbol always throws. We use the descriptive
             // string instead (the result of `String(symbol)`).
             return symbol_idx.descriptive_string(agent);
         };
-        match self.to_string(agent) {
+        match self.to_string(agent, gc) {
             Ok(result) => result,
             Err(_) => {
                 debug_assert!(self.is_object());
@@ -524,13 +525,13 @@ impl Value {
     }
 
     /// ### [ℝ](https://tc39.es/ecma262/#%E2%84%9D)
-    pub fn to_real(self, agent: &mut Agent) -> JsResult<f64> {
+    pub fn to_real(self, agent: &mut Agent, gc: GcScope<'_, '_>) -> JsResult<f64> {
         Ok(match self {
             Value::Number(n) => agent[n],
             Value::Integer(i) => i.into_i64() as f64,
             Value::SmallF64(f) => f.into_f64(),
             // NOTE: Converting to a number should give us a nice error message.
-            _ => to_number(agent, self)?.into_f64(agent),
+            _ => to_number(agent, gc, self)?.into_f64(agent),
         })
     }
 

--- a/nova_vm/src/engine.rs
+++ b/nova_vm/src/engine.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod bytecode;
+pub mod context;
 pub mod register_value;
 pub mod rootable;
 pub mod small_f64;

--- a/nova_vm/src/engine/bytecode/bytecode_compiler.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler.rs
@@ -1569,8 +1569,7 @@ impl CompileEvaluation for ast::RegExpLiteral<'_> {
             ast::RegExpPattern::Pattern(_) => unreachable!(),
         };
         let pattern = String::from_str(ctx.agent, pattern);
-        let regexp =
-            reg_exp_create(ctx.agent, pattern.into_value(), Some(self.regex.flags)).unwrap();
+        let regexp = reg_exp_create(ctx.agent, pattern, Some(self.regex.flags)).unwrap();
         ctx.add_instruction_with_constant(Instruction::StoreConstant, regexp);
     }
 }

--- a/nova_vm/src/engine/bytecode/iterator.rs
+++ b/nova_vm/src/engine/bytecode/iterator.rs
@@ -4,6 +4,7 @@
 
 use std::collections::VecDeque;
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -35,10 +36,14 @@ impl VmIterator {
     /// function implements much the same intent. It does the IteratorNext
     /// step, followed by a completion check, and finally extracts the value
     /// if the iterator did not complete yet.
-    pub(super) fn step_value(&mut self, agent: &mut Agent) -> JsResult<Option<Value>> {
+    pub(super) fn step_value(
+        &mut self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+    ) -> JsResult<Option<Value>> {
         match self {
             VmIterator::ObjectProperties(iter) => {
-                let result = iter.next(agent)?;
+                let result = iter.next(agent, gc.reborrow())?;
                 if let Some(result) = result {
                     Ok(Some(match result {
                         PropertyKey::Integer(int) => {
@@ -52,9 +57,15 @@ impl VmIterator {
                     Ok(None)
                 }
             }
-            VmIterator::ArrayValues(iter) => iter.next(agent),
+            VmIterator::ArrayValues(iter) => iter.next(agent, gc.reborrow()),
             VmIterator::GenericIterator(iter) => {
-                let result = call(agent, iter.next_method, iter.iterator.into_value(), None)?;
+                let result = call(
+                    agent,
+                    gc.reborrow(),
+                    iter.next_method,
+                    iter.iterator.into_value(),
+                    None,
+                )?;
                 let Ok(result) = Object::try_from(result) else {
                     return Err(agent.throw_exception_with_static_message(
                         ExceptionType::TypeError,
@@ -62,13 +73,23 @@ impl VmIterator {
                     ));
                 };
                 // 1. Return ToBoolean(? Get(iterResult, "done")).
-                let done = get(agent, result, BUILTIN_STRING_MEMORY.done.into())?;
+                let done = get(
+                    agent,
+                    gc.reborrow(),
+                    result,
+                    BUILTIN_STRING_MEMORY.done.into(),
+                )?;
                 let done = to_boolean(agent, done);
                 if done {
                     Ok(None)
                 } else {
                     // 1. Return ? Get(iterResult, "value").
-                    let value = get(agent, result, BUILTIN_STRING_MEMORY.value.into())?;
+                    let value = get(
+                        agent,
+                        gc.reborrow(),
+                        result,
+                        BUILTIN_STRING_MEMORY.value.into(),
+                    )?;
                     Ok(Some(value))
                 }
             }
@@ -96,10 +117,16 @@ impl VmIterator {
         }
     }
 
-    pub(super) fn from_value(agent: &mut Agent, value: Value) -> JsResult<Self> {
+    pub(super) fn from_value(
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        value: Value,
+    ) -> JsResult<Self> {
         // a. Let method be ? GetMethod(obj, %Symbol.iterator%).
         let method = get_method(
             agent,
+            gc.reborrow(),
             value,
             PropertyKey::Symbol(WellKnownSymbolIndexes::Iterator.into()),
         )?;
@@ -116,6 +143,7 @@ impl VmIterator {
             Value::Array(array)
                 if get_method(
                     agent,
+                    gc.reborrow(),
                     value,
                     PropertyKey::Symbol(WellKnownSymbolIndexes::Iterator.into()),
                 )? == Some(
@@ -129,7 +157,7 @@ impl VmIterator {
                 Ok(VmIterator::ArrayValues(ArrayValuesIterator::new(array)))
             }
             _ => {
-                let js_iterator = get_iterator_from_method(agent, value, method)?;
+                let js_iterator = get_iterator_from_method(agent, gc, value, method)?;
                 Ok(VmIterator::GenericIterator(js_iterator))
             }
         }
@@ -154,11 +182,15 @@ impl ObjectPropertiesIterator {
         }
     }
 
-    pub(super) fn next(&mut self, agent: &mut Agent) -> JsResult<Option<PropertyKey>> {
+    pub(super) fn next(
+        &mut self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+    ) -> JsResult<Option<PropertyKey>> {
         loop {
             let object = self.object;
             if !self.object_was_visited {
-                let keys = object.internal_own_property_keys(agent)?;
+                let keys = object.internal_own_property_keys(agent, gc.reborrow())?;
                 for key in keys {
                     if let PropertyKey::Symbol(_) = key {
                         continue;
@@ -172,7 +204,7 @@ impl ObjectPropertiesIterator {
                 if self.visited_keys.contains(&r) {
                     continue;
                 }
-                let desc = object.internal_get_own_property(agent, r)?;
+                let desc = object.internal_get_own_property(agent, gc.reborrow(), r)?;
                 if let Some(desc) = desc {
                     self.visited_keys.push(r);
                     if desc.enumerable == Some(true) {
@@ -180,7 +212,7 @@ impl ObjectPropertiesIterator {
                     }
                 }
             }
-            let prototype = object.internal_get_prototype_of(agent)?;
+            let prototype = object.internal_get_prototype_of(agent, gc.reborrow())?;
             if let Some(prototype) = prototype {
                 self.object_was_visited = false;
                 self.object = prototype;
@@ -206,7 +238,11 @@ impl ArrayValuesIterator {
         }
     }
 
-    pub(super) fn next(&mut self, agent: &mut Agent) -> JsResult<Option<Value>> {
+    pub(super) fn next(
+        &mut self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+    ) -> JsResult<Option<Value>> {
         // b. Repeat,
         let array = self.array;
         // iv. Let indexNumber be 𝔽(index).
@@ -226,7 +262,7 @@ impl ArrayValuesIterator {
         }
         // 1. Let elementKey be ! ToString(indexNumber).
         // 2. Let elementValue be ? Get(array, elementKey).
-        let element_value = get(agent, self.array, index.into())?;
+        let element_value = get(agent, gc.reborrow(), self.array, index.into())?;
         // a. Let result be elementValue.
         // vii. Perform ? GeneratorYield(CreateIterResultObject(result, false)).
         Ok(Some(element_value))

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -317,7 +317,7 @@ impl Vm {
                         .vm_stack
                         // SAFETY: Pointer to self is never null.
                         .push(vm);
-                    heap_gc(agent, &mut root_realms);
+                    heap_gc(agent, gc.reborrow(), &mut root_realms);
                     let return_vm = agent.vm_stack.pop().unwrap();
                     assert_eq!(vm, return_vm, "VM Stack was misused");
                 }

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -49,6 +49,7 @@ use crate::{
             Reference, String, Value, BUILTIN_STRING_MEMORY,
         },
     },
+    engine::context::GcScope,
     heap::{CompactionLists, HeapMarkAndSweep, WellKnownSymbolIndexes, WorkQueues},
 };
 
@@ -147,16 +148,20 @@ impl SuspendedVm {
     pub(crate) fn resume(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         executable: Executable,
         value: Value,
     ) -> ExecutionResult {
         let vm = Vm::from_suspended(self);
-        vm.resume(agent, executable, value)
+        vm.resume(agent, gc, executable, value)
     }
 
     pub(crate) fn resume_throw(
         self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         executable: Executable,
         err: Value,
     ) -> ExecutionResult {
@@ -167,7 +172,7 @@ impl SuspendedVm {
             return ExecutionResult::Throw(err);
         }
         let vm = Vm::from_suspended(self);
-        vm.resume_throw(agent, executable, err)
+        vm.resume_throw(agent, gc, executable, err)
     }
 }
 
@@ -211,6 +216,8 @@ impl Vm {
     /// Executes an executable using the virtual machine.
     pub(crate) fn execute(
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         executable: Executable,
         arguments: Option<&[Value]>,
     ) -> ExecutionResult {
@@ -252,22 +259,26 @@ impl Vm {
             eprintln!();
         }
 
-        vm.inner_execute(agent, executable)
+        vm.inner_execute(agent, gc, executable)
     }
 
     pub fn resume(
         mut self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         executable: Executable,
         value: Value,
     ) -> ExecutionResult {
         self.result = Some(value);
-        self.inner_execute(agent, executable)
+        self.inner_execute(agent, gc, executable)
     }
 
     pub fn resume_throw(
         mut self,
         agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
         executable: Executable,
         err: Value,
     ) -> ExecutionResult {
@@ -275,10 +286,16 @@ impl Vm {
         if !self.handle_error(agent, err) {
             return ExecutionResult::Throw(err);
         }
-        self.inner_execute(agent, executable)
+        self.inner_execute(agent, gc, executable)
     }
 
-    fn inner_execute(mut self, agent: &mut Agent, executable: Executable) -> ExecutionResult {
+    fn inner_execute(
+        mut self,
+        agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
+        executable: Executable,
+    ) -> ExecutionResult {
         #[cfg(feature = "interleaved-gc")]
         let do_gc = !agent.options.disable_gc;
         #[cfg(feature = "interleaved-gc")]
@@ -305,7 +322,7 @@ impl Vm {
                     assert_eq!(vm, return_vm, "VM Stack was misused");
                 }
             }
-            match Self::execute_instruction(agent, &mut self, executable, &instr) {
+            match Self::execute_instruction(agent, gc.reborrow(), &mut self, executable, &instr) {
                 Ok(ContinuationKind::Normal) => {}
                 Ok(ContinuationKind::Return) => {
                     let result = self.result.unwrap_or(Value::Undefined);
@@ -355,6 +372,8 @@ impl Vm {
 
     fn execute_instruction(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         vm: &mut Vm,
         executable: Executable,
         instr: &Instr,
@@ -376,7 +395,7 @@ impl Vm {
                 };
                 let len = array.len(agent);
                 let key = PropertyKey::Integer(len.into());
-                create_data_property_or_throw(agent, array, key, value)?
+                create_data_property_or_throw(agent, gc.reborrow(), array, key, value)?
             }
             Instruction::ArrayElision => {
                 let array = *vm.stack.last().unwrap();
@@ -385,6 +404,7 @@ impl Vm {
                 };
                 set(
                     agent,
+                    gc,
                     array.into_object(),
                     BUILTIN_STRING_MEMORY.length.into(),
                     (array.len(agent) + 1).into(),
@@ -394,12 +414,12 @@ impl Vm {
             Instruction::Await => return Ok(ContinuationKind::Await),
             Instruction::BitwiseNot => {
                 // 2. Let oldValue be ? ToNumeric(? GetValue(expr)).
-                let old_value = to_numeric(agent, vm.result.take().unwrap())?;
+                let old_value = to_numeric(agent, gc.reborrow(), vm.result.take().unwrap())?;
 
                 // 3. If oldValue is a Number, then
                 if let Ok(old_value) = Number::try_from(old_value) {
                     // a. Return Number::bitwiseNOT(oldValue).
-                    vm.result = Some(Number::bitwise_not(agent, old_value)?.into_value());
+                    vm.result = Some(Number::bitwise_not(agent, old_value).into_value());
                 } else {
                     // 4. Else,
                     // a. Assert: oldValue is a BigInt.
@@ -420,7 +440,7 @@ impl Vm {
                 let identifier =
                     executable.fetch_identifier(agent, instr.args[0].unwrap() as usize);
 
-                let reference = resolve_binding(agent, identifier, None)?;
+                let reference = resolve_binding(agent, gc, identifier, None)?;
 
                 vm.reference = Some(reference);
             }
@@ -484,12 +504,14 @@ impl Vm {
                 }
             }
             Instruction::ToNumber => {
-                vm.result =
-                    to_number(agent, vm.result.unwrap()).map(|number| Some(number.into()))?;
+                vm.result = to_number(agent, gc.reborrow(), vm.result.unwrap())
+                    .map(|number| Some(number.into()))?;
             }
             Instruction::ToNumeric => {
-                vm.result =
-                    Some(to_numeric(agent, vm.result.unwrap()).map(|result| result.into_value())?);
+                vm.result = Some(
+                    to_numeric(agent, gc.reborrow(), vm.result.unwrap())
+                        .map(|result| result.into_value())?,
+                );
             }
             Instruction::ToObject => {
                 vm.result = Some(to_object(agent, vm.result.unwrap())?.into_value());
@@ -498,15 +520,15 @@ impl Vm {
                 let lval = vm.stack.pop().unwrap();
                 let rval = vm.result.take().unwrap();
                 vm.result = Some(apply_string_or_numeric_binary_operator(
-                    agent, lval, op_text, rval,
+                    agent, gc, lval, op_text, rval,
                 )?);
             }
             Instruction::ObjectDefineProperty => {
                 let value = vm.result.take().unwrap();
-                let key = to_property_key(agent, vm.stack.pop().unwrap())?;
+                let key = to_property_key(agent, gc.reborrow(), vm.stack.pop().unwrap())?;
                 let object = *vm.stack.last().unwrap();
                 let object = Object::try_from(object).unwrap();
-                create_data_property_or_throw(agent, object, key, value).unwrap()
+                create_data_property_or_throw(agent, gc.reborrow(), object, key, value).unwrap()
             }
             Instruction::ObjectDefineMethod => {
                 let FunctionExpression { expression, .. } =
@@ -514,7 +536,7 @@ impl Vm {
                 let function_expression = expression.get();
                 let enumerable = instr.args[1].unwrap() != 0;
                 // 1. Let propKey be ? Evaluation of ClassElementName.
-                let prop_key = to_property_key(agent, vm.stack.pop().unwrap())?;
+                let prop_key = to_property_key(agent, gc.reborrow(), vm.stack.pop().unwrap())?;
                 let object = Object::try_from(*vm.stack.last().unwrap()).unwrap();
 
                 // 2. Let env be the running execution context's LexicalEnvironment.
@@ -591,7 +613,7 @@ impl Vm {
                 // b. Perform ? DefinePropertyOrThrow(homeObject, key, desc).
                 // c. NOTE: DefinePropertyOrThrow only returns an abrupt
                 // completion when attempting to define a class static method whose key is "prototype".
-                define_property_or_throw(agent, object, prop_key, desc)?;
+                define_property_or_throw(agent, gc.reborrow(), object, prop_key, desc)?;
                 // c. Return unused.
             }
             Instruction::ObjectDefineGetter => {
@@ -600,7 +622,7 @@ impl Vm {
                 let function_expression = expression.get();
                 let enumerable = instr.args[1].unwrap() != 0;
                 // 1. Let propKey be ? Evaluation of ClassElementName.
-                let prop_key = to_property_key(agent, vm.stack.pop().unwrap())?;
+                let prop_key = to_property_key(agent, gc.reborrow(), vm.stack.pop().unwrap())?;
                 // 2. Let env be the running execution context's LexicalEnvironment.
                 // 3. Let privateEnv be the running execution context's PrivateEnvironment.
                 let ECMAScriptCodeEvaluationState {
@@ -669,7 +691,7 @@ impl Vm {
                     configurable: Some(true),
                 };
                 // b. Perform ? DefinePropertyOrThrow(object, propKey, desc).
-                define_property_or_throw(agent, object, prop_key, desc)?;
+                define_property_or_throw(agent, gc.reborrow(), object, prop_key, desc)?;
                 // c. Return unused.
             }
             Instruction::ObjectDefineSetter => {
@@ -678,7 +700,7 @@ impl Vm {
                 let function_expression = expression.get();
                 let enumerable = instr.args[1].unwrap() != 0;
                 // 1. Let propKey be ? Evaluation of ClassElementName.
-                let prop_key = to_property_key(agent, vm.stack.pop().unwrap())?;
+                let prop_key = to_property_key(agent, gc.reborrow(), vm.stack.pop().unwrap())?;
                 // 2. Let env be the running execution context's LexicalEnvironment.
                 // 3. Let privateEnv be the running execution context's PrivateEnvironment.
                 let ECMAScriptCodeEvaluationState {
@@ -732,7 +754,7 @@ impl Vm {
                     configurable: Some(true),
                 };
                 // b. Perform ? DefinePropertyOrThrow(object, propKey, desc).
-                define_property_or_throw(agent, object, prop_key, desc)?;
+                define_property_or_throw(agent, gc.reborrow(), object, prop_key, desc)?;
                 // c. Return unused.
             }
             Instruction::ObjectSetPrototype => {
@@ -749,7 +771,7 @@ impl Vm {
                 };
                 // i. Perform ! object.[[SetPrototypeOf]](propValue).
                 let object = Object::try_from(*vm.stack.last().unwrap()).unwrap();
-                object.internal_set_prototype_of(agent, prop_value)?;
+                object.internal_set_prototype_of(agent, gc.reborrow(), prop_value)?;
                 // b. Return unused.
             }
             Instruction::PushReference => {
@@ -761,19 +783,19 @@ impl Vm {
             Instruction::PutValue => {
                 let value = vm.result.take().unwrap();
                 let reference = vm.reference.take().unwrap();
-                put_value(agent, &reference, value)?;
+                put_value(agent, gc.reborrow(), &reference, value)?;
             }
             Instruction::GetValue => {
                 // 1. If V is not a Reference Record, return V.
                 let reference = vm.reference.take().unwrap();
 
-                vm.result = Some(get_value(agent, &reference)?);
+                vm.result = Some(get_value(agent, gc.reborrow(), &reference)?);
             }
             Instruction::GetValueKeepReference => {
                 // 1. If V is not a Reference Record, return V.
                 let reference = vm.reference.as_ref().unwrap();
 
-                vm.result = Some(get_value(agent, reference)?);
+                vm.result = Some(get_value(agent, gc.reborrow(), reference)?);
             }
             Instruction::Typeof => {
                 // 2. If val is a Reference Record, then
@@ -783,7 +805,7 @@ impl Vm {
                         Value::Undefined
                     } else {
                         // 3. Set val to ? GetValue(val).
-                        get_value(agent, &reference)?
+                        get_value(agent, gc.reborrow(), &reference)?
                     }
                 } else {
                     vm.result.unwrap()
@@ -803,7 +825,7 @@ impl Vm {
                 let Value::Object(target) = *vm.stack.last().unwrap() else {
                     unreachable!()
                 };
-                copy_data_properties(agent, target, source)?;
+                copy_data_properties(agent, gc.reborrow(), target, source)?;
             }
             Instruction::CopyDataPropertiesIntoObject => {
                 let from = Object::try_from(vm.result.unwrap()).unwrap();
@@ -819,7 +841,8 @@ impl Vm {
                 }
 
                 vm.result = Some(
-                    copy_data_properties_into_object(agent, from, &excluded_items)?.into_value(),
+                    copy_data_properties_into_object(agent, gc.reborrow(), from, &excluded_items)?
+                        .into_value(),
                 );
             }
             Instruction::InstantiateArrowFunctionExpression => {
@@ -864,10 +887,10 @@ impl Vm {
                 let name = if let Some(parameter) = &identifier {
                     match parameter {
                         NamedEvaluationParameter::Result => {
-                            to_property_key(agent, vm.result.unwrap())?
+                            to_property_key(agent, gc.reborrow(), vm.result.unwrap())?
                         }
                         NamedEvaluationParameter::Stack => {
-                            to_property_key(agent, *vm.stack.last().unwrap())?
+                            to_property_key(agent, gc.reborrow(), *vm.stack.last().unwrap())?
                         }
                         NamedEvaluationParameter::Reference => {
                             vm.reference.as_ref().unwrap().referenced_name
@@ -905,10 +928,10 @@ impl Vm {
                     debug_assert!(function_expression.id.is_none());
                     let name = match parameter {
                         NamedEvaluationParameter::Result => {
-                            to_property_key(agent, vm.result.unwrap())?
+                            to_property_key(agent, gc.reborrow(), vm.result.unwrap())?
                         }
                         NamedEvaluationParameter::Stack => {
-                            to_property_key(agent, *vm.stack.last().unwrap())?
+                            to_property_key(agent, gc.reborrow(), *vm.stack.last().unwrap())?
                         }
                         NamedEvaluationParameter::Reference => {
                             vm.reference.as_ref().unwrap().referenced_name
@@ -967,6 +990,7 @@ impl Vm {
                     // 8. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
                     define_property_or_throw(
                         agent,
+                        gc.reborrow(),
                         function,
                         BUILTIN_STRING_MEMORY.prototype.to_property_key(),
                         PropertyDescriptor {
@@ -987,7 +1011,7 @@ impl Vm {
                         PropertyKey::String(data) => data.into(),
                         _ => unreachable!("maybe?"),
                     };
-                    env.initialize_binding(agent, name, function.into_value())
+                    env.initialize_binding(agent, gc.reborrow(), name, function.into_value())
                         .unwrap();
                 }
                 vm.result = Some(function.into_value());
@@ -1013,7 +1037,10 @@ impl Vm {
                 let proto = Object::try_from(*vm.stack.last().unwrap()).unwrap();
 
                 let is_null_derived_class = !has_constructor_parent
-                    && proto.internal_get_prototype_of(agent).unwrap().is_none();
+                    && proto
+                        .internal_get_prototype_of(agent, gc.reborrow())
+                        .unwrap()
+                        .is_none();
 
                 let ECMAScriptCodeEvaluationState {
                     lexical_environment,
@@ -1055,6 +1082,7 @@ impl Vm {
                 proto
                     .internal_define_own_property(
                         agent,
+                        gc.reborrow(),
                         BUILTIN_STRING_MEMORY.constructor.into(),
                         PropertyDescriptor {
                             value: Some(function.into_value()),
@@ -1119,6 +1147,7 @@ impl Vm {
                 proto
                     .internal_define_own_property(
                         agent,
+                        gc.reborrow(),
                         BUILTIN_STRING_MEMORY.constructor.into(),
                         PropertyDescriptor {
                             value: Some(function.into_value()),
@@ -1141,8 +1170,9 @@ impl Vm {
             Instruction::DirectEvalCall => {
                 let args = vm.get_call_args(instr);
 
-                let func_reference = resolve_binding(agent, BUILTIN_STRING_MEMORY.eval, None)?;
-                let func = get_value(agent, &func_reference)?;
+                let func_reference =
+                    resolve_binding(agent, gc.reborrow(), BUILTIN_STRING_MEMORY.eval, None)?;
+                let func = get_value(agent, gc.reborrow(), &func_reference)?;
 
                 // a. If SameValue(func, %eval%) is true, then
                 if func == agent.current_realm().intrinsics().eval().into_value() {
@@ -1162,12 +1192,24 @@ impl Vm {
                             .unwrap()
                             .is_strict_mode;
                         // v. Return ? PerformEval(evalArg, strictCaller, true).
-                        vm.result = Some(perform_eval(agent, eval_arg, true, strict_caller)?);
+                        vm.result = Some(perform_eval(
+                            agent,
+                            gc.reborrow(),
+                            eval_arg,
+                            true,
+                            strict_caller,
+                        )?);
                     }
                 } else if cfg!(feature = "interleaved-gc") {
                     let mut vm = NonNull::from(vm);
                     agent.vm_stack.push(vm);
-                    let result = call(agent, func, Value::Undefined, Some(ArgumentsList(&args)));
+                    let result = call(
+                        agent,
+                        gc,
+                        func,
+                        Value::Undefined,
+                        Some(ArgumentsList(&args)),
+                    );
                     let return_vm = agent.vm_stack.pop().unwrap();
                     assert_eq!(vm, return_vm, "VM Stack was misused");
                     // SAFETY: This is fairly bonkers-unsafe. We have an
@@ -1184,6 +1226,7 @@ impl Vm {
                 } else {
                     vm.result = Some(call(
                         agent,
+                        gc,
                         func,
                         Value::Undefined,
                         Some(ArgumentsList(&args)),
@@ -1219,13 +1262,19 @@ impl Vm {
                 if cfg!(feature = "interleaved-gc") {
                     let mut vm = NonNull::from(vm);
                     agent.vm_stack.push(vm);
-                    let result = call(agent, func, this_value, Some(ArgumentsList(&args)));
+                    let result = call(agent, gc, func, this_value, Some(ArgumentsList(&args)));
                     let return_vm = agent.vm_stack.pop().unwrap();
                     assert_eq!(vm, return_vm, "VM Stack was misused");
                     // SAFETY: This is fairly bonkers-unsafe. I'm sorry.
                     unsafe { vm.as_mut() }.result = Some(result?);
                 } else {
-                    vm.result = Some(call(agent, func, this_value, Some(ArgumentsList(&args)))?);
+                    vm.result = Some(call(
+                        agent,
+                        gc,
+                        func,
+                        this_value,
+                        Some(ArgumentsList(&args)),
+                    )?);
                 }
             }
             Instruction::EvaluateNew => {
@@ -1234,7 +1283,7 @@ impl Vm {
                 let Some(constructor) = is_constructor(agent, constructor) else {
                     let error_message = format!(
                         "'{}' is not a constructor.",
-                        constructor.string_repr(agent).as_str(agent)
+                        constructor.string_repr(agent, gc.reborrow(),).as_str(agent)
                     );
                     return Err(agent.throw_exception(ExceptionType::TypeError, error_message));
                 };
@@ -1242,16 +1291,28 @@ impl Vm {
                 if cfg!(feature = "interleaved-gc") {
                     let mut vm = NonNull::from(vm);
                     agent.vm_stack.push(vm);
-                    let result = construct(agent, constructor, Some(ArgumentsList(&args)), None)
-                        .map(|result| result.into_value());
+                    let result = construct(
+                        agent,
+                        gc.reborrow(),
+                        constructor,
+                        Some(ArgumentsList(&args)),
+                        None,
+                    )
+                    .map(|result| result.into_value());
                     let return_vm = agent.vm_stack.pop().unwrap();
                     assert_eq!(vm, return_vm, "VM Stack was misused");
                     // SAFETY: This is fairly bonkers-unsafe. I'm sorry.
                     unsafe { vm.as_mut() }.result = Some(result?);
                 } else {
                     vm.result = Some(
-                        construct(agent, constructor, Some(ArgumentsList(&args)), None)?
-                            .into_value(),
+                        construct(
+                            agent,
+                            gc.reborrow(),
+                            constructor,
+                            Some(ArgumentsList(&args)),
+                            None,
+                        )?
+                        .into_value(),
                     );
                 }
             }
@@ -1267,7 +1328,7 @@ impl Vm {
                     (
                         Function::try_from(data.new_target.unwrap()).unwrap(),
                         data.function_object
-                            .internal_get_prototype_of(agent)
+                            .internal_get_prototype_of(agent, gc.reborrow())
                             .unwrap(),
                     )
                 };
@@ -1278,7 +1339,7 @@ impl Vm {
                     let error_message = format!(
                         "'{}' is not a constructor.",
                         func.map_or(Value::Null, |func| func.into_value())
-                            .string_repr(agent)
+                            .string_repr(agent, gc.reborrow(),)
                             .as_str(agent)
                     );
                     return Err(agent.throw_exception(ExceptionType::TypeError, error_message));
@@ -1286,6 +1347,7 @@ impl Vm {
                 // 6. Let result be ? Construct(func, argList, newTarget).
                 let result = construct(
                     agent,
+                    gc.reborrow(),
                     func,
                     Some(ArgumentsList(&arg_list)),
                     Some(new_target),
@@ -1315,7 +1377,7 @@ impl Vm {
                     .unwrap()
                     .is_strict_mode;
 
-                let property_key = to_property_key(agent, property_name_value)?;
+                let property_key = to_property_key(agent, gc.reborrow(), property_name_value)?;
 
                 vm.reference = Some(Reference {
                     base: Base::Value(base_value),
@@ -1364,7 +1426,7 @@ impl Vm {
             }
             Instruction::Increment => {
                 let lhs = vm.result.take().unwrap();
-                let old_value = to_numeric(agent, lhs)?;
+                let old_value = to_numeric(agent, gc.reborrow(), lhs)?;
                 let new_value = if let Ok(old_value) = Number::try_from(old_value) {
                     Number::add(agent, old_value, 1.into())
                 } else {
@@ -1376,7 +1438,7 @@ impl Vm {
             }
             Instruction::Decrement => {
                 let lhs = vm.result.take().unwrap();
-                let old_value = to_numeric(agent, lhs)?;
+                let old_value = to_numeric(agent, gc.reborrow(), lhs)?;
                 let new_value = if let Ok(old_value) = Number::try_from(old_value) {
                     Number::subtract(agent, old_value, 1.into())
                 } else {
@@ -1389,25 +1451,25 @@ impl Vm {
             Instruction::LessThan => {
                 let lval = vm.stack.pop().unwrap();
                 let rval = vm.result.take().unwrap();
-                let result = is_less_than::<true>(agent, lval, rval)? == Some(true);
+                let result = is_less_than::<true>(agent, gc, lval, rval)? == Some(true);
                 vm.result = Some(result.into());
             }
             Instruction::LessThanEquals => {
                 let lval = vm.stack.pop().unwrap();
                 let rval = vm.result.take().unwrap();
-                let result = is_less_than::<false>(agent, rval, lval)? == Some(false);
+                let result = is_less_than::<false>(agent, gc, rval, lval)? == Some(false);
                 vm.result = Some(result.into());
             }
             Instruction::GreaterThan => {
                 let lval = vm.stack.pop().unwrap();
                 let rval = vm.result.take().unwrap();
-                let result = is_less_than::<false>(agent, rval, lval)? == Some(true);
+                let result = is_less_than::<false>(agent, gc, rval, lval)? == Some(true);
                 vm.result = Some(result.into());
             }
             Instruction::GreaterThanEquals => {
                 let lval = vm.stack.pop().unwrap();
                 let rval = vm.result.take().unwrap();
-                let result = is_less_than::<true>(agent, lval, rval)? == Some(false);
+                let result = is_less_than::<true>(agent, gc, lval, rval)? == Some(false);
                 vm.result = Some(result.into());
             }
             Instruction::HasProperty => {
@@ -1418,13 +1480,18 @@ impl Vm {
                 let Ok(rval) = Object::try_from(rval) else {
                     let error_message = format!(
                         "The right-hand side of an `in` expression must be an object, got '{}'.",
-                        rval.string_repr(agent).as_str(agent)
+                        rval.string_repr(agent, gc.reborrow(),).as_str(agent)
                     );
                     return Err(agent.throw_exception(ExceptionType::TypeError, error_message));
                 };
                 // 6. Return ? HasProperty(rval, ? ToPropertyKey(lval)).
-                let property_key = to_property_key(agent, lval)?;
-                vm.result = Some(Value::Boolean(has_property(agent, rval, property_key)?));
+                let property_key = to_property_key(agent, gc.reborrow(), lval)?;
+                vm.result = Some(Value::Boolean(has_property(
+                    agent,
+                    gc.reborrow(),
+                    rval,
+                    property_key,
+                )?));
             }
             Instruction::IsStrictlyEqual => {
                 let lval = vm.stack.pop().unwrap();
@@ -1435,7 +1502,7 @@ impl Vm {
             Instruction::IsLooselyEqual => {
                 let lval = vm.stack.pop().unwrap();
                 let rval = vm.result.take().unwrap();
-                let result = is_loosely_equal(agent, lval, rval)?;
+                let result = is_loosely_equal(agent, gc.reborrow(), lval, rval)?;
                 vm.result = Some(result.into());
             }
             Instruction::IsNullOrUndefined => {
@@ -1478,7 +1545,7 @@ impl Vm {
             Instruction::InitializeReferencedBinding => {
                 let v = vm.reference.take().unwrap();
                 let w = vm.result.take().unwrap();
-                initialize_referenced_binding(agent, v, w)?;
+                initialize_referenced_binding(agent, gc.reborrow(), v, w)?;
             }
             Instruction::InitializeVariableEnvironment => {
                 let num_variables = instr.args[0].unwrap();
@@ -1598,7 +1665,9 @@ impl Vm {
                     .unwrap()
                     .lexical_environment;
                 let name = executable.fetch_identifier(agent, instr.args[0].unwrap() as usize);
-                lex_env.create_mutable_binding(agent, name, false).unwrap();
+                lex_env
+                    .create_mutable_binding(agent, gc.reborrow(), name, false)
+                    .unwrap();
             }
             Instruction::CreateImmutableBinding => {
                 let lex_env = agent
@@ -1618,9 +1687,11 @@ impl Vm {
                     .unwrap()
                     .lexical_environment;
                 let name = executable.fetch_identifier(agent, instr.args[0].unwrap() as usize);
-                lex_env.create_mutable_binding(agent, name, false).unwrap();
                 lex_env
-                    .initialize_binding(agent, name, vm.exception.unwrap())
+                    .create_mutable_binding(agent, gc.reborrow(), name, false)
+                    .unwrap();
+                lex_env
+                    .initialize_binding(agent, gc.reborrow(), name, vm.exception.unwrap())
                     .unwrap();
                 vm.exception = None;
             }
@@ -1656,13 +1727,13 @@ impl Vm {
                 if cfg!(feature = "interleaved-gc") {
                     let mut vm = NonNull::from(vm);
                     agent.vm_stack.push(vm);
-                    let result = instanceof_operator(agent, lval, rval);
+                    let result = instanceof_operator(agent, gc, lval, rval);
                     let return_vm = agent.vm_stack.pop().unwrap();
                     assert_eq!(vm, return_vm, "VM Stack was misused");
                     // SAFETY: This is fairly bonkers-unsafe. I'm sorry.
                     unsafe { vm.as_mut() }.result = Some(result?.into());
                 } else {
-                    vm.result = Some(instanceof_operator(agent, lval, rval)?.into());
+                    vm.result = Some(instanceof_operator(agent, gc, lval, rval)?.into());
                 }
             }
             Instruction::BeginSimpleArrayBindingPattern => {
@@ -1682,7 +1753,7 @@ impl Vm {
                     None
                 };
                 let iterator = vm.iterator_stack.pop().unwrap();
-                Self::execute_simple_array_binding(agent, vm, executable, iterator, env)?
+                Self::execute_simple_array_binding(agent, gc, vm, executable, iterator, env)?
             }
             Instruction::BeginSimpleObjectBindingPattern => {
                 let lexical = instr.args[0].unwrap() == 1;
@@ -1701,7 +1772,7 @@ impl Vm {
                     None
                 };
                 let object = to_object(agent, vm.stack.pop().unwrap())?;
-                Self::execute_simple_object_binding(agent, vm, executable, object, env)?
+                Self::execute_simple_object_binding(agent, gc, vm, executable, object, env)?
             }
             Instruction::BindingPatternBind
             | Instruction::BindingPatternBindNamed
@@ -1719,7 +1790,7 @@ impl Vm {
                 let mut length = 0;
                 for ele in vm.stack[last_item..].iter_mut() {
                     if !ele.is_string() {
-                        *ele = to_string(agent, *ele)?.into_value();
+                        *ele = to_string(agent, gc.reborrow(), *ele)?.into_value();
                     }
                     let string = String::try_from(*ele).unwrap();
                     length += string.len(agent);
@@ -1759,8 +1830,11 @@ impl Vm {
                         // TODO: Is this relevant?
                         // i. Set ref.[[ReferencedName]] to ? ToPropertyKey(ref.[[ReferencedName]]).
                         // e. Let deleteStatus be ? baseObj.[[Delete]](ref.[[ReferencedName]]).
-                        let delete_status =
-                            base_obj.internal_delete(agent, refer.referenced_name)?;
+                        let delete_status = base_obj.internal_delete(
+                            agent,
+                            gc.reborrow(),
+                            refer.referenced_name,
+                        )?;
                         // f. If deleteStatus is false and ref.[[Strict]] is true, throw a TypeError exception.
                         if !delete_status && refer.strict {
                             return Err(agent.throw_exception_with_static_message(
@@ -1781,7 +1855,7 @@ impl Vm {
                             _ => unreachable!(),
                         };
                         // c. Return ? base.DeleteBinding(ref.[[ReferencedName]]).
-                        vm.result = Some(base.delete_binding(agent, referenced_name)?.into());
+                        vm.result = Some(base.delete_binding(agent, gc, referenced_name)?.into());
                     }
                 }
 
@@ -1812,13 +1886,13 @@ impl Vm {
             Instruction::GetIteratorSync => {
                 let expr_value = vm.result.take().unwrap();
                 vm.iterator_stack
-                    .push(VmIterator::from_value(agent, expr_value)?);
+                    .push(VmIterator::from_value(agent, gc, expr_value)?);
             }
             Instruction::GetIteratorAsync => {
                 todo!();
             }
             Instruction::IteratorStepValue => {
-                let result = vm.iterator_stack.last_mut().unwrap().step_value(agent);
+                let result = vm.iterator_stack.last_mut().unwrap().step_value(agent, gc);
                 if let Ok(result) = result {
                     vm.result = result;
                     if result.is_none() {
@@ -1833,7 +1907,7 @@ impl Vm {
             }
             Instruction::IteratorStepValueOrUndefined => {
                 let iterator = vm.iterator_stack.last_mut().unwrap();
-                let result = iterator.step_value(agent);
+                let result = iterator.step_value(agent, gc);
                 if let Ok(result) = result {
                     vm.result = Some(result.unwrap_or(Value::Undefined));
                     if result.is_none() {
@@ -1852,9 +1926,9 @@ impl Vm {
                 let array = array_create(agent, 0, capacity, None)?;
 
                 let mut idx: u32 = 0;
-                while let Some(value) = iterator.step_value(agent)? {
+                while let Some(value) = iterator.step_value(agent, gc.reborrow())? {
                     let key = PropertyKey::Integer(idx.into());
-                    create_data_property(agent, array, key, value).unwrap();
+                    create_data_property(agent, gc.reborrow(), array, key, value).unwrap();
                     idx += 1;
                 }
                 vm.result = Some(array.into_value());
@@ -1864,6 +1938,7 @@ impl Vm {
                 if let VmIterator::GenericIterator(iterator_record) = iterator {
                     iterator_close(
                         agent,
+                        gc,
                         &iterator_record,
                         Ok(vm.result.take().unwrap_or(Value::Undefined)),
                     )?;
@@ -1874,7 +1949,8 @@ impl Vm {
                 let Some(VmIterator::SliceIterator(slice)) = vm.iterator_stack.last() else {
                     unreachable!()
                 };
-                vm.result = Some(create_unmapped_arguments_object(agent, slice.get()).into_value());
+                vm.result =
+                    Some(create_unmapped_arguments_object(agent, gc, slice.get()).into_value());
             }
             other => todo!("{other:?}"),
         }
@@ -1900,6 +1976,8 @@ impl Vm {
 
     fn execute_simple_array_binding(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         vm: &mut Vm,
         executable: Executable,
         mut iterator: VmIterator,
@@ -1915,7 +1993,7 @@ impl Vm {
                 Instruction::BindingPatternBind
                 | Instruction::BindingPatternGetValue
                 | Instruction::BindingPatternSkip => {
-                    let result = iterator.step_value(agent)?;
+                    let result = iterator.step_value(agent, gc.reborrow())?;
                     iterator_is_done = result.is_none();
 
                     if instr.kind == Instruction::BindingPatternSkip {
@@ -1931,9 +2009,10 @@ impl Vm {
                         let capacity = iterator.remaining_length_estimate(agent).unwrap_or(0);
                         let rest = array_create(agent, 0, capacity, None).unwrap();
                         let mut idx = 0u32;
-                        while let Some(result) = iterator.step_value(agent)? {
+                        while let Some(result) = iterator.step_value(agent, gc.reborrow())? {
                             create_data_property_or_throw(
                                 agent,
+                                gc.reborrow(),
                                 rest,
                                 PropertyKey::from(idx),
                                 result,
@@ -1954,15 +2033,22 @@ impl Vm {
                 Instruction::BindingPatternBind | Instruction::BindingPatternBindRest => {
                     let binding_id =
                         executable.fetch_identifier(agent, instr.args[0].unwrap() as usize);
-                    let lhs = resolve_binding(agent, binding_id, environment)?;
+                    let lhs = resolve_binding(agent, gc.reborrow(), binding_id, environment)?;
                     if environment.is_none() {
-                        put_value(agent, &lhs, value)?;
+                        put_value(agent, gc.reborrow(), &lhs, value)?;
                     } else {
-                        initialize_referenced_binding(agent, lhs, value)?;
+                        initialize_referenced_binding(agent, gc.reborrow(), lhs, value)?;
                     }
                 }
                 Instruction::BindingPatternGetValue | Instruction::BindingPatternGetRestValue => {
-                    Self::execute_nested_simple_binding(agent, vm, executable, value, environment)?;
+                    Self::execute_nested_simple_binding(
+                        agent,
+                        gc.reborrow(),
+                        vm,
+                        executable,
+                        value,
+                        environment,
+                    )?;
                 }
                 _ => unreachable!(),
             }
@@ -1978,7 +2064,7 @@ impl Vm {
         // NOTE: `result` here seems to be UNUSED, which isn't a Value. This seems to be a spec bug.
         if !iterator_is_done {
             if let VmIterator::GenericIterator(iterator_record) = iterator {
-                iterator_close(agent, &iterator_record, Ok(Value::Undefined))?;
+                iterator_close(agent, gc.reborrow(), &iterator_record, Ok(Value::Undefined))?;
             }
         }
 
@@ -1987,6 +2073,8 @@ impl Vm {
 
     fn execute_simple_object_binding(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         vm: &mut Vm,
         executable: Executable,
         object: Object,
@@ -2009,12 +2097,12 @@ impl Vm {
                     };
                     excluded_names.insert(property_key);
 
-                    let lhs = resolve_binding(agent, binding_id, environment)?;
-                    let v = get(agent, object, property_key)?;
+                    let lhs = resolve_binding(agent, gc.reborrow(), binding_id, environment)?;
+                    let v = get(agent, gc.reborrow(), object, property_key)?;
                     if environment.is_none() {
-                        put_value(agent, &lhs, v)?;
+                        put_value(agent, gc.reborrow(), &lhs, v)?;
                     } else {
-                        initialize_referenced_binding(agent, lhs, v)?;
+                        initialize_referenced_binding(agent, gc.reborrow(), lhs, v)?;
                     }
                 }
                 Instruction::BindingPatternGetValueNamed => {
@@ -2024,25 +2112,36 @@ impl Vm {
                     )
                     .unwrap();
                     excluded_names.insert(property_key);
-                    let v = get(agent, object, property_key)?;
-                    Self::execute_nested_simple_binding(agent, vm, executable, v, environment)?;
+                    let v = get(agent, gc.reborrow(), object, property_key)?;
+                    Self::execute_nested_simple_binding(
+                        agent,
+                        gc.reborrow(),
+                        vm,
+                        executable,
+                        v,
+                        environment,
+                    )?;
                 }
                 Instruction::BindingPatternBindRest => {
                     // 1. Let lhs be ? ResolveBinding(StringValue of BindingIdentifier, environment).
                     let binding_id =
                         executable.fetch_identifier(agent, instr.args[0].unwrap() as usize);
-                    let lhs = resolve_binding(agent, binding_id, environment)?;
+                    let lhs = resolve_binding(agent, gc.reborrow(), binding_id, environment)?;
                     // 2. Let restObj be OrdinaryObjectCreate(%Object.prototype%).
                     // 3. Perform ? CopyDataProperties(restObj, value, excludedNames).
-                    let rest_obj =
-                        copy_data_properties_into_object(agent, object, &excluded_names)?
-                            .into_value();
+                    let rest_obj = copy_data_properties_into_object(
+                        agent,
+                        gc.reborrow(),
+                        object,
+                        &excluded_names,
+                    )?
+                    .into_value();
                     // 4. If environment is undefined, return ? PutValue(lhs, restObj).
                     // 5. Return ? InitializeReferencedBinding(lhs, restObj).
                     if environment.is_none() {
-                        put_value(agent, &lhs, rest_obj)?;
+                        put_value(agent, gc.reborrow(), &lhs, rest_obj)?;
                     } else {
-                        initialize_referenced_binding(agent, lhs, rest_obj)?;
+                        initialize_referenced_binding(agent, gc.reborrow(), lhs, rest_obj)?;
                     }
                     break;
                 }
@@ -2055,6 +2154,8 @@ impl Vm {
 
     fn execute_nested_simple_binding(
         agent: &mut Agent,
+        mut gc: GcScope<'_, '_>,
+
         vm: &mut Vm,
         executable: Executable,
         value: Value,
@@ -2063,12 +2164,26 @@ impl Vm {
         let instr = executable.get_instruction(agent, &mut vm.ip).unwrap();
         match instr.kind {
             Instruction::BeginSimpleArrayBindingPattern => {
-                let new_iterator = VmIterator::from_value(agent, value)?;
-                Vm::execute_simple_array_binding(agent, vm, executable, new_iterator, environment)
+                let new_iterator = VmIterator::from_value(agent, gc.reborrow(), value)?;
+                Vm::execute_simple_array_binding(
+                    agent,
+                    gc.reborrow(),
+                    vm,
+                    executable,
+                    new_iterator,
+                    environment,
+                )
             }
             Instruction::BeginSimpleObjectBindingPattern => {
                 let object = to_object(agent, value)?;
-                Vm::execute_simple_object_binding(agent, vm, executable, object, environment)
+                Vm::execute_simple_object_binding(
+                    agent,
+                    gc.reborrow(),
+                    vm,
+                    executable,
+                    object,
+                    environment,
+                )
             }
             _ => unreachable!(),
         }
@@ -2085,6 +2200,8 @@ impl Vm {
 #[inline]
 fn apply_string_or_numeric_binary_operator(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     lval: Value,
     op_text: BinaryOperator,
     rval: Value,
@@ -2094,18 +2211,18 @@ fn apply_string_or_numeric_binary_operator(
     // 1. If opText is +, then
     if op_text == BinaryOperator::Addition {
         // a. Let lprim be ? ToPrimitive(lval).
-        let lprim = to_primitive(agent, lval, None)?;
+        let lprim = to_primitive(agent, gc.reborrow(), lval, None)?;
 
         // b. Let rprim be ? ToPrimitive(rval).
-        let rprim = to_primitive(agent, rval, None)?;
+        let rprim = to_primitive(agent, gc.reborrow(), rval, None)?;
 
         // c. If lprim is a String or rprim is a String, then
         if lprim.is_string() || rprim.is_string() {
             // i. Let lstr be ? ToString(lprim).
-            let lstr = to_string(agent, lprim)?;
+            let lstr = to_string(agent, gc.reborrow(), lprim)?;
 
             // ii. Let rstr be ? ToString(rprim).
-            let rstr = to_string(agent, rprim)?;
+            let rstr = to_string(agent, gc.reborrow(), rprim)?;
 
             // iii. Return the string-concatenation of lstr and rstr.
             return Ok(String::concat(agent, [lstr, rstr]).into_value());
@@ -2115,14 +2232,14 @@ fn apply_string_or_numeric_binary_operator(
         // e. Set rval to rprim.
         // 2. NOTE: At this point, it must be a numeric operation.
         // 3. Let lnum be ? ToNumeric(lval).
-        lnum = to_numeric(agent, lprim)?;
+        lnum = to_numeric(agent, gc.reborrow(), lprim)?;
         // 4. Let rnum be ? ToNumeric(rval).
-        rnum = to_numeric(agent, rprim)?;
+        rnum = to_numeric(agent, gc.reborrow(), rprim)?;
     } else {
         // 3. Let lnum be ? ToNumeric(lval).
-        lnum = to_numeric(agent, lval)?;
+        lnum = to_numeric(agent, gc.reborrow(), lval)?;
         // 4. Let rnum be ? ToNumeric(rval).
-        rnum = to_numeric(agent, rval)?;
+        rnum = to_numeric(agent, gc.reborrow(), rval)?;
     }
 
     // 6. If lnum is a BigInt, then
@@ -2190,11 +2307,11 @@ fn apply_string_or_numeric_binary_operator(
                 Number::unsigned_right_shift(agent, lnum, rnum).into_value()
             }
             // |	Number	Number::bitwiseOR
-            BinaryOperator::BitwiseOR => Number::bitwise_or(agent, lnum, rnum)?.into(),
+            BinaryOperator::BitwiseOR => Number::bitwise_or(agent, lnum, rnum).into(),
             // ^	Number	Number::bitwiseXOR
-            BinaryOperator::BitwiseXOR => Number::bitwise_xor(agent, lnum, rnum)?.into(),
+            BinaryOperator::BitwiseXOR => Number::bitwise_xor(agent, lnum, rnum).into(),
             // &	Number	Number::bitwiseAND
-            BinaryOperator::BitwiseAnd => Number::bitwise_and(agent, lnum, rnum)?.into(),
+            BinaryOperator::BitwiseAnd => Number::bitwise_and(agent, lnum, rnum).into(),
             _ => unreachable!(),
         })
     } else {
@@ -2302,6 +2419,8 @@ fn typeof_operator(_: &mut Agent, val: Value) -> String {
 /// > the default instanceof semantics.
 pub(crate) fn instanceof_operator(
     agent: &mut Agent,
+    mut gc: GcScope<'_, '_>,
+
     value: impl IntoValue,
     target: impl IntoValue,
 ) -> JsResult<bool> {
@@ -2309,13 +2428,17 @@ pub(crate) fn instanceof_operator(
     let Ok(target) = Object::try_from(target.into_value()) else {
         let error_message = format!(
             "Invalid instanceof target {}.",
-            target.into_value().string_repr(agent).as_str(agent)
+            target
+                .into_value()
+                .string_repr(agent, gc.reborrow(),)
+                .as_str(agent)
         );
         return Err(agent.throw_exception(ExceptionType::TypeError, error_message));
     };
     // 2. Let instOfHandler be ? GetMethod(target, @@hasInstance).
     let inst_of_handler = get_method(
         agent,
+        gc.reborrow(),
         target.into_value(),
         WellKnownSymbolIndexes::HasInstance.into(),
     )?;
@@ -2324,6 +2447,7 @@ pub(crate) fn instanceof_operator(
         // a. Return ToBoolean(? Call(instOfHandler, target, « V »)).
         let result = call_function(
             agent,
+            gc.reborrow(),
             inst_of_handler,
             target.into_value(),
             Some(ArgumentsList(&[value.into_value()])),
@@ -2334,12 +2458,15 @@ pub(crate) fn instanceof_operator(
         let Some(target) = is_callable(target) else {
             let error_message = format!(
                 "Invalid instanceof target {} is not a function.",
-                target.into_value().string_repr(agent).as_str(agent)
+                target
+                    .into_value()
+                    .string_repr(agent, gc.reborrow(),)
+                    .as_str(agent)
             );
             return Err(agent.throw_exception(ExceptionType::TypeError, error_message));
         };
         // 5. Return ? OrdinaryHasInstance(target, V).
-        Ok(ordinary_has_instance(agent, target, value)?)
+        Ok(ordinary_has_instance(agent, gc, target, value)?)
     }
 }
 

--- a/nova_vm/src/engine/context.rs
+++ b/nova_vm/src/engine/context.rs
@@ -1,0 +1,114 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::marker::PhantomData;
+
+/// # ZST type representing access to the garbage collector.
+///
+/// Access to a garbage collected type's heap data should mainly require
+/// holding a `ContextRef<'gc, GcToken>`. Borrowing the heap data should bind
+/// to the `'gc` lifetime.
+// Note: non-exhaustive to make sure this is not constructable on the outside.
+#[non_exhaustive]
+#[derive(Debug)]
+pub(crate) struct GcToken;
+
+/// # ZST type representing a JavaScript call scope
+///
+/// Access to scoped root values should mainly require holding a
+/// `ContextRef<'scope, ScopeToken>`. In limited cases, borrowing heap data can
+/// bind to the `'scope` lifetime.
+// Note: non-exhaustive to make sure this is not constructable on the outside.
+#[non_exhaustive]
+#[derive(Debug)]
+pub(crate) struct ScopeToken;
+
+/// # Access to garbage collector
+///
+/// Holding this token is required for garbage collection.
+#[derive(Debug)]
+pub struct GcScope<'a, 'b> {
+    gc: GcToken,
+    scope: ScopeToken,
+    _gc_marker: PhantomData<&'a mut GcToken>,
+    _scope_marker: PhantomData<&'b ScopeToken>,
+}
+
+/// # Access to the JavaScript call stack
+///
+/// Holding this token is required for JavaScript calls.
+#[derive(Debug)]
+pub struct Scope<'a> {
+    inner: ScopeToken,
+    _marker: PhantomData<&'a ScopeToken>,
+}
+
+impl GcToken {
+    unsafe fn new() -> Self {
+        Self
+    }
+}
+
+impl ScopeToken {
+    unsafe fn new() -> Self {
+        Self
+    }
+}
+
+impl<'a, 'b> GcScope<'a, 'b> {
+    /// SAFETY: Only one GcScope root should exist at any point in time.
+    ///
+    /// The caller must make sure to only create a new root when a new
+    /// JavaScript call stack is initialized.
+    #[inline]
+    pub(crate) unsafe fn create_root() -> (GcToken, ScopeToken) {
+        (GcToken::new(), ScopeToken::new())
+    }
+
+    #[inline]
+    pub(crate) fn new(_: &'a mut GcToken, _: &'b mut ScopeToken) -> Self {
+        Self {
+            gc: GcToken,
+            scope: ScopeToken,
+            _gc_marker: PhantomData,
+            _scope_marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn reborrow(&mut self) -> Self {
+        Self {
+            gc: GcToken,
+            scope: ScopeToken,
+            _gc_marker: PhantomData,
+            _scope_marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn print(&mut self) {
+        println!("GC!");
+    }
+}
+
+impl Scope<'_> {
+    #[inline]
+    pub(crate) fn new(_: &mut ScopeToken) -> Self {
+        Self {
+            inner: ScopeToken,
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn reborrow(&self) -> Self {
+        Self {
+            inner: ScopeToken,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn print(&self) {
+        println!("GC!");
+    }
+}

--- a/nova_vm/src/engine/register_value.rs
+++ b/nova_vm/src/engine/register_value.rs
@@ -38,7 +38,7 @@ impl<T: IntoValue> Register<T> {
     ///
     /// ```rs
     /// fn example(
-    ///     agent: &mut Agent,
+    ///     agent: &mut Agent, mut gc: Gc<'_>,
     ///     this: Register<Value>,
     ///     args: ArgumentsList
     /// ) {
@@ -57,7 +57,7 @@ impl<T: IntoValue> Register<T> {
     ///
     /// ```rs
     /// fn example(
-    ///     agent: &mut Agent,
+    ///     agent: &mut Agent, mut gc: Gc<'_>,
     ///     this: Register<Value>,
     ///     args: ArgumentsList
     /// ) {

--- a/nova_vm/src/engine/rootable/global.rs
+++ b/nova_vm/src/engine/rootable/global.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use crate::engine::context::GcScope;
 use crate::{
     ecmascript::execution::Agent,
     engine::rootable::{HeapRootRef, Rootable},
@@ -73,7 +74,7 @@ impl<T: Rootable> Global<T> {
 
     /// Access the rooted value from inside this Global without releasing the
     /// Global.
-    pub fn get(&self, agent: &mut Agent) -> T {
+    pub fn get(&self, agent: &mut Agent, _: GcScope<'_, '_>) -> T {
         let heap_ref = match T::from_root_repr(&self.0) {
             Ok(value) => {
                 // The value didn't need rooting
@@ -99,8 +100,8 @@ impl<T: Rootable> Global<T> {
     /// original Global and the cloned one must be explicitly released before
     /// the rooted value can be garbage collected.
     #[must_use]
-    pub fn clone(&self, agent: &mut Agent) -> Self {
-        let value = self.get(agent);
+    pub fn clone(&self, agent: &mut Agent, gc: GcScope<'_, '_>) -> Self {
+        let value = self.get(agent, gc);
         Self::new(agent, value)
     }
 }

--- a/nova_vm/tests/garbage_collection_tests.rs
+++ b/nova_vm/tests/garbage_collection_tests.rs
@@ -1,15 +1,18 @@
 use std::{fs, path::PathBuf};
 
-use nova_vm::ecmascript::{
-    execution::{
-        agent::{GcAgent, Options},
-        Agent, DefaultHostHooks,
+use nova_vm::{
+    ecmascript::{
+        execution::{
+            agent::{GcAgent, Options},
+            Agent, DefaultHostHooks,
+        },
+        scripts_and_modules::script::{parse_script, script_evaluation},
+        types::{Object, String, Value},
     },
-    scripts_and_modules::script::{parse_script, script_evaluation},
-    types::{Object, String, Value},
+    engine::context::GcScope,
 };
 
-fn initialize_global_object(agent: &mut Agent, global: Object) {
+fn initialize_global_object(agent: &mut Agent, gc: GcScope<'_, '_>, global: Object) {
     use nova_vm::ecmascript::{
         builtins::{create_builtin_function, ArgumentsList, Behaviour, BuiltinFunctionArgs},
         execution::JsResult,
@@ -17,11 +20,17 @@ fn initialize_global_object(agent: &mut Agent, global: Object) {
     };
 
     // `print` function
-    fn print(agent: &mut Agent, _this: Value, args: ArgumentsList) -> JsResult<Value> {
+    fn print(
+        agent: &mut Agent,
+        gc: GcScope<'_, '_>,
+
+        _this: Value,
+        args: ArgumentsList,
+    ) -> JsResult<Value> {
         if args.len() == 0 {
             println!();
         } else {
-            println!("{}", args[0].to_string(agent)?.as_str(agent));
+            println!("{}", args[0].to_string(agent, gc)?.as_str(agent));
         }
         Ok(Value::Undefined)
     }
@@ -34,6 +43,7 @@ fn initialize_global_object(agent: &mut Agent, global: Object) {
     global
         .internal_define_own_property(
             agent,
+            gc,
             property_key,
             PropertyDescriptor {
                 value: Some(function.into_value()),
@@ -67,39 +77,39 @@ fn garbage_collection_tests() {
         fs::read_to_string(d.clone()).expect("Should have been able to read the file");
 
     let mut agent = GcAgent::new(Options::default(), &DefaultHostHooks);
-    let create_global_object: Option<fn(&mut Agent) -> Object> = None;
-    let create_global_this_value: Option<fn(&mut Agent) -> Object> = None;
+    let create_global_object: Option<fn(&mut Agent, GcScope<'_, '_>) -> Object> = None;
+    let create_global_this_value: Option<fn(&mut Agent, GcScope<'_, '_>) -> Object> = None;
     let realm = agent.create_realm(
         create_global_object,
         create_global_this_value,
         Some(initialize_global_object),
     );
-    agent.run_in_realm(&realm, |agent| {
+    agent.run_in_realm(&realm, |agent, mut gc| {
         let realm = agent.current_realm_id();
         let source_text = String::from_string(agent, header_contents);
         let script = parse_script(agent, source_text, realm, false, None).unwrap();
-        let _ = script_evaluation(agent, script).unwrap_or_else(|err| {
+        let _ = script_evaluation(agent, gc.reborrow(), script).unwrap_or_else(|err| {
             panic!(
                 "Header evaluation failed: '{}' failed: {:?}",
                 d.display(),
-                err.value().string_repr(agent).as_str(agent)
+                err.value().string_repr(agent, gc).as_str(agent)
             )
         });
     });
     agent.gc();
 
     for i in 0..2 {
-        agent.run_in_realm(&realm, |agent| {
+        agent.run_in_realm(&realm, |agent, mut gc| {
             let realm = agent.current_realm_id();
             let source_text = String::from_string(agent, call_contents.clone());
             let script = parse_script(agent, source_text, realm, false, None).unwrap();
-            let _ = script_evaluation(agent, script).unwrap_or_else(|err| {
+            let _ = script_evaluation(agent, gc.reborrow(), script).unwrap_or_else(|err| {
                 println!("Error kind: {:?}", err.value());
                 panic!(
                     "Loop index run {} '{}' failed: {:?}",
                     i,
                     d.display(),
-                    err.value().string_repr(agent).as_str(agent)
+                    err.value().string_repr(agent, gc.reborrow(),).as_str(agent)
                 )
             });
         });

--- a/nova_vm/tests/object_prototype_tests.rs
+++ b/nova_vm/tests/object_prototype_tests.rs
@@ -27,15 +27,15 @@ fn object_prototype_tests() {
 
     let mut agent = GcAgent::new(Options::default(), &DefaultHostHooks);
     let realm = agent.create_default_realm();
-    agent.run_in_realm(&realm, |agent| {
+    agent.run_in_realm(&realm, |agent, mut gc| {
         let realm = agent.current_realm_id();
         let source_text = String::from_string(agent, contents);
         let script = parse_script(agent, source_text, realm, false, None).unwrap();
-        let _ = script_evaluation(agent, script).unwrap_or_else(|err| {
+        let _ = script_evaluation(agent, gc.reborrow(), script).unwrap_or_else(|err| {
             panic!(
                 "Test '{}' failed: {:?}",
                 d.display(),
-                err.to_string(agent).as_str(agent)
+                err.to_string(agent, gc).as_str(agent)
             )
         });
     });


### PR DESCRIPTION
One more step towards interleaved GC. The `GcScope` ZST (zero-sized type) carries two lifetimes, the "scope" lifetime and the "GC" lifetime. The GC lifetime is somewhat related to the `&mut Agent` borrow lifetime in that code that does not receive `&mut Agent` cannot perform GC, but the intention is that neither can it without the `GcScope`'s `'gc` lifetime. In the future, if/once `&mut Agent` becomes `&Agent` then the GC will become possible with just `&Agent + 'gc`.

I could probably maybe move this lifetime into a `GcContext` that is a `#[repr(transparent)]` over `Agent` with the GC and Scope lifetimes embedded into that... And then `NoGcContext` that is similar but now with a shared borrow over the GC lifetime...

I'll try that in a separate branch.