### PR TITLE
feat(heap): Implement a simple string interner

### DIFF
--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -15,8 +15,8 @@ use crate::{
     ecmascript::{execution::Agent, types::PropertyDescriptor},
     engine::rootable::{HeapRootData, HeapRootRef, Rootable},
     heap::{
-        indexes::StringIndex, CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep,
-        PrimitiveHeap, WorkQueues,
+        indexes::{IntoBaseIndex, StringIndex},
+        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, PrimitiveHeap, WorkQueues,
     },
     SmallInteger, SmallString,
 };
@@ -50,6 +50,18 @@ impl Index<HeapString> for PrimitiveHeap<'_> {
 
     fn index(&self, index: HeapString) -> &Self::Output {
         &self.strings[index]
+    }
+}
+
+impl IntoBaseIndex<StringHeapData> for HeapString {
+    fn into_base_index(self) -> StringIndex {
+        self.0
+    }
+}
+
+impl From<StringIndex> for HeapString {
+    fn from(base: StringIndex) -> Self {
+        Self(base)
     }
 }
 

--- a/nova_vm/src/ecmascript/types/language/string/data.rs
+++ b/nova_vm/src/ecmascript/types/language/string/data.rs
@@ -29,6 +29,12 @@ impl PartialEq for StringHeapData {
 }
 impl Eq for StringHeapData {}
 
+impl std::hash::Hash for StringHeapData {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum IndexMapping {
     Ascii,

--- a/nova_vm/src/heap/heap_gc.rs
+++ b/nova_vm/src/heap/heap_gc.rs
@@ -11,8 +11,8 @@ use super::{
     heap_bits::{
         mark_array_with_u32_length, mark_descriptors, sweep_heap_elements_vector_descriptors,
         sweep_heap_u16_elements_vector_values, sweep_heap_u32_elements_vector_values,
-        sweep_heap_u8_elements_vector_values, sweep_heap_vector_values, sweep_side_table_values,
-        CompactionLists, HeapBits, HeapMarkAndSweep, WorkQueues,
+        sweep_heap_u8_elements_vector_values, sweep_heap_vector_values, sweep_lookup_table_values,
+        sweep_side_table_values, CompactionLists, HeapBits, HeapMarkAndSweep, WorkQueues,
     },
     indexes::{ElementIndex, StringIndex},
     Heap, WellKnownSymbolIndexes,
@@ -187,6 +187,7 @@ pub fn heap_gc(
             #[cfg(feature = "shared-array-buffer")]
             shared_array_buffers,
             strings,
+            strings_map: _,
             symbols,
             #[cfg(feature = "array-buffer")]
             typed_arrays,
@@ -1061,6 +1062,7 @@ fn sweep(
         #[cfg(feature = "shared-array-buffer")]
         shared_array_buffers,
         strings,
+        strings_map,
         symbols,
         #[cfg(feature = "array-buffer")]
         typed_arrays,
@@ -1432,6 +1434,7 @@ fn sweep(
         if !strings.is_empty() {
             s.spawn(|| {
                 sweep_heap_vector_values(strings, &compactions, &bits.strings);
+                sweep_lookup_table_values(strings_map, &compactions.strings, &bits.strings);
             });
         }
         if !symbols.is_empty() {


### PR DESCRIPTION
A quite simple implementation of a string interner as a `AHashMap<StringHeapData, StringIndex>` lookup table. Seems to be broken and breaking tests, probably for a good reason. Ideally I would like the lookup table to not take `StringHeapData` as the key and instead take something like `&'a str` but that would require a lifetime for the heap. Far from mergeable as is.

> [!WARNING]
> Needs to be implemented using a `HashTable<...>` instead. See `Map`/`Set` for reference.

Greatly speeds up operations where there are lots of strings.
