### PR TITLE
chore(ecmascript): Make TypedArray and DataView memory work take NoGcScope

### DIFF
--- a/nova_vm/src/ecmascript/abstract_operations/type_conversion.rs
+++ b/nova_vm/src/ecmascript/abstract_operations/type_conversion.rs
@@ -521,17 +521,9 @@ pub(crate) fn to_int32_number(agent: &mut Agent, number: Number) -> i32 {
     }
 
     // 3. Let int be truncate(ℝ(number)).
-    let int = number.truncate(agent).into_i64(agent);
-
     // 4. Let int32bit be int modulo 2^32.
-    let int32bit = int % 2i64.pow(32);
-
     // 5. If int32bit ≥ 2^31, return 𝔽(int32bit - 2^32); otherwise return 𝔽(int32bit).
-    if int32bit >= 2i64.pow(32) {
-        (int32bit - 2i64.pow(32)) as i32
-    } else {
-        int32bit as i32
-    }
+    number.into_f64(agent).trunc() as i64 as i32
 }
 
 /// ### [7.1.7 ToUint32 ( argument )](https://tc39.es/ecma262/#sec-touint32)
@@ -562,13 +554,9 @@ pub(crate) fn to_uint32_number(agent: &mut Agent, number: Number) -> u32 {
     }
 
     // 3. Let int be truncate(ℝ(number)).
-    let int = number.truncate(agent).into_i64(agent);
-
     // 4. Let int32bit be int modulo 2^32.
-    let int32bit = int % 2i64.pow(32);
-
     // 5. Return 𝔽(int32bit).
-    int32bit as u32
+    number.into_f64(agent).trunc() as i64 as u32
 }
 
 /// ### [7.1.8 ToInt16 ( argument )](https://tc39.es/ecma262/#sec-toint16)
@@ -582,29 +570,25 @@ pub(crate) fn to_int16(agent: &mut Agent, gc: GcScope<'_, '_>, argument: Value) 
     // 1. Let number be ? ToNumber(argument).
     let number = to_number(agent, gc, argument)?;
 
+    Ok(to_int16_number(agent, number))
+}
+
+pub(crate) fn to_int16_number(agent: &mut Agent, number: Number) -> i16 {
     if let Number::Integer(int) = number {
         // Fast path: Integer value is very nearly int16 already.
         let int = int.into_i64();
-        return Ok(int as i16);
+        return int as i16;
     }
 
     // 2. If number is not finite or number is either +0𝔽 or -0𝔽, return +0𝔽.
     if !number.is_finite(agent) || number.is_pos_zero(agent) || number.is_neg_zero(agent) {
-        return Ok(0);
+        return 0;
     }
 
     // 3. Let int be truncate(ℝ(number)).
-    let int = number.truncate(agent).into_i64(agent);
-
     // 4. Let int16bit be int modulo 2^16.
-    let int16bit = int % 2i64.pow(16);
-
     // 5. If int16bit ≥ 2^15, return 𝔽(int16bit - 2^16); otherwise return 𝔽(int16bit).
-    Ok(if int16bit >= 2i64.pow(15) {
-        int16bit - 2i64.pow(16)
-    } else {
-        int16bit
-    } as i16)
+    number.into_f64(agent).trunc() as i64 as i16
 }
 
 /// ### [7.1.9 ToUint16 ( argument )](https://tc39.es/ecma262/#sec-touint16)
@@ -618,25 +602,25 @@ pub(crate) fn to_uint16(agent: &mut Agent, gc: GcScope<'_, '_>, argument: Value)
     // 1. Let number be ? ToNumber(argument).
     let number = to_number(agent, gc, argument)?;
 
+    Ok(to_uint16_number(agent, number))
+}
+
+pub(crate) fn to_uint16_number(agent: &mut Agent, number: Number) -> u16 {
     if let Number::Integer(int) = number {
         // Fast path: Integer value is very nearly uin16 already.
         let int = int.into_i64();
-        return Ok(int as u16);
+        return int as u16;
     }
 
     // 2. If number is not finite or number is either +0𝔽 or -0𝔽, return +0𝔽.
     if !number.is_finite(agent) || number.is_pos_zero(agent) || number.is_neg_zero(agent) {
-        return Ok(0);
+        return 0;
     }
 
     // 3. Let int be truncate(ℝ(number)).
-    let int = number.truncate(agent).into_i64(agent);
-
     // 4. Let int16bit be int modulo 2^16.
-    let int16bit = int % 2i64.pow(16);
-
     // Return 𝔽(int16bit).
-    Ok(int16bit as u16)
+    number.into_f64(agent).trunc() as i64 as u16
 }
 
 /// ### [7.1.10 ToInt8 ( argument )](https://tc39.es/ecma262/#sec-toint8)
@@ -650,29 +634,25 @@ pub(crate) fn to_int8(agent: &mut Agent, gc: GcScope<'_, '_>, argument: Value) -
     // 1. Let number be ? ToNumber(argument).
     let number = to_number(agent, gc, argument)?;
 
+    Ok(to_int8_number(agent, number))
+}
+
+pub(crate) fn to_int8_number(agent: &mut Agent, number: Number) -> i8 {
     if let Number::Integer(int) = number {
         // Fast path: Integer value is very nearly uint32 already.
         let int = int.into_i64();
-        return Ok(int as i8);
+        return int as i8;
     }
 
     // 2. If number is not finite or number is either +0𝔽 or -0𝔽, return +0𝔽.
     if !number.is_finite(agent) || number.is_pos_zero(agent) || number.is_neg_zero(agent) {
-        return Ok(0);
+        return 0;
     }
 
     // 3. Let int be truncate(ℝ(number)).
-    let int = number.truncate(agent).into_i64(agent);
-
     // 4. Let int8bit be int modulo 2^8.
-    let int8bit = int % 2i64.pow(8);
-
     // 5. If int8bit ≥ 2^7, return 𝔽(int8bit - 2^8); otherwise return 𝔽(int8bit).
-    Ok(if int8bit >= 2i64.pow(7) {
-        int8bit - 2i64.pow(8)
-    } else {
-        int8bit
-    } as i8)
+    number.into_f64(agent).trunc() as i64 as i8
 }
 
 /// ### [7.1.11 ToUint8 ( argument )](https://tc39.es/ecma262/#sec-touint8)
@@ -686,25 +666,27 @@ pub(crate) fn to_uint8(agent: &mut Agent, gc: GcScope<'_, '_>, argument: Value) 
     // 1. Let number be ? ToNumber(argument).
     let number = to_number(agent, gc, argument)?;
 
+    Ok(to_uint8_number(agent, number))
+}
+
+pub(crate) fn to_uint8_number(agent: &mut Agent, number: Number) -> u8 {
     if let Number::Integer(int) = number {
         // Fast path: Integer value is very nearly uint32 already.
         let int = int.into_i64();
-        return Ok(int as u8);
+        println!("Here {}", int as u8);
+        return int as u8;
     }
 
     // 2. If number is not finite or number is either +0𝔽 or -0𝔽, return +0𝔽.
     if !number.is_finite(agent) || number.is_pos_zero(agent) || number.is_neg_zero(agent) {
-        return Ok(0);
+        return 0;
     }
 
     // 3. Let int be truncate(ℝ(number)).
-    let int = number.truncate(agent).into_i64(agent);
-
     // 4. Let int8bit be int modulo 2^8.
-    let int8bit = int % 2i64.pow(8);
-
     // 5. Return 𝔽(int8bit).
-    Ok(int8bit as u8)
+    println!("There");
+    number.into_f64(agent).trunc() as i64 as u8
 }
 
 /// ### [7.1.12 ToUint8Clamp ( argument )](https://tc39.es/ecma262/#sec-touint8clamp)
@@ -722,43 +704,29 @@ pub(crate) fn to_uint8_clamp(
     // 1. Let number be ? ToNumber(argument).
     let number = to_number(agent, gc, argument)?;
 
+    Ok(to_uint8_clamp_number(agent, number))
+}
+
+pub(crate) fn to_uint8_clamp_number(agent: &mut Agent, number: Number) -> u8 {
     if let Number::Integer(int) = number {
         // Fast path: Integer value is very nearly uint8 already.
-        let int = int.into_i64().clamp(0, 255);
-        return Ok(int as u8);
+        return int.into_i64().clamp(0, 255) as u8;
     }
 
     // 2. If number is NaN, return +0𝔽.
     if number.is_nan(agent) {
-        return Ok(0);
+        return 0;
     }
 
     // 3. Let mv be the extended mathematical value of number.
-    // TODO: Is there a better way?
     let mv = number.into_f64(agent);
 
     // 4. Let clamped be the result of clamping mv between 0 and 255.
-    let clamped = mv.clamp(0.0, 255.0);
-
     // 5. Let f be floor(clamped).
-    let f = clamped.floor();
-
-    Ok(
-        // 6. If clamped < f + 0.5, return 𝔽(f).
-        if clamped < f + 0.5 {
-            f as u8
-        }
-        // 7. If clamped > f + 0.5, return 𝔽(f + 1).
-        else if clamped > f + 0.5 {
-            f as u8 + 1
-        }
-        // 8. If f is even, return 𝔽(f). Otherwise, return 𝔽(f + 1).
-        else if f % 2.0 == 0.0 {
-            f as u8
-        } else {
-            f as u8 + 1
-        },
-    )
+    // 6. If clamped < f + 0.5, return 𝔽(f).
+    // 7. If clamped > f + 0.5, return 𝔽(f + 1).
+    // 8. If f is even, return 𝔽(f). Otherwise, return 𝔽(f + 1).
+    mv.clamp(0.0, 255.0).round_ties_even() as u8
 }
 
 /// ### [7.1.13 ToBigInt ( argument )](https://tc39.es/ecma262/#sec-tobigint)
@@ -874,7 +842,6 @@ pub(crate) fn string_to_big_int(
 /// language value) and returns either a normal completion containing a BigInt
 /// or a throw completion. It converts argument to one of 2**64 BigInt values
 /// in the inclusive interval from ℤ(-2**63) to ℤ(2**63 - 1).
-#[inline(always)]
 pub(crate) fn to_big_int64(
     agent: &mut Agent,
     gc: GcScope<'_, '_>,
@@ -883,6 +850,10 @@ pub(crate) fn to_big_int64(
     // 1. Let n be ? ToBigInt(argument).
     let n = to_big_int(agent, gc, argument)?;
 
+    Ok(to_big_int64_big_int(agent, n))
+}
+
+pub(crate) fn to_big_int64_big_int(agent: &mut Agent, n: BigInt) -> i64 {
     // 2. Let int64bit be ℝ(n) modulo 2**64.
     match n {
         BigInt::BigInt(heap_big_int) => {
@@ -894,13 +865,9 @@ pub(crate) fn to_big_int64(
             } else {
                 int64bit
             };
-            let int64bit = i64::from_ne_bytes(int64bit.to_ne_bytes());
-            Ok(int64bit)
+            i64::from_ne_bytes(int64bit.to_ne_bytes())
         }
-        BigInt::SmallBigInt(small_big_int) => {
-            let int64bit = small_big_int.into_i64();
-            Ok(int64bit)
-        }
+        BigInt::SmallBigInt(small_big_int) => small_big_int.into_i64(),
     }
 }
 
@@ -910,7 +877,6 @@ pub(crate) fn to_big_int64(
 /// language value) and returns either a normal completion containing a BigInt
 /// or a throw completion. It converts argument to one of 2**64 BigInt values
 /// in the inclusive interval from 0ℤ to ℤ(2**64 - 1).
-#[inline(always)]
 pub(crate) fn to_big_uint64(
     agent: &mut Agent,
     gc: GcScope<'_, '_>,
@@ -918,7 +884,10 @@ pub(crate) fn to_big_uint64(
 ) -> JsResult<u64> {
     // 1. Let n be ? ToBigInt(argument).
     let n = to_big_int(agent, gc, argument)?;
+    Ok(to_big_uint64_big_int(agent, n))
+}
 
+pub(crate) fn to_big_uint64_big_int(agent: &mut Agent, n: BigInt) -> u64 {
     // 2. Let int64bit be ℝ(n) modulo 2**64.
     match n {
         BigInt::BigInt(heap_big_int) => {
@@ -930,11 +899,11 @@ pub(crate) fn to_big_uint64(
             } else {
                 int64bit
             };
-            Ok(int64bit)
+            int64bit
         }
         BigInt::SmallBigInt(small_big_int) => {
             let int64bit = small_big_int.into_i64();
-            Ok(int64bit as u64)
+            int64bit as u64
         }
     }
 }

--- a/nova_vm/src/ecmascript/builtins/array_buffer/abstract_operations.rs
+++ b/nova_vm/src/ecmascript/builtins/array_buffer/abstract_operations.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{ArrayBuffer, ArrayBufferHeapData};
-use crate::ecmascript::types::Viewable;
+use crate::ecmascript::types::{Numeric, Viewable};
 use crate::engine::context::{GcScope, NoGcScope};
 use crate::{
     ecmascript::{
@@ -325,7 +325,7 @@ pub(crate) fn raw_bytes_to_numeric<T: Viewable>(
     agent: &mut Agent,
     raw_bytes: T,
     is_little_endian: bool,
-) -> Value {
+) -> Numeric {
     // 1. Let elementSize be the Element Size value specified in Table 71 for Element Type type.
     // 2. If isLittleEndian is false, reverse the order of the elements of rawBytes.
     // 3. If type is FLOAT32, then
@@ -389,7 +389,7 @@ pub(crate) fn get_value_from_buffer<T: Viewable>(
     _is_typed_array: bool,
     _order: Ordering,
     is_little_endian: Option<bool>,
-) -> Value {
+) -> Numeric {
     // 1. Assert: IsDetachedBuffer(arrayBuffer) is false.
     debug_assert!(!array_buffer.is_detached(agent));
     // 2. Assert: There are sufficient bytes in arrayBuffer starting at byteIndex to represent a value of type.
@@ -429,8 +429,7 @@ pub(crate) fn get_value_from_buffer<T: Viewable>(
 /// isLittleEndian (a Boolean) and returns a List of byte values.
 pub(crate) fn numeric_to_raw_bytes<T: Viewable>(
     agent: &mut Agent,
-    gc: GcScope<'_, '_>,
-    value: Value,
+    value: Numeric,
     is_little_endian: bool,
 ) -> T {
     // 1. If type is FLOAT32, then
@@ -448,9 +447,9 @@ pub(crate) fn numeric_to_raw_bytes<T: Viewable>(
     // 4. If isLittleEndian is false, reverse the order of the elements of rawBytes.
     // 5. Return rawBytes.
     if is_little_endian {
-        T::from_le_value(agent, gc, value)
+        T::from_le_value(agent, value)
     } else {
-        T::from_be_value(agent, gc, value)
+        T::from_be_value(agent, value)
     }
 }
 
@@ -464,10 +463,9 @@ pub(crate) fn numeric_to_raw_bytes<T: Viewable>(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn set_value_in_buffer<T: Viewable>(
     agent: &mut Agent,
-    gc: GcScope<'_, '_>,
     array_buffer: ArrayBuffer,
     byte_index: usize,
-    value: Value,
+    value: Numeric,
     _is_typed_array: bool,
     _order: Ordering,
     is_little_endian: Option<bool>,
@@ -491,7 +489,7 @@ pub(crate) fn set_value_in_buffer<T: Viewable>(
     });
 
     // 7. Let rawBytes be NumericToRawBytes(type, value, isLittleEndian).
-    let raw_bytes = numeric_to_raw_bytes::<T>(agent, gc, value, is_little_endian);
+    let raw_bytes = numeric_to_raw_bytes::<T>(agent, value, is_little_endian);
     // 8. If IsSharedArrayBuffer(arrayBuffer) is true, then
     // a. Let execution be the [[CandidateExecution]] field of the surrounding agent's Agent Record.
     // b. Let eventsRecord be the Agent Events Record of execution.[[EventsRecords]] whose [[AgentSignifier]] is AgentSignifier().

--- a/nova_vm/src/ecmascript/builtins/data_view/abstract_operations.rs
+++ b/nova_vm/src/ecmascript/builtins/data_view/abstract_operations.rs
@@ -9,7 +9,7 @@ use crate::{
             structured_data::data_view_objects::data_view_prototype::require_internal_slot_data_view,
         },
         execution::{agent::ExceptionType, Agent, JsResult},
-        types::{IntoValue, Value, Viewable},
+        types::{IntoNumeric, Numeric, Value, Viewable},
     },
     engine::context::GcScope,
 };
@@ -170,7 +170,7 @@ pub(crate) fn get_view_value<T: Viewable>(
     request_index: Value,
     // 4. Set isLittleEndian to ToBoolean(isLittleEndian).
     is_little_endian: bool,
-) -> JsResult<Value> {
+) -> JsResult<Numeric> {
     // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
     // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
     let view = require_internal_slot_data_view(agent, gc.nogc(), view)?;
@@ -248,10 +248,10 @@ pub(crate) fn set_view_value<T: Viewable>(
 
     // 4. If IsBigIntElementType(type) is true, let numberValue be ? ToBigInt(value).
     let number_value = if T::IS_BIGINT {
-        to_big_int(agent, gc.reborrow(), value)?.into_value()
+        to_big_int(agent, gc.reborrow(), value)?.into_numeric()
     } else {
         // 5. Otherwise, let numberValue be ? ToNumber(value).
-        to_number(agent, gc.reborrow(), value)?.into_value()
+        to_number(agent, gc.reborrow(), value)?.into_numeric()
     };
 
     // 7. Let viewOffset be view.[[ByteOffset]].
@@ -290,7 +290,6 @@ pub(crate) fn set_view_value<T: Viewable>(
     // 15. Perform SetValueInBuffer(view.[[ViewedArrayBuffer]], bufferIndex, type, numberValue, false, unordered, isLittleEndian).
     set_value_in_buffer::<T>(
         agent,
-        gc,
         view.get_viewed_array_buffer(agent),
         buffer_index,
         number_value,

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_constructors.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_constructors.rs
@@ -683,13 +683,13 @@ fn typed_array_constructor<T: Viewable>(
             match first_argument {
                 TypedArray::Int8Array(_) => initialize_typed_array_from_typed_array::<T, i8>(
                     agent,
-                    gc.reborrow(),
+                    gc.nogc(),
                     o,
                     first_argument,
                 )?,
                 TypedArray::Uint8Array(_) => initialize_typed_array_from_typed_array::<T, u8>(
                     agent,
-                    gc.reborrow(),
+                    gc.nogc(),
                     o,
                     first_argument,
                 )?,
@@ -697,53 +697,53 @@ fn typed_array_constructor<T: Viewable>(
                     T,
                     U8Clamped,
                 >(
-                    agent, gc.reborrow(), o, first_argument
+                    agent, gc.nogc(), o, first_argument
                 )?,
                 TypedArray::Int16Array(_) => initialize_typed_array_from_typed_array::<T, i16>(
                     agent,
-                    gc.reborrow(),
+                    gc.nogc(),
                     o,
                     first_argument,
                 )?,
                 TypedArray::Uint16Array(_) => initialize_typed_array_from_typed_array::<T, u16>(
                     agent,
-                    gc.reborrow(),
+                    gc.nogc(),
                     o,
                     first_argument,
                 )?,
                 TypedArray::Int32Array(_) => initialize_typed_array_from_typed_array::<T, i32>(
                     agent,
-                    gc.reborrow(),
+                    gc.nogc(),
                     o,
                     first_argument,
                 )?,
                 TypedArray::Uint32Array(_) => initialize_typed_array_from_typed_array::<T, u32>(
                     agent,
-                    gc.reborrow(),
+                    gc.nogc(),
                     o,
                     first_argument,
                 )?,
                 TypedArray::BigInt64Array(_) => initialize_typed_array_from_typed_array::<T, i64>(
                     agent,
-                    gc.reborrow(),
+                    gc.nogc(),
                     o,
                     first_argument,
                 )?,
                 TypedArray::BigUint64Array(_) => initialize_typed_array_from_typed_array::<T, u64>(
                     agent,
-                    gc.reborrow(),
+                    gc.nogc(),
                     o,
                     first_argument,
                 )?,
                 TypedArray::Float32Array(_) => initialize_typed_array_from_typed_array::<T, f32>(
                     agent,
-                    gc.reborrow(),
+                    gc.nogc(),
                     o,
                     first_argument,
                 )?,
                 TypedArray::Float64Array(_) => initialize_typed_array_from_typed_array::<T, f64>(
                     agent,
-                    gc.reborrow(),
+                    gc.nogc(),
                     o,
                     first_argument,
                 )?,

--- a/nova_vm/src/ecmascript/builtins/structured_data/data_view_objects/data_view_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/data_view_objects/data_view_prototype.rs
@@ -264,6 +264,7 @@ impl DataViewPrototype {
         // 1. Let v be the this value.
         // 2. Return ? GetViewValue(v, byteOffset, littleEndian, bigint64).
         get_view_value::<i64>(agent, gc, this_value, byte_offset, little_endian)
+            .map(IntoValue::into_value)
     }
 
     /// ### [25.3.4.6 DataView.prototype.getBigUint64 ( byteOffset \[ , littleEndian \] )](https://tc39.es/ecma262/#sec-dataview.prototype.getbiguint64)
@@ -278,6 +279,7 @@ impl DataViewPrototype {
         // 1. Let v be the this value.
         // 2. Return ? GetViewValue(v, byteOffset, littleEndian, biguint64).
         get_view_value::<u64>(agent, gc, this_value, byte_offset, little_endian)
+            .map(IntoValue::into_value)
     }
 
     /// ### [25.3.4.7 DataView.prototype.getFloat32 ( byteOffset \[ , littleEndian \] )](https://tc39.es/ecma262/#sec-dataview.prototype.getfloat32)
@@ -293,6 +295,7 @@ impl DataViewPrototype {
         // 1. Let v be the this value.
         // 3. Return ? GetViewValue(v, byteOffset, littleEndian, float32).
         get_view_value::<f32>(agent, gc, this_value, byte_offset, little_endian)
+            .map(IntoValue::into_value)
     }
 
     /// ### [25.3.4.8 DataView.prototype.getFloat64 ( byteOffset \[ , littleEndian \] )](https://tc39.es/ecma262/#sec-dataview.prototype.getfloat64)
@@ -308,6 +311,7 @@ impl DataViewPrototype {
         // 1. Let v be the this value.
         // 3. Return ? GetViewValue(v, byteOffset, littleEndian, float64).
         get_view_value::<f64>(agent, gc, this_value, byte_offset, little_endian)
+            .map(IntoValue::into_value)
     }
 
     /// ### [25.3.4.9 DataView.prototype.getInt8 ( byteOffset )](https://tc39.es/ecma262/#sec-dataview.prototype.getint8)
@@ -320,7 +324,7 @@ impl DataViewPrototype {
         let byte_offset = arguments.get(0);
         // 1. Let v be the this value.
         // 2. Return ? GetViewValue(v, byteOffset, true, int8).
-        get_view_value::<i8>(agent, gc, this_value, byte_offset, true)
+        get_view_value::<i8>(agent, gc, this_value, byte_offset, true).map(IntoValue::into_value)
     }
 
     /// ### [25.3.4.10 DataView.prototype.getInt16 ( byteOffset \[ , littleEndian \] )](https://tc39.es/ecma262/#sec-dataview.prototype.getint16)
@@ -336,6 +340,7 @@ impl DataViewPrototype {
         // 1. Let v be the this value.
         // 3. Return ? GetViewValue(v, byteOffset, littleEndian, int16).
         get_view_value::<i16>(agent, gc, this_value, byte_offset, little_endian)
+            .map(IntoValue::into_value)
     }
 
     /// ### [25.3.4.11 DataView.prototype.getInt32 ( byteOffset \[ , littleEndian \] )](https://tc39.es/ecma262/#sec-dataview.prototype.getint32)
@@ -351,6 +356,7 @@ impl DataViewPrototype {
         // 1. Let v be the this value.
         // 3. Return ? GetViewValue(v, byteOffset, littleEndian, int32).
         get_view_value::<i32>(agent, gc, this_value, byte_offset, little_endian)
+            .map(IntoValue::into_value)
     }
 
     /// ### [25.3.4.12 DataView.prototype.getUint8 ( byteOffset )](https://tc39.es/ecma262/#sec-dataview.prototype.getuint8)
@@ -363,7 +369,7 @@ impl DataViewPrototype {
         let byte_offset = arguments.get(0);
         // 1. Let v be the this value.
         // 2. Return ? GetViewValue(v, byteOffset, true, uint8).
-        get_view_value::<u8>(agent, gc, this_value, byte_offset, true)
+        get_view_value::<u8>(agent, gc, this_value, byte_offset, true).map(IntoValue::into_value)
     }
 
     /// ### [25.3.4.13 DataView.prototype.getUint16 ( byteOffset \[ , littleEndian \] )](https://tc39.es/ecma262/#sec-dataview.prototype.getuint16)
@@ -379,6 +385,7 @@ impl DataViewPrototype {
         // 1. Let v be the this value.
         // 3. Return ? GetViewValue(v, byteOffset, littleEndian, uint16).
         get_view_value::<u16>(agent, gc, this_value, byte_offset, little_endian)
+            .map(IntoValue::into_value)
     }
 
     /// ### [25.3.4.14 DataView.prototype.getUint32 ( byteOffset \[ , littleEndian \] )](https://tc39.es/ecma262/#sec-dataview.prototype.getuint32)
@@ -394,6 +401,7 @@ impl DataViewPrototype {
         // 1. Let v be the this value.
         // 3. Return ? GetViewValue(v, byteOffset, littleEndian, uint32).
         get_view_value::<u32>(agent, gc, this_value, byte_offset, little_endian)
+            .map(IntoValue::into_value)
     }
 
     /// ### [25.3.4.15 DataView.prototype.setBigInt64 ( byteOffset, value \[ , littleEndian \] )](https://tc39.es/ecma262/#sec-dataview.prototype.setbigint64)

--- a/tests/metrics.json
+++ b/tests/metrics.json
@@ -1,7 +1,7 @@
 {
   "results": {
-    "crash": 14826,
-    "fail": 8752,
+    "crash": 14824,
+    "fail": 8754,
     "pass": 21665,
     "skip": 45,
     "timeout": 3,


### PR DESCRIPTION
Using `Numeric` and so on allows us to avoid GC.