### PR TITLE
fix(ecmascript): `anchor` function length

### DIFF
--- a/nova_vm/src/ecmascript/builtins/text_processing/string_objects/string_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/text_processing/string_objects/string_prototype.rs
@@ -273,7 +273,7 @@ struct StringPrototypeAnchor;
 #[cfg(feature = "annex-b-string")]
 impl Builtin for StringPrototypeAnchor {
     const NAME: String<'static> = BUILTIN_STRING_MEMORY.anchor;
-    const LENGTH: u8 = 0;
+    const LENGTH: u8 = 1;
     const BEHAVIOUR: Behaviour = Behaviour::Regular(StringPrototype::anchor);
 }
 


### PR DESCRIPTION
Ran test262 and found some issues in the annex-b tests. Related #548 