### PR TITLE
perf: String hashing, creation and concatenating

### DIFF
--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -402,14 +402,7 @@ impl<'a> String<'a> {
                 let str_slice = unsafe { std::str::from_utf8_unchecked(&data[..len]) };
                 SmallString::from_str_unchecked(str_slice).into()
             }
-            Status::String(string) => {
-                let data = StringHeapData {
-                    data: data::StringBuffer::Owned(string),
-                    mapping: Default::default(),
-                };
-                let hash = agent.heap.string_hasher.hash_one(&data.data);
-                agent.heap.create((data, hash)).bind(gc)
-            }
+            Status::String(string) => agent.heap.create(string.into_string().unwrap()).bind(gc),
         }
     }
 

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use wtf8::Wtf8;
+
 use super::{
     bigint::{HeapBigInt, SmallBigInt},
     number::HeapNumber,
@@ -640,10 +642,10 @@ impl Value {
             }
             Value::String(data) => {
                 // Skip discriminant hashing in strings
-                arena[data].as_str().hash(hasher);
+                arena[data].data.hash(hasher);
             }
             Value::SmallString(data) => {
-                data.as_str().hash(hasher);
+                Wtf8::from_str(data.as_str()).hash(hasher);
             }
             Value::Symbol(data) => {
                 discriminant.hash(hasher);

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -68,6 +68,8 @@ use crate::{
     heap::{CompactionLists, HeapMarkAndSweep, WellKnownSymbolIndexes, WorkQueues},
 };
 
+use super::executable::get_instruction;
+
 struct EmptyParametersList(ast::FormalParameters<'static>);
 unsafe impl Send for EmptyParametersList {}
 unsafe impl Sync for EmptyParametersList {}
@@ -289,7 +291,9 @@ impl<'a> Vm {
         let do_gc = !agent.options.disable_gc;
         #[cfg(feature = "interleaved-gc")]
         let mut instr_count = 0u8;
-        while let Some(instr) = executable.get_instruction(agent, &mut self.ip) {
+
+        let instructions = executable.get_instructions(agent);
+        while let Some(instr) = get_instruction(instructions, &mut self.ip) {
             #[cfg(feature = "interleaved-gc")]
             if do_gc {
                 instr_count = instr_count.wrapping_add(1);


### PR DESCRIPTION
String hashing is currently always iterating the string twice: Once for `as_str` and once for `hash`.

String creation was also hashing twice: Once to lookup an existing string and once to store a new string.

String concatenation could also be optimised.

I also mildly refactored instruction fetching to make it a bit nicer, also a bit more performant if my quick check is correct.