### PR TITLE
chore: update rust toolchain version by cargo 1.85

### DIFF
--- a/nova_vm/src/ecmascript/builders/builtin_function_builder.rs
+++ b/nova_vm/src/ecmascript/builders/builtin_function_builder.rs
@@ -280,7 +280,7 @@ impl<'agent, P, L, B, Pr> BuiltinFunctionBuilder<'agent, P, L, NoName, B, Pr> {
     }
 }
 
-impl<'agent, P, L, B, Pr> BuiltinFunctionBuilder<'agent, P, L, CreatorName, B, Pr> {
+impl<P, L, B, Pr> BuiltinFunctionBuilder<'_, P, L, CreatorName, B, Pr> {
     pub(crate) fn get_name(&self) -> String<'static> {
         self.name.0
     }
@@ -528,9 +528,9 @@ impl<'agent, P, L, N, B> BuiltinFunctionBuilder<'agent, P, L, N, B, CreatorPrope
     }
 }
 
-impl<'agent>
+impl
     BuiltinFunctionBuilder<
-        'agent,
+        '_,
         NoPrototype,
         CreatorLength,
         CreatorName,
@@ -559,9 +559,9 @@ impl<'agent>
     }
 }
 
-impl<'agent>
+impl
     BuiltinFunctionBuilder<
-        'agent,
+        '_,
         NoPrototype,
         CreatorLength,
         CreatorName,
@@ -635,9 +635,9 @@ impl<'agent>
     }
 }
 
-impl<'agent>
+impl
     BuiltinFunctionBuilder<
-        'agent,
+        '_,
         CreatorPrototype,
         CreatorLength,
         CreatorName,

--- a/nova_vm/src/ecmascript/builders/ordinary_object_builder.rs
+++ b/nova_vm/src/ecmascript/builders/ordinary_object_builder.rs
@@ -280,9 +280,7 @@ impl OrdinaryObjectBuilder<'_, NoPrototype, NoProperties> {
     }
 }
 
-impl<T: IntoObject<'static>>
-    OrdinaryObjectBuilder<'_, CreatorPrototype<T>, NoProperties>
-{
+impl<T: IntoObject<'static>> OrdinaryObjectBuilder<'_, CreatorPrototype<T>, NoProperties> {
     pub fn build(self) -> OrdinaryObject<'static> {
         let (keys, values) = self.agent.heap.elements.create_with_stuff(vec![]);
         let slot = self
@@ -338,9 +336,7 @@ impl OrdinaryObjectBuilder<'_, NoPrototype, CreatorProperties> {
     }
 }
 
-impl<T: IntoObject<'static>>
-    OrdinaryObjectBuilder<'_, CreatorPrototype<T>, CreatorProperties>
-{
+impl<T: IntoObject<'static>> OrdinaryObjectBuilder<'_, CreatorPrototype<T>, CreatorProperties> {
     pub fn build(self) -> OrdinaryObject<'static> {
         assert_eq!(self.properties.0.len(), self.properties.0.capacity());
         {

--- a/nova_vm/src/ecmascript/builders/ordinary_object_builder.rs
+++ b/nova_vm/src/ecmascript/builders/ordinary_object_builder.rs
@@ -78,7 +78,7 @@ impl<'agent> OrdinaryObjectBuilder<'agent, NoPrototype, NoProperties> {
     }
 }
 
-impl<'agent, P, Pr> OrdinaryObjectBuilder<'agent, P, Pr> {
+impl<P, Pr> OrdinaryObjectBuilder<'_, P, Pr> {
     #[must_use]
     pub fn with_extensible(self, extensible: bool) -> Self {
         Self {
@@ -126,7 +126,7 @@ impl<'agent, P> OrdinaryObjectBuilder<'agent, P, NoProperties> {
     }
 }
 
-impl<'agent, P> OrdinaryObjectBuilder<'agent, P, CreatorProperties> {
+impl<P> OrdinaryObjectBuilder<'_, P, CreatorProperties> {
     #[must_use]
     pub fn with_data_property(mut self, key: PropertyKey<'static>, value: Value) -> Self {
         self.properties.0.push((key, None, Some(value)));
@@ -260,7 +260,7 @@ impl<'agent, P> OrdinaryObjectBuilder<'agent, P, CreatorProperties> {
     }
 }
 
-impl<'agent> OrdinaryObjectBuilder<'agent, NoPrototype, NoProperties> {
+impl OrdinaryObjectBuilder<'_, NoPrototype, NoProperties> {
     pub fn build(self) -> OrdinaryObject<'static> {
         let (keys, values) = self.agent.heap.elements.create_with_stuff(vec![]);
         let slot = self
@@ -280,8 +280,8 @@ impl<'agent> OrdinaryObjectBuilder<'agent, NoPrototype, NoProperties> {
     }
 }
 
-impl<'agent, T: IntoObject<'static>>
-    OrdinaryObjectBuilder<'agent, CreatorPrototype<T>, NoProperties>
+impl<T: IntoObject<'static>>
+    OrdinaryObjectBuilder<'_, CreatorPrototype<T>, NoProperties>
 {
     pub fn build(self) -> OrdinaryObject<'static> {
         let (keys, values) = self.agent.heap.elements.create_with_stuff(vec![]);
@@ -302,7 +302,7 @@ impl<'agent, T: IntoObject<'static>>
     }
 }
 
-impl<'agent> OrdinaryObjectBuilder<'agent, NoPrototype, CreatorProperties> {
+impl OrdinaryObjectBuilder<'_, NoPrototype, CreatorProperties> {
     pub fn build(self) -> OrdinaryObject<'static> {
         assert_eq!(self.properties.0.len(), self.properties.0.capacity());
         {
@@ -338,8 +338,8 @@ impl<'agent> OrdinaryObjectBuilder<'agent, NoPrototype, CreatorProperties> {
     }
 }
 
-impl<'agent, T: IntoObject<'static>>
-    OrdinaryObjectBuilder<'agent, CreatorPrototype<T>, CreatorProperties>
+impl<T: IntoObject<'static>>
+    OrdinaryObjectBuilder<'_, CreatorPrototype<T>, CreatorProperties>
 {
     pub fn build(self) -> OrdinaryObject<'static> {
         assert_eq!(self.properties.0.len(), self.properties.0.capacity());

--- a/nova_vm/src/ecmascript/builders/property_builder.rs
+++ b/nova_vm/src/ecmascript/builders/property_builder.rs
@@ -242,7 +242,7 @@ impl<'agent, K, D> PropertyBuilder<'agent, K, D> {
     }
 }
 
-impl<'agent> PropertyBuilder<'agent, CreatorKey, CreatorValue> {
+impl PropertyBuilder<'_, CreatorKey, CreatorValue> {
     pub fn build(
         self,
     ) -> (
@@ -258,7 +258,7 @@ impl<'agent> PropertyBuilder<'agent, CreatorKey, CreatorValue> {
     }
 }
 
-impl<'agent> PropertyBuilder<'agent, CreatorKey, CreatorReadOnlyValue> {
+impl PropertyBuilder<'_, CreatorKey, CreatorReadOnlyValue> {
     pub fn build(
         self,
     ) -> (
@@ -274,7 +274,7 @@ impl<'agent> PropertyBuilder<'agent, CreatorKey, CreatorReadOnlyValue> {
     }
 }
 
-impl<'agent> PropertyBuilder<'agent, CreatorKey, CreatorGetAccessor> {
+impl PropertyBuilder<'_, CreatorKey, CreatorGetAccessor> {
     pub fn build(
         self,
     ) -> (
@@ -294,7 +294,7 @@ impl<'agent> PropertyBuilder<'agent, CreatorKey, CreatorGetAccessor> {
     }
 }
 
-impl<'agent> PropertyBuilder<'agent, CreatorKey, CreatorSetAccess> {
+impl PropertyBuilder<'_, CreatorKey, CreatorSetAccess> {
     pub fn build(
         self,
     ) -> (
@@ -314,7 +314,7 @@ impl<'agent> PropertyBuilder<'agent, CreatorKey, CreatorSetAccess> {
     }
 }
 
-impl<'agent> PropertyBuilder<'agent, CreatorKey, CreatorGetSetAccessor> {
+impl PropertyBuilder<'_, CreatorKey, CreatorGetSetAccessor> {
     pub fn build(
         self,
     ) -> (

--- a/nova_vm/src/ecmascript/builtins/array.rs
+++ b/nova_vm/src/ecmascript/builtins/array.rs
@@ -880,7 +880,8 @@ fn ordinary_define_own_property_for_array(
         // b. If Desc has an [[Enumerable]] field and SameValue(Desc.[[Enumerable]], current.[[Enumerable]])
         //    is false, return false.
         if descriptor
-            .enumerable.is_some_and(|enumerable| enumerable != current_enumerable)
+            .enumerable
+            .is_some_and(|enumerable| enumerable != current_enumerable)
         {
             return false;
         }
@@ -898,7 +899,7 @@ fn ordinary_define_own_property_for_array(
             // i. If Desc has a [[Get]] field and SameValue(Desc.[[Get]], current.[[Get]]) is false,
             //    return false.
             if let Some(desc_get) = descriptor.get {
-                if current_getter.map_or(true, |current_getter| desc_get != current_getter) {
+                if current_getter != Some(desc_get) {
                     return false;
                 }
             }
@@ -906,7 +907,7 @@ fn ordinary_define_own_property_for_array(
             // ii. If Desc has a [[Set]] field and SameValue(Desc.[[Set]], current.[[Set]]) is
             //     false, return false.
             if let Some(desc_set) = descriptor.set {
-                if current_setter.map_or(true, |current_setter| desc_set != current_setter) {
+                if current_setter != Some(desc_set) {
                     return false;
                 }
             }

--- a/nova_vm/src/ecmascript/builtins/array.rs
+++ b/nova_vm/src/ecmascript/builtins/array.rs
@@ -862,11 +862,11 @@ fn ordinary_define_own_property_for_array(
     // If current descriptor doesn't exist, then its a default data descriptor
     // with WEC all true.
     let current_writable = current_descriptor.map_or(Some(true), |c| c.is_writable());
-    let current_enumerable = current_descriptor.map_or(true, |c| c.is_enumerable());
-    let current_configurable = current_descriptor.map_or(true, |c| c.is_configurable());
-    let current_is_data_descriptor = current_descriptor.map_or(false, |c| c.is_data_descriptor());
+    let current_enumerable = current_descriptor.is_none_or(|c| c.is_enumerable());
+    let current_configurable = current_descriptor.is_none_or(|c| c.is_configurable());
+    let current_is_data_descriptor = current_descriptor.is_some_and(|c| c.is_data_descriptor());
     let current_is_accessor_descriptor =
-        current_descriptor.map_or(false, |c| c.is_accessor_descriptor());
+        current_descriptor.is_some_and(|c| c.is_accessor_descriptor());
     let current_getter = current_descriptor.and_then(|c| c.getter_function(gc));
     let current_setter = current_descriptor.and_then(|c| c.setter_function(gc));
 
@@ -880,8 +880,7 @@ fn ordinary_define_own_property_for_array(
         // b. If Desc has an [[Enumerable]] field and SameValue(Desc.[[Enumerable]], current.[[Enumerable]])
         //    is false, return false.
         if descriptor
-            .enumerable
-            .map_or(false, |enumerable| enumerable != current_enumerable)
+            .enumerable.is_some_and(|enumerable| enumerable != current_enumerable)
         {
             return false;
         }
@@ -1070,5 +1069,5 @@ pub(crate) trait ArrayHeapIndexable<'a>:
     Index<Array<'a>, Output = ArrayHeapData> + AsRef<ElementArrays>
 {
 }
-impl<'a, 'b> ArrayHeapIndexable<'a> for ArrayHeap<'b> {}
-impl<'a> ArrayHeapIndexable<'a> for Agent {}
+impl ArrayHeapIndexable<'_> for ArrayHeap<'_> {}
+impl ArrayHeapIndexable<'_> for Agent {}

--- a/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
@@ -42,7 +42,7 @@ use super::ArgumentsList;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BuiltinConstructorFunction<'a>(pub(crate) BuiltinConstructorIndex<'a>);
 
-impl<'a> BuiltinConstructorFunction<'a> {
+impl BuiltinConstructorFunction<'_> {
     /// Unbind this BuiltinConstructorFunction from its current lifetime. This is necessary to use
     /// the BuiltinConstructorFunction as a parameter in a call that can perform garbage
     /// collection.

--- a/nova_vm/src/ecmascript/builtins/date.rs
+++ b/nova_vm/src/ecmascript/builtins/date.rs
@@ -29,7 +29,7 @@ use self::data::DateHeapData;
 #[repr(transparent)]
 pub struct Date<'a>(pub(crate) DateIndex<'a>);
 
-impl<'a> Date<'a> {
+impl Date<'_> {
     /// Unbind this Date from its current lifetime. This is necessary to use
     /// the Date as a parameter in a call that can perform garbage
     /// collection.

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -287,7 +287,7 @@ impl IndexMut<ECMAScriptFunction<'_>> for Vec<Option<ECMAScriptFunctionHeapData>
     }
 }
 
-impl<'a> ECMAScriptFunction<'a> {
+impl ECMAScriptFunction<'_> {
     /// Unbind this ECMAScriptFunction from its current lifetime. This is necessary to use
     /// the ECMAScriptFunction as a parameter in a call that can perform garbage
     /// collection.

--- a/nova_vm/src/ecmascript/builtins/finalization_registry.rs
+++ b/nova_vm/src/ecmascript/builtins/finalization_registry.rs
@@ -30,7 +30,7 @@ pub mod data;
 #[repr(transparent)]
 pub struct FinalizationRegistry<'a>(pub(crate) FinalizationRegistryIndex<'a>);
 
-impl<'a> FinalizationRegistry<'a> {
+impl FinalizationRegistry<'_> {
     /// Unbind this FinalizationRegistry from its current lifetime. This is necessary to use
     /// the FinalizationRegistry as a parameter in a call that can perform garbage
     /// collection.

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
@@ -3837,7 +3837,7 @@ fn flatten_into_array(
         // iii. Let shouldFlatten be false.
         let mut should_flatten = false;
         // iv. If depth > 0, then
-        if depth.map_or(true, |depth| depth > 0) {
+        if depth.is_none_or(|depth| depth > 0) {
             // 1. Set shouldFlatten to ? IsArray(element).
             should_flatten = is_array(agent, element, gc.nogc())?;
         }

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
@@ -3625,7 +3625,6 @@ impl ArrayPrototype {
 /// The abstract operation IsConcatSpreadable takes argument O (an ECMAScript
 /// language value) and returns either a normal completion containing a Boolean
 /// or a throw completion.
-
 fn is_concat_spreadable(agent: &mut Agent, o: Value, mut gc: GcScope) -> JsResult<bool> {
     // 1. If O is not an Object, return false.
     let Ok(o) = Object::try_from(o) else {

--- a/nova_vm/src/ecmascript/builtins/map.rs
+++ b/nova_vm/src/ecmascript/builtins/map.rs
@@ -30,7 +30,7 @@ pub mod data;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Map<'a>(pub(crate) MapIndex<'a>);
 
-impl<'a> Map<'a> {
+impl Map<'_> {
     /// Unbind this Map from its current lifetime. This is necessary to use
     /// the Map as a parameter in a call that can perform garbage
     /// collection.

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -617,9 +617,10 @@ impl<'a> InternalMethods<'a> for Module<'a> {
             PropertyKey::Symbol(_) => {
                 // 1. If P is a Symbol, then
                 // a. Return ! OrdinaryDelete(O, P).
-                TryResult::Continue(self.get_backing_object(agent).is_none_or(|object| {
-                    ordinary_delete(agent, object, property_key, gc)
-                }))
+                TryResult::Continue(
+                    self.get_backing_object(agent)
+                        .is_none_or(|object| ordinary_delete(agent, object, property_key, gc)),
+                )
             }
             PropertyKey::Integer(_) | PropertyKey::SmallString(_) | PropertyKey::String(_) => {
                 let p = match property_key {

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -300,7 +300,7 @@ impl<'a> InternalMethods<'a> for Module<'a> {
         match property_key {
             PropertyKey::Symbol(_) => {
                 // 1. If P is a Symbol, return ! OrdinaryDefineOwnProperty(O, P, Desc).
-                TryResult::Continue(self.get_backing_object(agent).map_or(false, |object| {
+                TryResult::Continue(self.get_backing_object(agent).is_some_and(|object| {
                     ordinary_define_own_property(
                         agent,
                         object,
@@ -428,7 +428,7 @@ impl<'a> InternalMethods<'a> for Module<'a> {
             }
             PropertyKey::Symbol(_) => {
                 // 1. If P is a Symbol, return ! OrdinaryHasProperty(O, P).
-                TryResult::Continue(self.get_backing_object(agent).map_or(false, |object| {
+                TryResult::Continue(self.get_backing_object(agent).is_some_and(|object| {
                     unwrap_try(ordinary_try_has_property(agent, object, property_key, gc))
                 }))
             }
@@ -617,7 +617,7 @@ impl<'a> InternalMethods<'a> for Module<'a> {
             PropertyKey::Symbol(_) => {
                 // 1. If P is a Symbol, then
                 // a. Return ! OrdinaryDelete(O, P).
-                TryResult::Continue(self.get_backing_object(agent).map_or(true, |object| {
+                TryResult::Continue(self.get_backing_object(agent).is_none_or(|object| {
                     ordinary_delete(agent, object, property_key, gc)
                 }))
             }

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/math_object.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/math_object.rs
@@ -973,11 +973,11 @@ impl MathObject {
         }
 
         // 7. Return an implementation-approximated Number value representing the square root of the sum of squares of the mathematical values of the elements of coerced.
-        return Ok(Value::from_f64(
+        Ok(Value::from_f64(
             agent,
             sum_of_squares.sqrt(),
             gc.into_nogc(),
-        ));
+        ))
     }
 
     fn imul(

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -567,7 +567,7 @@ pub(crate) enum PrimitiveObjectData {
     SmallBigInt(SmallBigInt) = SMALL_BIGINT_DISCRIMINANT,
 }
 
-impl<'a> TryFrom<PrimitiveObjectData> for BigInt<'a> {
+impl TryFrom<PrimitiveObjectData> for BigInt<'_> {
     type Error = ();
 
     fn try_from(value: PrimitiveObjectData) -> Result<Self, Self::Error> {

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -618,8 +618,7 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         if result_desc.configurable == Some(false) {
             // a. If targetDesc is undefined or targetDesc.[[Configurable]] is true, then
             if target_desc
-                .as_ref()
-                .map_or(true, |d| d.configurable == Some(true))
+                .as_ref().is_none_or(|d| d.configurable == Some(true))
             {
                 // i. Throw a TypeError exception.
                 return Err(agent.throw_exception(
@@ -1382,7 +1381,7 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
                 gc.reborrow(),
             )?;
             //  b. If desc is not undefined and desc.[[Configurable]] is false, then
-            if desc.map_or(false, |d| d.configurable == Some(false)) {
+            if desc.is_some_and(|d| d.configurable == Some(false)) {
                 // i. Append key to targetNonconfigurableKeys.
                 target_nonconfigurable_keys.push(key);
             } else {
@@ -1526,7 +1525,7 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         // 7. Let argArray be CreateArrayFromList(argumentsList).
         let arg_array = create_array_from_list(agent, &[arguments_list], gc.nogc());
         // 8. Return ? Call(trap, handler, « target, thisArgument, argArray »).
-        return call_function(
+        call_function(
             agent,
             trap.unbind(),
             handler.into_value(),
@@ -1536,7 +1535,7 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
                 arg_array.into_value(),
             ])),
             gc,
-        );
+        )
     }
 
     fn internal_construct<'gc>(

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -618,7 +618,8 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         if result_desc.configurable == Some(false) {
             // a. If targetDesc is undefined or targetDesc.[[Configurable]] is true, then
             if target_desc
-                .as_ref().is_none_or(|d| d.configurable == Some(true))
+                .as_ref()
+                .is_none_or(|d| d.configurable == Some(true))
             {
                 // i. Throw a TypeError exception.
                 return Err(agent.throw_exception(

--- a/nova_vm/src/ecmascript/builtins/typed_array.rs
+++ b/nova_vm/src/ecmascript/builtins/typed_array.rs
@@ -734,9 +734,10 @@ impl<'a> InternalMethods<'a> for TypedArray<'a> {
             TryResult::Continue(numeric_index.is_none())
         } else {
             // 2. Return ! OrdinaryDelete(O, P).
-            TryResult::Continue(self.get_backing_object(agent).is_none_or(|object| {
-                ordinary_delete(agent, object, property_key, gc)
-            }))
+            TryResult::Continue(
+                self.get_backing_object(agent)
+                    .is_none_or(|object| ordinary_delete(agent, object, property_key, gc)),
+            )
         }
     }
 

--- a/nova_vm/src/ecmascript/builtins/typed_array.rs
+++ b/nova_vm/src/ecmascript/builtins/typed_array.rs
@@ -734,7 +734,7 @@ impl<'a> InternalMethods<'a> for TypedArray<'a> {
             TryResult::Continue(numeric_index.is_none())
         } else {
             // 2. Return ! OrdinaryDelete(O, P).
-            TryResult::Continue(self.get_backing_object(agent).map_or(true, |object| {
+            TryResult::Continue(self.get_backing_object(agent).is_none_or(|object| {
                 ordinary_delete(agent, object, property_key, gc)
             }))
         }

--- a/nova_vm/src/ecmascript/types/language/object/property_key.rs
+++ b/nova_vm/src/ecmascript/types/language/object/property_key.rs
@@ -239,7 +239,7 @@ pub(crate) struct DisplayablePropertyKey<'a, 'b, 'c> {
     agent: &'c Agent,
 }
 
-impl<'a, 'b, 'c> core::fmt::Display for DisplayablePropertyKey<'a, 'b, 'c> {
+impl core::fmt::Display for DisplayablePropertyKey<'_, '_, '_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self.key {
             PropertyKey::Integer(data) => data.into_i64().fmt(f),

--- a/nova_vm/src/ecmascript/types/language/primitive.rs
+++ b/nova_vm/src/ecmascript/types/language/primitive.rs
@@ -136,7 +136,7 @@ impl TryFrom<Value> for HeapPrimitive {
     }
 }
 
-impl<'a> IntoValue for Primitive<'a> {
+impl IntoValue for Primitive<'_> {
     fn into_value(self) -> super::Value {
         match self {
             Primitive::Undefined => Value::Undefined,

--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -302,8 +302,7 @@ impl<'a> String<'a> {
 
     pub const fn from_small_string(message: &'static str) -> String<'static> {
         assert!(
-            message.len() < 8
-                && (message.is_empty() || message.as_bytes()[message.len() - 1] != 0)
+            message.len() < 8 && (message.is_empty() || message.as_bytes()[message.len() - 1] != 0)
         );
         String::SmallString(SmallString::from_str_unchecked(message))
     }

--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -303,7 +303,7 @@ impl<'a> String<'a> {
     pub const fn from_small_string(message: &'static str) -> String<'static> {
         assert!(
             message.len() < 8
-                && (message.is_empty() || message.as_bytes()[message.as_bytes().len() - 1] != 0)
+                && (message.is_empty() || message.as_bytes()[message.len() - 1] != 0)
         );
         String::SmallString(SmallString::from_str_unchecked(message))
     }

--- a/nova_vm/src/heap/element_array.rs
+++ b/nova_vm/src/heap/element_array.rs
@@ -135,7 +135,7 @@ impl ElementsVector {
     /// An elements vector is simple if it contains no accessor descriptors.
     pub(crate) fn is_simple(&self, arena: &impl AsRef<ElementArrays>) -> bool {
         let backing_store = arena.as_ref().get_descriptors_and_slice(*self);
-        backing_store.0.map_or(true, |hashmap| {
+        backing_store.0.is_none_or(|hashmap| {
             !hashmap
                 .iter()
                 .any(|desc| desc.1.has_getter() || desc.1.has_setter())

--- a/nova_vm/src/heap/indexes.rs
+++ b/nova_vm/src/heap/indexes.rs
@@ -68,48 +68,48 @@ pub(crate) trait GetBaseIndexMut<'a, T: ?Sized> {
     fn get_base_index_mut(&mut self) -> &mut BaseIndex<'a, T>;
 }
 
-impl<'a, T: ?Sized> Debug for BaseIndex<'a, T> {
+impl<T: ?Sized> Debug for BaseIndex<'_, T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         assert!(self.0.get() != 0);
         (&self.0.get() - 1).fmt(f)
     }
 }
 
-impl<'a, T: ?Sized> Clone for BaseIndex<'a, T> {
+impl<T: ?Sized> Clone for BaseIndex<'_, T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, T: ?Sized> Copy for BaseIndex<'a, T> {}
+impl<T: ?Sized> Copy for BaseIndex<'_, T> {}
 
-impl<'a, T: ?Sized> PartialEq for BaseIndex<'a, T> {
+impl<T: ?Sized> PartialEq for BaseIndex<'_, T> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
 }
 
-impl<'a, T: ?Sized> Eq for BaseIndex<'a, T> {}
+impl<T: ?Sized> Eq for BaseIndex<'_, T> {}
 
-impl<'a, T: ?Sized> PartialOrd for BaseIndex<'a, T> {
+impl<T: ?Sized> PartialOrd for BaseIndex<'_, T> {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<'a, T: ?Sized> Ord for BaseIndex<'a, T> {
+impl<T: ?Sized> Ord for BaseIndex<'_, T> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.0.cmp(&other.0)
     }
 }
 
-impl<'a, T: ?Sized> Hash for BaseIndex<'a, T> {
+impl<T: ?Sized> Hash for BaseIndex<'_, T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.hash(state);
     }
 }
 
-impl<'a, T: ?Sized> BaseIndex<'a, T> {
+impl<T: ?Sized> BaseIndex<'_, T> {
     pub const fn into_index(self) -> usize {
         self.0.get() as usize - 1
     }
@@ -181,7 +181,7 @@ impl<'a, T: ?Sized> BaseIndex<'a, T> {
     }
 }
 
-impl<'a, T> Default for BaseIndex<'a, T> {
+impl<T> Default for BaseIndex<'_, T> {
     fn default() -> Self {
         Self::from_u32_index(0)
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]

--- a/tests/expectations.json
+++ b/tests/expectations.json
@@ -21930,7 +21930,6 @@
   "staging/sm/String/split-GetMethod.js": "FAIL",
   "staging/sm/String/split-xregexp.js": "FAIL",
   "staging/sm/String/split.js": "CRASH",
-  "staging/sm/String/string-code-point-upper-lower-mapping.js": "CRASH",
   "staging/sm/String/string-upper-lower-mapping.js": "CRASH",
   "staging/sm/String/thisv-error.js": "CRASH",
   "staging/sm/String/unicode-braced.js": "CRASH",

--- a/tests/metrics.json
+++ b/tests/metrics.json
@@ -1,8 +1,8 @@
 {
   "results": {
-    "crash": 13225,
-    "fail": 8869,
-    "pass": 24642,
+    "crash": 13216,
+    "fail": 8877,
+    "pass": 24643,
     "skip": 65,
     "timeout": 0,
     "unresolved": 0


### PR DESCRIPTION
CI is running Rust 1.85, but the rust-toolchain file in Nova was set to 1.81.
As a result, the following error occurs in CI.

```
error: failed to parse manifest at `/home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/munge_macro-0.4.2/Cargo.toml`
Caused by:
  feature `edition2024` is required
  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.81.0 (2dbb1af80 2024-08-20)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
Error: Process completed with exit code 101.
```

In this PR, I unified the Cargo version used in Nova to 1.85 and ran `cargo clippy --fix` along with some manual fixes.
Alternatively, aligning the CI version with the rust-toolchain version could also be a solution.
