### PR TITLE
feat(linter): Create `nova_lint` and implement three basic rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy, llvm-tools-preview, rustc-dev
       - name: Install Dylint
         run: cargo install cargo-dylint dylint-link
       - name: Spell check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: nightly-2024-11-28
           components: rustfmt, clippy, llvm-tools-preview, rustc-dev
       - name: Install Dylint
         run: cargo install cargo-dylint dylint-link

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: cargo fmt --check
       - name: Clippy
         run: >
-          cargo +nightly clippy --all-targets --all-features
+          cargo +nightly-2024-11-28 clippy --all-targets --all-features
           -- -D warnings
       - name: Dylint tests
         working-directory: nova_lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,29 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        run: rustup update nightly
+      - name: Install Dylint
+        run: cargo install cargo-dylint dylint-link
+      - name: Spell check
+        uses: crate-ci/typos@master
+      - name: Check formatting
+        run: cargo fmt --check
+      - name: Clippy
+        run: >
+          cargo clippy --all-targets --all-features
+          -- -D warnings
+      - name: Dylint tests
+        working-directory: nova_lint
+        run: cargo test
+      - name: Dylint
+        run: cargo dylint --all
+
   build:
     name: Build
     # TODO: Run CI on all three platforms.
@@ -21,15 +44,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: rustup update stable
-      - name: Check formatting
-        run: cargo fmt --check
-      - name: Clippy
-        run: >
-          cargo clippy --all-targets
-          --features default,annex-b,interleaved-gc,typescript
-          -- -D warnings
-      - name: Spell check
-        uses: crate-ci/typos@master
       - name: Build
         run: cargo build
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: cargo fmt --check
       - name: Clippy
         run: |
-          cargo +stable --all-targets
+          cargo +stable clippy --all-targets -- -D warnings
           cargo +nightly-2024-11-28 clippy --all-targets --all-features -- -D warnings
       - name: Dylint tests
         working-directory: nova_lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: cargo fmt --check
       - name: Clippy
         run: >
-          cargo clippy --all-targets --all-features
+          cargo +nightly clippy --all-targets --all-features
           -- -D warnings
       - name: Dylint tests
         working-directory: nova_lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
-        run: rustup update nightly
+        uses: dtolnay/rust-toolchain@nightly
       - name: Install Dylint
         run: cargo install cargo-dylint dylint-link
       - name: Spell check
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
-        run: rustup update stable
+        uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: cargo build
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
       - name: Clippy
-        run: >
-          cargo +nightly-2024-11-28 clippy --all-targets --all-features
-          -- -D warnings
+        run: |
+          cargo +stable --all-targets
+          cargo +nightly-2024-11-28 clippy --all-targets --all-features -- -D warnings
       - name: Dylint tests
         working-directory: nova_lint
         run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = ["nova_cli", "nova_vm", "small_string", "tests"]
+exclude = ["nova_lint"]
 
 [workspace.package]
 edition = "2021"
@@ -45,6 +46,9 @@ sonic-rs = "0.3.17"
 unicode-normalization = "0.1.24"
 wtf8 = "0.1"
 fast_float = "0.2.0"
+
+[workspace.metadata.dylint]
+libraries = [{ path = "nova_lint" }]
 
 [profile.release]
 lto = true

--- a/nova_lint/.cargo/config.toml
+++ b/nova_lint/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(all())']
+rustflags = ["-C", "linker=dylint-link"]

--- a/nova_lint/Cargo.toml
+++ b/nova_lint/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "nova_lint"
+repository = "https://github.com/trynova/nova/tree/main/nova_lint"
+description = "A collection of custom lints to ease the development and maintenance of the Nova project."
+edition = "2021"
+version = "0.1.0"
+license = "MPL-2.0"
+homepage = "https://trynova.dev"
+authors = ["The Nova Team"]
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[[example]]
+name = "agent_comes_first"
+path = "ui/agent_comes_first.rs"
+
+[dependencies]
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "ff4a26d442bead94a4c96fb1de967374bc4fbd8e" }
+dylint_linting = "4.0.0"
+
+[dev-dependencies]
+dylint_testing = "4.0.0"
+nova_vm = { path = "../nova_vm" }
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/nova_lint/Cargo.toml
+++ b/nova_lint/Cargo.toml
@@ -20,6 +20,10 @@ path = "ui/agent_comes_first.rs"
 name = "gc_scope_comes_last"
 path = "ui/gc_scope_comes_last.rs"
 
+[[example]]
+name = "gc_scope_is_only_passed_by_value"
+path = "ui/gc_scope_is_only_passed_by_value.rs"
+
 [dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "ff4a26d442bead94a4c96fb1de967374bc4fbd8e" }
 dylint_linting = { version = "4.0.0", features = ["constituent"] }

--- a/nova_lint/Cargo.toml
+++ b/nova_lint/Cargo.toml
@@ -16,9 +16,13 @@ crate-type = ["cdylib"]
 name = "agent_comes_first"
 path = "ui/agent_comes_first.rs"
 
+[[example]]
+name = "gc_scope_comes_last"
+path = "ui/gc_scope_comes_last.rs"
+
 [dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "ff4a26d442bead94a4c96fb1de967374bc4fbd8e" }
-dylint_linting = "4.0.0"
+dylint_linting = { version = "4.0.0", features = ["constituent"] }
 
 [dev-dependencies]
 dylint_testing = "4.0.0"

--- a/nova_lint/README.md
+++ b/nova_lint/README.md
@@ -1,0 +1,21 @@
+# Linting
+
+This is an additional set of linter rules specific for the Nova engine and any
+applications which may be built on top of it. This ensures we conform to our
+conventions, best practices and most importantly the requirements of the engine,
+more specifically the garbage collector.
+
+For this we use [dylint](https://github.com/trailofbits/dylint) which is a tool
+that allows us to write custom lints for our codebase. It is designed to be used
+along side [Clippy](https://doc.rust-lang.org/stable/clippy/index.html).
+
+## Usage
+
+1. Install `cargo-dylint` and `dylint-link`:
+  ```bash
+  cargo install cargo-dylint dylint-link
+  ```
+2. Run the linter in the root of the project:
+  ```bash
+  cargo dylint --all
+  ```

--- a/nova_lint/rust-toolchain.toml
+++ b/nova_lint/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2024-11-28"
+components = ["llvm-tools-preview", "rustc-dev"]

--- a/nova_lint/src/agent_comes_first.rs
+++ b/nova_lint/src/agent_comes_first.rs
@@ -1,8 +1,5 @@
 use clippy_utils::{diagnostics::span_lint_and_help, is_self, match_def_path};
-use rustc_hir::{
-    def_id::LocalDefId,
-    intravisit::FnKind, Body, FnDecl,
-};
+use rustc_hir::{def_id::LocalDefId, intravisit::FnKind, Body, FnDecl};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{Ty, TyKind};
 use rustc_span::Span;

--- a/nova_lint/src/agent_comes_first.rs
+++ b/nova_lint/src/agent_comes_first.rs
@@ -1,8 +1,9 @@
-use clippy_utils::{diagnostics::span_lint_and_help, is_self, match_def_path};
+use clippy_utils::{diagnostics::span_lint_and_help, is_self};
 use rustc_hir::{def_id::LocalDefId, intravisit::FnKind, Body, FnDecl};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_middle::ty::{Ty, TyKind};
 use rustc_span::Span;
+
+use crate::{is_agent_ty, is_param_ty};
 
 dylint_linting::declare_late_lint! {
     /// ### What it does
@@ -73,20 +74,5 @@ impl<'tcx> LateLintPass<'tcx> for AgentComesFirst {
                 );
             }
         }
-    }
-}
-
-fn is_param_ty(ty: &Ty) -> bool {
-    matches!(ty.kind(), TyKind::Param(_))
-}
-
-fn is_agent_ty(cx: &LateContext<'_>, ty: &Ty) -> bool {
-    match ty.peel_refs().kind() {
-        TyKind::Adt(def, _) => match_def_path(
-            cx,
-            def.did(),
-            &["nova_vm", "ecmascript", "execution", "agent", "Agent"],
-        ),
-        _ => false,
     }
 }

--- a/nova_lint/src/agent_comes_first.rs
+++ b/nova_lint/src/agent_comes_first.rs
@@ -1,0 +1,96 @@
+use clippy_utils::{diagnostics::span_lint_and_help, is_self, match_def_path};
+use rustc_hir::{
+    def_id::LocalDefId,
+    intravisit::FnKind, Body, FnDecl,
+};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::{Ty, TyKind};
+use rustc_span::Span;
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Checks that the `nova_vm::ecmascript::execution::agent::Agent` is the first parameter of a function.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The `nova_vm::ecmascript::execution::agent::Agent` is expected to be
+    /// the first parameter of a function according to the Nova engines conventions.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// fn foo(other: &Other, agent: &Agent) {}
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```rust
+    /// fn bar(agent: &Agent, other: &Other) {}
+    /// ```
+    pub AGENT_COMES_FIRST,
+    Warn,
+    "the `nova_vm::ecmascript::execution::agent::Agent` should be the first parameter of any function using it"
+}
+
+impl<'tcx> LateLintPass<'tcx> for AgentComesFirst {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _: FnKind<'tcx>,
+        _: &'tcx FnDecl<'tcx>,
+        body: &'tcx Body<'tcx>,
+        span: Span,
+        _: LocalDefId,
+    ) {
+        if span.from_expansion() {
+            return;
+        }
+
+        for param in body
+            .params
+            .iter()
+            // Skip while the first parameter is `self`, a param type or an agent
+            .skip_while(|param| {
+                if is_self(param) {
+                    true
+                } else {
+                    let ty = cx.typeck_results().pat_ty(param.pat);
+                    is_param_ty(&ty) || is_agent_ty(cx, &ty)
+                }
+            })
+            // We hit the first parameter that is not `self`, a param type or
+            // an agent, so we can safely skip it without worrying about it
+            // being an agent
+            .skip(1)
+        {
+            let ty = cx.typeck_results().pat_ty(param.pat);
+            if is_agent_ty(cx, &ty) {
+                span_lint_and_help(
+                    cx,
+                    AGENT_COMES_FIRST,
+                    param.span,
+                    "the `nova_vm::ecmascript::execution::agent::Agent` should be the first parameter of any function using it",
+                    None,
+                    "consider moving the `nova_vm::ecmascript::execution::agent::Agent` to the first parameter",
+                );
+            }
+        }
+    }
+}
+
+fn is_param_ty(ty: &Ty) -> bool {
+    matches!(ty.kind(), TyKind::Param(_))
+}
+
+fn is_agent_ty(cx: &LateContext<'_>, ty: &Ty) -> bool {
+    match ty.kind() {
+        TyKind::Adt(def, _) => match_def_path(
+            cx,
+            def.did(),
+            &["nova_vm", "ecmascript", "execution", "agent", "Agent"],
+        ),
+        TyKind::Ref(_, ty, _) => is_agent_ty(cx, ty),
+        _ => false,
+    }
+}

--- a/nova_lint/src/agent_comes_first.rs
+++ b/nova_lint/src/agent_comes_first.rs
@@ -84,13 +84,12 @@ fn is_param_ty(ty: &Ty) -> bool {
 }
 
 fn is_agent_ty(cx: &LateContext<'_>, ty: &Ty) -> bool {
-    match ty.kind() {
+    match ty.peel_refs().kind() {
         TyKind::Adt(def, _) => match_def_path(
             cx,
             def.did(),
             &["nova_vm", "ecmascript", "execution", "agent", "Agent"],
         ),
-        TyKind::Ref(_, ty, _) => is_agent_ty(cx, ty),
         _ => false,
     }
 }

--- a/nova_lint/src/gc_scope_comes_last.rs
+++ b/nova_lint/src/gc_scope_comes_last.rs
@@ -1,8 +1,9 @@
-use clippy_utils::{diagnostics::span_lint_and_help, match_def_path};
+use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir::{def_id::LocalDefId, intravisit::FnKind, Body, FnDecl};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_middle::ty::{Ty, TyKind};
 use rustc_span::Span;
+
+use crate::{is_gc_scope_ty, is_no_gc_scope_ty};
 
 dylint_linting::declare_late_lint! {
     /// ### What it does
@@ -11,19 +12,29 @@ dylint_linting::declare_late_lint! {
     ///
     /// ### Why is this bad?
     ///
-    /// The gc scope is expected to be the last parameter of a function
-    /// according to the Nova engines conventions.
-    ///
+    /// The gc scope parameter should be passed as the last parameter of a
+    /// function because it invalidates all values which refer to it, take
+    /// for example the following code:
+    /// 
+    /// ```rust
+    /// let data = data.bind(gc.nogc());
+    /// call(agent, gc.reborrow(), data.unbind());
+    /// ```
+    /// 
+    /// This wouldn't work beause `gc.reborrow()` invalidates data immediately,
+    /// meaning that when `data.unbind()` is being called the data is already
+    /// invalidated and illegal to use, leading to a borrow checker error.
+    /// 
     /// ### Example
     ///
     /// ```rust
-    /// fn bar(gc: &GcScope<'_, '_>, other: &Other) {}
+    /// fn bar(gc: GcScope<'_, '_>, other: &Other) {}
     /// ```
     ///
     /// Use instead:
     ///
     /// ```rust
-    /// fn foo(other: &Other, gc: &GcScope<'_, '_>) {}
+    /// fn foo(other: &Other, gc: GcScope<'_, '_>) {}
     /// ```
     pub GC_SCOPE_COMES_LAST,
     Warn,
@@ -51,14 +62,14 @@ impl<'tcx> LateLintPass<'tcx> for GcScopeComesLast {
             // Skip while the last parameter is the gc scope
             .skip_while(|param| {
                 let ty = cx.typeck_results().pat_ty(param.pat);
-                is_gc_scope(cx, &ty) || is_no_gc_scope(cx, &ty)
+                is_gc_scope_ty(cx, &ty) || is_no_gc_scope_ty(cx, &ty)
             })
             // We hit the first parameter that is not a gc scope, so we can
             // safely skip it without worrying about it being a gc scope
             .skip(1)
         {
             let ty = cx.typeck_results().pat_ty(param.pat);
-            if is_gc_scope(cx, &ty) || is_no_gc_scope(cx, &ty) {
+            if is_gc_scope_ty(cx, &ty) || is_no_gc_scope_ty(cx, &ty) {
                 span_lint_and_help(
                     cx,
                     GC_SCOPE_COMES_LAST,
@@ -69,25 +80,5 @@ impl<'tcx> LateLintPass<'tcx> for GcScopeComesLast {
                 );
             }
         }
-    }
-}
-
-fn is_gc_scope(cx: &LateContext<'_>, ty: &Ty) -> bool {
-    match ty.peel_refs().kind() {
-        TyKind::Adt(def, _) => {
-            match_def_path(cx, def.did(), &["nova_vm", "engine", "context", "GcScope"])
-        }
-        _ => false,
-    }
-}
-
-fn is_no_gc_scope(cx: &LateContext<'_>, ty: &Ty) -> bool {
-    match ty.peel_refs().kind() {
-        TyKind::Adt(def, _) => match_def_path(
-            cx,
-            def.did(),
-            &["nova_vm", "engine", "context", "NoGcScope"],
-        ),
-        _ => false,
     }
 }

--- a/nova_lint/src/gc_scope_comes_last.rs
+++ b/nova_lint/src/gc_scope_comes_last.rs
@@ -21,7 +21,7 @@ dylint_linting::declare_late_lint! {
     /// call(agent, gc.reborrow(), data.unbind());
     /// ```
     ///
-    /// This wouldn't work beause `gc.reborrow()` invalidates `data` immediately,
+    /// This wouldn't work because `gc.reborrow()` invalidates `data` immediately,
     /// meaning that when `data.unbind()` is being called the `data` is already
     /// invalidated and illegal to use, leading to a borrow checker error.
     ///

--- a/nova_lint/src/gc_scope_comes_last.rs
+++ b/nova_lint/src/gc_scope_comes_last.rs
@@ -15,16 +15,16 @@ dylint_linting::declare_late_lint! {
     /// The gc scope parameter should be passed as the last parameter of a
     /// function because it invalidates all values which refer to it, take
     /// for example the following code:
-    /// 
+    ///
     /// ```rust
     /// let data = data.bind(gc.nogc());
     /// call(agent, gc.reborrow(), data.unbind());
     /// ```
-    /// 
-    /// This wouldn't work beause `gc.reborrow()` invalidates data immediately,
-    /// meaning that when `data.unbind()` is being called the data is already
+    ///
+    /// This wouldn't work beause `gc.reborrow()` invalidates `data` immediately,
+    /// meaning that when `data.unbind()` is being called the `data` is already
     /// invalidated and illegal to use, leading to a borrow checker error.
-    /// 
+    ///
     /// ### Example
     ///
     /// ```rust

--- a/nova_lint/src/gc_scope_comes_last.rs
+++ b/nova_lint/src/gc_scope_comes_last.rs
@@ -1,0 +1,93 @@
+use clippy_utils::{diagnostics::span_lint_and_help, match_def_path};
+use rustc_hir::{def_id::LocalDefId, intravisit::FnKind, Body, FnDecl};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::{Ty, TyKind};
+use rustc_span::Span;
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Checks that the gc scope is the last parameter of a function.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The gc scope is expected to be the last parameter of a function
+    /// according to the Nova engines conventions.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// fn bar(gc: &GcScope<'_, '_>, other: &Other) {}
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```rust
+    /// fn foo(other: &Other, gc: &GcScope<'_, '_>) {}
+    /// ```
+    pub GC_SCOPE_COMES_LAST,
+    Warn,
+    "the gc scope should be the last parameter of any function using it"
+}
+
+impl<'tcx> LateLintPass<'tcx> for GcScopeComesLast {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _: FnKind<'tcx>,
+        _: &'tcx FnDecl<'tcx>,
+        body: &'tcx Body<'tcx>,
+        span: Span,
+        _: LocalDefId,
+    ) {
+        if span.from_expansion() {
+            return;
+        }
+
+        for param in body
+            .params
+            .iter()
+            .rev()
+            // Skip while the last parameter is the gc scope
+            .skip_while(|param| {
+                let ty = cx.typeck_results().pat_ty(param.pat);
+                is_gc_scope(cx, &ty) || is_no_gc_scope(cx, &ty)
+            })
+            // We hit the first parameter that is not a gc scope, so we can
+            // safely skip it without worrying about it being a gc scope
+            .skip(1)
+        {
+            let ty = cx.typeck_results().pat_ty(param.pat);
+            if is_gc_scope(cx, &ty) || is_no_gc_scope(cx, &ty) {
+                span_lint_and_help(
+                    cx,
+                    GC_SCOPE_COMES_LAST,
+                    param.span,
+                    "the gc scope should be the last parameter of any function using it",
+                    None,
+                    "consider moving the gc scope to the last parameter",
+                );
+            }
+        }
+    }
+}
+
+fn is_gc_scope(cx: &LateContext<'_>, ty: &Ty) -> bool {
+    match ty.peel_refs().kind() {
+        TyKind::Adt(def, _) => {
+            match_def_path(cx, def.did(), &["nova_vm", "engine", "context", "GcScope"])
+        }
+        _ => false,
+    }
+}
+
+fn is_no_gc_scope(cx: &LateContext<'_>, ty: &Ty) -> bool {
+    match ty.peel_refs().kind() {
+        TyKind::Adt(def, _) => match_def_path(
+            cx,
+            def.did(),
+            &["nova_vm", "engine", "context", "NoGcScope"],
+        ),
+        _ => false,
+    }
+}

--- a/nova_lint/src/gc_scope_is_only_passed_by_value.rs
+++ b/nova_lint/src/gc_scope_is_only_passed_by_value.rs
@@ -1,0 +1,65 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_hir::{def_id::LocalDefId, intravisit::FnKind, Body, FnDecl};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::TyKind;
+use rustc_span::Span;
+
+use crate::{is_gc_scope_ty, is_no_gc_scope_ty};
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Checks that the gc scope is only passed by value.
+    ///
+    /// ### Why is this bad?
+    ///
+    ///
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// fn bar(gc: &GcScope<'_, '_>) {}
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```rust
+    /// fn bar(gc: GcScope<'_, '_>) {}
+    /// ```
+    pub GC_SCOPE_IS_ONLY_PASSED_BY_VALUE,
+    Deny,
+    "the gc scope should only be passed by value"
+}
+
+impl<'tcx> LateLintPass<'tcx> for GcScopeIsOnlyPassedByValue {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _: FnKind<'tcx>,
+        _: &'tcx FnDecl<'tcx>,
+        body: &'tcx Body<'tcx>,
+        span: Span,
+        _: LocalDefId,
+    ) {
+        if span.from_expansion() {
+            return;
+        }
+
+        for param in body.params {
+            let ty = cx.typeck_results().pat_ty(param.pat);
+            if let TyKind::Ref(_, ty, _) = ty.kind() {
+                ty.peel_refs();
+                if is_gc_scope_ty(cx, ty) || is_no_gc_scope_ty(cx, ty) {
+                    span_lint_and_help(
+                        cx,
+                        GC_SCOPE_IS_ONLY_PASSED_BY_VALUE,
+                        param.ty_span,
+                        "gc scope should only be passed by value",
+                        None,
+                        "remove the reference",
+                    );
+                }
+            }
+        }
+    }
+}

--- a/nova_lint/src/gc_scope_is_only_passed_by_value.rs
+++ b/nova_lint/src/gc_scope_is_only_passed_by_value.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::{diagnostics::span_lint_and_help, is_self};
 use rustc_hir::{def_id::LocalDefId, intravisit::FnKind, Body, FnDecl};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::TyKind;
@@ -61,6 +61,10 @@ impl<'tcx> LateLintPass<'tcx> for GcScopeIsOnlyPassedByValue {
         }
 
         for param in body.params {
+            if is_self(param) {
+                continue;
+            }
+
             let ty = cx.typeck_results().pat_ty(param.pat);
             if let TyKind::Ref(_, ty, _) = ty.kind() {
                 ty.peel_refs();

--- a/nova_lint/src/gc_scope_is_only_passed_by_value.rs
+++ b/nova_lint/src/gc_scope_is_only_passed_by_value.rs
@@ -13,12 +13,27 @@ dylint_linting::declare_late_lint! {
     ///
     /// ### Why is this bad?
     ///
-    ///
+    /// Passing the gc scope by reference is not necessary and should be avoided.
+    /// This is because a immutable reference `&GcScope` would be equivalent to
+    /// simply using `NoGcScope` while using `&mut GcScope` would technically
+    /// work but be less efficient.
     ///
     /// ### Example
     ///
     /// ```rust
     /// fn bar(gc: &GcScope<'_, '_>) {}
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```rust
+    /// fn bar(gc: NoGcScope<'_, '_>) {}
+    /// ```
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// fn bar(gc: &mut GcScope<'_, '_>) {}
     /// ```
     ///
     /// Use instead:

--- a/nova_lint/src/lib.rs
+++ b/nova_lint/src/lib.rs
@@ -1,6 +1,8 @@
 #![feature(rustc_private)]
 #![allow(unused_extern_crates)]
 
+dylint_linting::dylint_library!();
+
 extern crate rustc_arena;
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
@@ -15,11 +17,19 @@ extern crate rustc_lint;
 extern crate rustc_middle;
 extern crate rustc_mir_dataflow;
 extern crate rustc_parse;
+extern crate rustc_session;
 extern crate rustc_span;
 extern crate rustc_target;
 extern crate rustc_trait_selection;
 
 mod agent_comes_first;
+mod gc_scope_comes_last;
+
+#[no_mangle]
+pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint::LintStore) {
+    agent_comes_first::register_lints(sess, lint_store);
+    gc_scope_comes_last::register_lints(sess, lint_store);
+}
 
 #[test]
 fn ui_examples() {

--- a/nova_lint/src/lib.rs
+++ b/nova_lint/src/lib.rs
@@ -1,0 +1,27 @@
+#![feature(rustc_private)]
+#![allow(unused_extern_crates)]
+
+extern crate rustc_arena;
+extern crate rustc_ast;
+extern crate rustc_ast_pretty;
+extern crate rustc_data_structures;
+extern crate rustc_errors;
+extern crate rustc_hir;
+extern crate rustc_hir_pretty;
+extern crate rustc_index;
+extern crate rustc_infer;
+extern crate rustc_lexer;
+extern crate rustc_lint;
+extern crate rustc_middle;
+extern crate rustc_mir_dataflow;
+extern crate rustc_parse;
+extern crate rustc_span;
+extern crate rustc_target;
+extern crate rustc_trait_selection;
+
+mod agent_comes_first;
+
+#[test]
+fn ui_examples() {
+    dylint_testing::ui_test_examples(env!("CARGO_PKG_NAME"));
+}

--- a/nova_lint/src/lib.rs
+++ b/nova_lint/src/lib.rs
@@ -22,8 +22,11 @@ extern crate rustc_span;
 extern crate rustc_target;
 extern crate rustc_trait_selection;
 
+mod utils;
 mod agent_comes_first;
 mod gc_scope_comes_last;
+
+pub(crate) use utils::*;
 
 #[no_mangle]
 pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint::LintStore) {

--- a/nova_lint/src/lib.rs
+++ b/nova_lint/src/lib.rs
@@ -22,9 +22,10 @@ extern crate rustc_span;
 extern crate rustc_target;
 extern crate rustc_trait_selection;
 
-mod utils;
 mod agent_comes_first;
 mod gc_scope_comes_last;
+mod gc_scope_is_only_passed_by_value;
+mod utils;
 
 pub(crate) use utils::*;
 
@@ -32,6 +33,7 @@ pub(crate) use utils::*;
 pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint::LintStore) {
     agent_comes_first::register_lints(sess, lint_store);
     gc_scope_comes_last::register_lints(sess, lint_store);
+    gc_scope_is_only_passed_by_value::register_lints(sess, lint_store);
 }
 
 #[test]

--- a/nova_lint/src/utils.rs
+++ b/nova_lint/src/utils.rs
@@ -1,0 +1,38 @@
+use clippy_utils::match_def_path;
+use rustc_lint::LateContext;
+use rustc_middle::ty::{Ty, TyKind};
+
+pub fn is_param_ty(ty: &Ty) -> bool {
+  matches!(ty.kind(), TyKind::Param(_))
+}
+
+pub fn is_agent_ty(cx: &LateContext<'_>, ty: &Ty) -> bool {
+  match ty.peel_refs().kind() {
+      TyKind::Adt(def, _) => match_def_path(
+          cx,
+          def.did(),
+          &["nova_vm", "ecmascript", "execution", "agent", "Agent"],
+      ),
+      _ => false,
+  }
+}
+
+pub fn is_gc_scope_ty(cx: &LateContext<'_>, ty: &Ty) -> bool {
+  match ty.kind() {
+      TyKind::Adt(def, _) => {
+          match_def_path(cx, def.did(), &["nova_vm", "engine", "context", "GcScope"])
+      }
+      _ => false,
+  }
+}
+
+pub fn is_no_gc_scope_ty(cx: &LateContext<'_>, ty: &Ty) -> bool {
+  match ty.kind() {
+      TyKind::Adt(def, _) => match_def_path(
+          cx,
+          def.did(),
+          &["nova_vm", "engine", "context", "NoGcScope"],
+      ),
+      _ => false,
+  }
+}

--- a/nova_lint/src/utils.rs
+++ b/nova_lint/src/utils.rs
@@ -3,36 +3,36 @@ use rustc_lint::LateContext;
 use rustc_middle::ty::{Ty, TyKind};
 
 pub fn is_param_ty(ty: &Ty) -> bool {
-  matches!(ty.kind(), TyKind::Param(_))
+    matches!(ty.kind(), TyKind::Param(_))
 }
 
 pub fn is_agent_ty(cx: &LateContext<'_>, ty: &Ty) -> bool {
-  match ty.peel_refs().kind() {
-      TyKind::Adt(def, _) => match_def_path(
-          cx,
-          def.did(),
-          &["nova_vm", "ecmascript", "execution", "agent", "Agent"],
-      ),
-      _ => false,
-  }
+    match ty.peel_refs().kind() {
+        TyKind::Adt(def, _) => match_def_path(
+            cx,
+            def.did(),
+            &["nova_vm", "ecmascript", "execution", "agent", "Agent"],
+        ),
+        _ => false,
+    }
 }
 
 pub fn is_gc_scope_ty(cx: &LateContext<'_>, ty: &Ty) -> bool {
-  match ty.kind() {
-      TyKind::Adt(def, _) => {
-          match_def_path(cx, def.did(), &["nova_vm", "engine", "context", "GcScope"])
-      }
-      _ => false,
-  }
+    match ty.kind() {
+        TyKind::Adt(def, _) => {
+            match_def_path(cx, def.did(), &["nova_vm", "engine", "context", "GcScope"])
+        }
+        _ => false,
+    }
 }
 
 pub fn is_no_gc_scope_ty(cx: &LateContext<'_>, ty: &Ty) -> bool {
-  match ty.kind() {
-      TyKind::Adt(def, _) => match_def_path(
-          cx,
-          def.did(),
-          &["nova_vm", "engine", "context", "NoGcScope"],
-      ),
-      _ => false,
-  }
+    match ty.kind() {
+        TyKind::Adt(def, _) => match_def_path(
+            cx,
+            def.did(),
+            &["nova_vm", "engine", "context", "NoGcScope"],
+        ),
+        _ => false,
+    }
 }

--- a/nova_lint/ui/agent_comes_first.rs
+++ b/nova_lint/ui/agent_comes_first.rs
@@ -1,0 +1,85 @@
+#![allow(dead_code, unused_variables, clippy::disallowed_names)]
+
+type Agent = nova_vm::ecmascript::execution::agent::Agent;
+type GcScope<'a, 'b> = nova_vm::engine::context::GcScope<'a, 'b>;
+type NoGcScope<'a, 'b> = nova_vm::engine::context::NoGcScope<'a, 'b>;
+
+fn test_no_params() {
+  unimplemented!()
+}
+
+fn test_one_param(_foo: ()) {
+  unimplemented!()
+}
+
+fn test_owned_qualified_agent_only(agent: nova_vm::ecmascript::execution::Agent) {
+  unimplemented!()
+}
+
+fn test_owned_agent_only(agent: Agent) {
+  unimplemented!()
+}
+
+fn test_borrowed_agent_only(agent: &Agent) {
+  unimplemented!()
+}
+
+fn test_mut_agent_only(agent: &mut Agent) {
+  unimplemented!()
+}
+
+fn test_multiple_agents(agent1: Agent, agent2: Agent) {
+  unimplemented!()
+}
+
+fn test_something_else_before_agent(foo: (), agent: Agent) {
+  unimplemented!()
+}
+
+fn test_multiple_agents_with_something_in_between(agent1: Agent, foo: (), agent2: Agent) {
+  unimplemented!()
+}
+
+fn test_impl_can_come_before_agent(foo: impl std::fmt::Debug, agent: Agent) {
+  unimplemented!()
+}
+
+fn test_generic_can_come_before_agent<T>(foo: T, agent: Agent) {
+  unimplemented!()
+}
+
+struct Test;
+
+impl Test {
+  fn test_no_params(&self) {
+    unimplemented!()
+  }
+
+  fn test_one_param(&self, _foo: ()) {
+    unimplemented!()
+  }
+
+  fn test_self_and_owned_agent_only(&self, agent: Agent) {
+    unimplemented!()
+  }
+
+  fn test_self_and_something_before_agent(&self, foo: (), agent: &Agent) {
+    unimplemented!()
+  }
+
+  fn test_something_before_agent(foo: (), agent: &Agent) {
+    unimplemented!()
+  }
+
+  fn test_self_and_impl_can_come_before_agent(&self, foo: impl std::fmt::Debug, agent: Agent) {
+    unimplemented!()
+  }
+
+  fn test_self_and_generic_can_come_before_agent<T>(&self, foo: T, agent: Agent) {
+    unimplemented!()
+  }
+}
+
+fn main() {
+  unimplemented!()
+}

--- a/nova_lint/ui/agent_comes_first.rs
+++ b/nova_lint/ui/agent_comes_first.rs
@@ -78,6 +78,17 @@ impl Test {
   fn test_self_and_generic_can_come_before_agent<T>(&self, foo: T, agent: Agent) {
     unimplemented!()
   }
+
+  // TODO: Support `Self` as a leading parameter before `Agent`
+  // fn test_uppercase_self(me: Self, agent: Agent) {
+  //   unimplemented!()
+  // }
+  // fn test_optional_uppercase_self(me: Option<Self>, agent: Agent) {
+  //   unimplemented!()
+  // }
+  // fn test_optional_borrowed_uppercase_self(me: Option<&Self>, agent: Agent) {
+  //   unimplemented!()
+  // }
 }
 
 fn main() {

--- a/nova_lint/ui/agent_comes_first.rs
+++ b/nova_lint/ui/agent_comes_first.rs
@@ -1,96 +1,94 @@
 #![allow(dead_code, unused_variables, clippy::disallowed_names)]
 
 type Agent = nova_vm::ecmascript::execution::agent::Agent;
-type GcScope<'a, 'b> = nova_vm::engine::context::GcScope<'a, 'b>;
-type NoGcScope<'a, 'b> = nova_vm::engine::context::NoGcScope<'a, 'b>;
 
 fn test_no_params() {
-  unimplemented!()
+    unimplemented!()
 }
 
 fn test_one_param(_foo: ()) {
-  unimplemented!()
+    unimplemented!()
 }
 
 fn test_owned_qualified_agent_only(agent: nova_vm::ecmascript::execution::Agent) {
-  unimplemented!()
+    unimplemented!()
 }
 
 fn test_owned_agent_only(agent: Agent) {
-  unimplemented!()
+    unimplemented!()
 }
 
 fn test_borrowed_agent_only(agent: &Agent) {
-  unimplemented!()
+    unimplemented!()
 }
 
 fn test_mut_agent_only(agent: &mut Agent) {
-  unimplemented!()
+    unimplemented!()
 }
 
 fn test_multiple_agents(agent1: Agent, agent2: Agent) {
-  unimplemented!()
+    unimplemented!()
 }
 
 fn test_something_else_before_agent(foo: (), agent: Agent) {
-  unimplemented!()
+    unimplemented!()
 }
 
 fn test_multiple_agents_with_something_in_between(agent1: Agent, foo: (), agent2: Agent) {
-  unimplemented!()
+    unimplemented!()
 }
 
 fn test_impl_can_come_before_agent(foo: impl std::fmt::Debug, agent: Agent) {
-  unimplemented!()
+    unimplemented!()
 }
 
 fn test_generic_can_come_before_agent<T>(foo: T, agent: Agent) {
-  unimplemented!()
+    unimplemented!()
 }
 
 struct Test;
 
 impl Test {
-  fn test_no_params(&self) {
-    unimplemented!()
-  }
+    fn test_no_params(&self) {
+        unimplemented!()
+    }
 
-  fn test_one_param(&self, _foo: ()) {
-    unimplemented!()
-  }
+    fn test_one_param(&self, _foo: ()) {
+        unimplemented!()
+    }
 
-  fn test_self_and_owned_agent_only(&self, agent: Agent) {
-    unimplemented!()
-  }
+    fn test_self_and_owned_agent_only(&self, agent: Agent) {
+        unimplemented!()
+    }
 
-  fn test_self_and_something_before_agent(&self, foo: (), agent: &Agent) {
-    unimplemented!()
-  }
+    fn test_self_and_something_before_agent(&self, foo: (), agent: &Agent) {
+        unimplemented!()
+    }
 
-  fn test_something_before_agent(foo: (), agent: &Agent) {
-    unimplemented!()
-  }
+    fn test_something_before_agent(foo: (), agent: &Agent) {
+        unimplemented!()
+    }
 
-  fn test_self_and_impl_can_come_before_agent(&self, foo: impl std::fmt::Debug, agent: Agent) {
-    unimplemented!()
-  }
+    fn test_self_and_impl_can_come_before_agent(&self, foo: impl std::fmt::Debug, agent: Agent) {
+        unimplemented!()
+    }
 
-  fn test_self_and_generic_can_come_before_agent<T>(&self, foo: T, agent: Agent) {
-    unimplemented!()
-  }
+    fn test_self_and_generic_can_come_before_agent<T>(&self, foo: T, agent: Agent) {
+        unimplemented!()
+    }
 
-  // TODO: Support `Self` as a leading parameter before `Agent`
-  // fn test_uppercase_self(me: Self, agent: Agent) {
-  //   unimplemented!()
-  // }
-  // fn test_optional_uppercase_self(me: Option<Self>, agent: Agent) {
-  //   unimplemented!()
-  // }
-  // fn test_optional_borrowed_uppercase_self(me: Option<&Self>, agent: Agent) {
-  //   unimplemented!()
-  // }
+    // TODO: Support `Self` as a leading parameter before `Agent`
+    // fn test_uppercase_self(me: Self, agent: Agent) {
+    //   unimplemented!()
+    // }
+    // fn test_optional_uppercase_self(me: Option<Self>, agent: Agent) {
+    //   unimplemented!()
+    // }
+    // fn test_optional_borrowed_uppercase_self(me: Option<&Self>, agent: Agent) {
+    //   unimplemented!()
+    // }
 }
 
 fn main() {
-  unimplemented!()
+    unimplemented!()
 }

--- a/nova_lint/ui/agent_comes_first.stderr
+++ b/nova_lint/ui/agent_comes_first.stderr
@@ -1,0 +1,35 @@
+warning: the `nova_vm::ecmascript::execution::agent::Agent` should be the first parameter of any function using it
+  --> $DIR/agent_comes_first.rs:35:46
+   |
+LL | fn test_something_else_before_agent(foo: (), agent: Agent) {
+   |                                              ^^^^^^^^^^^^
+   |
+   = help: consider moving the `nova_vm::ecmascript::execution::agent::Agent` to the first parameter
+   = note: `#[warn(agent_comes_first)]` on by default
+
+warning: the `nova_vm::ecmascript::execution::agent::Agent` should be the first parameter of any function using it
+  --> $DIR/agent_comes_first.rs:39:75
+   |
+LL | fn test_multiple_agents_with_something_in_between(agent1: Agent, foo: (), agent2: Agent) {
+   |                                                                           ^^^^^^^^^^^^^
+   |
+   = help: consider moving the `nova_vm::ecmascript::execution::agent::Agent` to the first parameter
+
+warning: the `nova_vm::ecmascript::execution::agent::Agent` should be the first parameter of any function using it
+  --> $DIR/agent_comes_first.rs:66:59
+   |
+LL |   fn test_self_and_something_before_agent(&self, foo: (), agent: &Agent) {
+   |                                                           ^^^^^^^^^^^^^
+   |
+   = help: consider moving the `nova_vm::ecmascript::execution::agent::Agent` to the first parameter
+
+warning: the `nova_vm::ecmascript::execution::agent::Agent` should be the first parameter of any function using it
+  --> $DIR/agent_comes_first.rs:70:43
+   |
+LL |   fn test_something_before_agent(foo: (), agent: &Agent) {
+   |                                           ^^^^^^^^^^^^^
+   |
+   = help: consider moving the `nova_vm::ecmascript::execution::agent::Agent` to the first parameter
+
+warning: 4 warnings emitted
+

--- a/nova_lint/ui/agent_comes_first.stderr
+++ b/nova_lint/ui/agent_comes_first.stderr
@@ -16,18 +16,18 @@ LL | fn test_multiple_agents_with_something_in_between(agent1: Agent, foo: (), a
    = help: consider moving the `nova_vm::ecmascript::execution::agent::Agent` to the first parameter
 
 warning: the `nova_vm::ecmascript::execution::agent::Agent` should be the first parameter of any function using it
-  --> $DIR/agent_comes_first.rs:64:59
+  --> $DIR/agent_comes_first.rs:64:61
    |
-LL |   fn test_self_and_something_before_agent(&self, foo: (), agent: &Agent) {
-   |                                                           ^^^^^^^^^^^^^
+LL |     fn test_self_and_something_before_agent(&self, foo: (), agent: &Agent) {
+   |                                                             ^^^^^^^^^^^^^
    |
    = help: consider moving the `nova_vm::ecmascript::execution::agent::Agent` to the first parameter
 
 warning: the `nova_vm::ecmascript::execution::agent::Agent` should be the first parameter of any function using it
-  --> $DIR/agent_comes_first.rs:68:43
+  --> $DIR/agent_comes_first.rs:68:45
    |
-LL |   fn test_something_before_agent(foo: (), agent: &Agent) {
-   |                                           ^^^^^^^^^^^^^
+LL |     fn test_something_before_agent(foo: (), agent: &Agent) {
+   |                                             ^^^^^^^^^^^^^
    |
    = help: consider moving the `nova_vm::ecmascript::execution::agent::Agent` to the first parameter
 

--- a/nova_lint/ui/agent_comes_first.stderr
+++ b/nova_lint/ui/agent_comes_first.stderr
@@ -1,5 +1,5 @@
 warning: the `nova_vm::ecmascript::execution::agent::Agent` should be the first parameter of any function using it
-  --> $DIR/agent_comes_first.rs:35:46
+  --> $DIR/agent_comes_first.rs:33:46
    |
 LL | fn test_something_else_before_agent(foo: (), agent: Agent) {
    |                                              ^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | fn test_something_else_before_agent(foo: (), agent: Agent) {
    = note: `#[warn(agent_comes_first)]` on by default
 
 warning: the `nova_vm::ecmascript::execution::agent::Agent` should be the first parameter of any function using it
-  --> $DIR/agent_comes_first.rs:39:75
+  --> $DIR/agent_comes_first.rs:37:75
    |
 LL | fn test_multiple_agents_with_something_in_between(agent1: Agent, foo: (), agent2: Agent) {
    |                                                                           ^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL | fn test_multiple_agents_with_something_in_between(agent1: Agent, foo: (), a
    = help: consider moving the `nova_vm::ecmascript::execution::agent::Agent` to the first parameter
 
 warning: the `nova_vm::ecmascript::execution::agent::Agent` should be the first parameter of any function using it
-  --> $DIR/agent_comes_first.rs:66:59
+  --> $DIR/agent_comes_first.rs:64:59
    |
 LL |   fn test_self_and_something_before_agent(&self, foo: (), agent: &Agent) {
    |                                                           ^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |   fn test_self_and_something_before_agent(&self, foo: (), agent: &Agent) {
    = help: consider moving the `nova_vm::ecmascript::execution::agent::Agent` to the first parameter
 
 warning: the `nova_vm::ecmascript::execution::agent::Agent` should be the first parameter of any function using it
-  --> $DIR/agent_comes_first.rs:70:43
+  --> $DIR/agent_comes_first.rs:68:43
    |
 LL |   fn test_something_before_agent(foo: (), agent: &Agent) {
    |                                           ^^^^^^^^^^^^^

--- a/nova_lint/ui/gc_scope_comes_last.rs
+++ b/nova_lint/ui/gc_scope_comes_last.rs
@@ -1,0 +1,80 @@
+#![allow(dead_code, unused_variables, clippy::disallowed_names)]
+
+type GcScope<'a, 'b> = nova_vm::engine::context::GcScope<'a, 'b>;
+type NoGcScope<'a, 'b> = nova_vm::engine::context::NoGcScope<'a, 'b>;
+
+fn test_no_params() {
+    unimplemented!()
+}
+
+fn test_one_param(_foo: ()) {
+    unimplemented!()
+}
+
+fn test_owned_qualified_gc_scope_only(gc_scope: nova_vm::engine::context::GcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_owned_gc_scope_only(gc_scope: GcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_borrowed_gc_scope_only(gc_scope: &GcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_mut_gc_scope_only(gc_scope: &mut GcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_multiple_gc_scopes(gc_scope1: GcScope<'_, '_>, gc_scope2: GcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_something_else_after_gc_scope(gc_scope: GcScope<'_, '_>, foo: ()) {
+    unimplemented!()
+}
+
+fn test_multiple_gc_scopes_with_something_in_between(
+    gc_scope1: GcScope<'_, '_>,
+    foo: (),
+    gc_scope2: GcScope<'_, '_>,
+) {
+    unimplemented!()
+}
+
+fn test_multiple_no_gc_scopes_with_something_in_between(
+    gc_scope1: NoGcScope<'_, '_>,
+    foo: (),
+    gc_scope2: GcScope<'_, '_>,
+) {
+    unimplemented!()
+}
+
+struct Test;
+
+impl Test {
+    fn test_no_params(&self) {
+        unimplemented!()
+    }
+
+    fn test_one_param(&self, _foo: ()) {
+        unimplemented!()
+    }
+
+    fn test_self_and_owned_gc_scope_only(&self, gc_scope: GcScope<'_, '_>) {
+        unimplemented!()
+    }
+
+    fn test_self_and_something_after_gc_scope(&self, gc_scope: &GcScope<'_, '_>, foo: ()) {
+        unimplemented!()
+    }
+
+    fn test_something_after_gc_scope(gc_scope: &GcScope<'_, '_>, foo: ()) {
+        unimplemented!()
+    }
+}
+
+fn main() {
+    unimplemented!()
+}

--- a/nova_lint/ui/gc_scope_comes_last.rs
+++ b/nova_lint/ui/gc_scope_comes_last.rs
@@ -19,14 +19,6 @@ fn test_owned_gc_scope_only(gc_scope: GcScope<'_, '_>) {
     unimplemented!()
 }
 
-fn test_borrowed_gc_scope_only(gc_scope: &GcScope<'_, '_>) {
-    unimplemented!()
-}
-
-fn test_mut_gc_scope_only(gc_scope: &mut GcScope<'_, '_>) {
-    unimplemented!()
-}
-
 fn test_multiple_gc_scopes(gc_scope1: GcScope<'_, '_>, gc_scope2: GcScope<'_, '_>) {
     unimplemented!()
 }
@@ -66,11 +58,11 @@ impl Test {
         unimplemented!()
     }
 
-    fn test_self_and_something_after_gc_scope(&self, gc_scope: &GcScope<'_, '_>, foo: ()) {
+    fn test_self_and_something_after_gc_scope(&self, gc_scope: GcScope<'_, '_>, foo: ()) {
         unimplemented!()
     }
 
-    fn test_something_after_gc_scope(gc_scope: &GcScope<'_, '_>, foo: ()) {
+    fn test_something_after_gc_scope(gc_scope: GcScope<'_, '_>, foo: ()) {
         unimplemented!()
     }
 }

--- a/nova_lint/ui/gc_scope_comes_last.stderr
+++ b/nova_lint/ui/gc_scope_comes_last.stderr
@@ -1,0 +1,43 @@
+warning: the gc scope should be the last parameter of any function using it
+  --> $DIR/gc_scope_comes_last.rs:34:39
+   |
+LL | fn test_something_else_after_gc_scope(gc_scope: GcScope<'_, '_>, foo: ()) {
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the gc scope to the last parameter
+   = note: `#[warn(gc_scope_comes_last)]` on by default
+
+warning: the gc scope should be the last parameter of any function using it
+  --> $DIR/gc_scope_comes_last.rs:38:54
+   |
+LL | fn test_multiple_gc_scopes_with_something_in_between(gc_scope1: GcScope<'_, '_>, foo: (), gc_scope2: GcScope<'_, '_>) {
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the gc scope to the last parameter
+
+warning: the gc scope should be the last parameter of any function using it
+  --> $DIR/gc_scope_comes_last.rs:42:57
+   |
+LL | fn test_multiple_no_gc_scopes_with_something_in_between(gc_scope1: NoGcScope<'_, '_>, foo: (), gc_scope2: GcScope<'_, '_>) {
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the gc scope to the last parameter
+
+warning: the gc scope should be the last parameter of any function using it
+  --> $DIR/gc_scope_comes_last.rs:61:52
+   |
+LL |   fn test_self_and_something_after_gc_scope(&self, gc_scope: &GcScope<'_, '_>, foo: ()) {
+   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the gc scope to the last parameter
+
+warning: the gc scope should be the last parameter of any function using it
+  --> $DIR/gc_scope_comes_last.rs:65:36
+   |
+LL |   fn test_something_after_gc_scope(gc_scope: &GcScope<'_, '_>, foo: ()) {
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the gc scope to the last parameter
+
+warning: 5 warnings emitted
+

--- a/nova_lint/ui/gc_scope_comes_last.stderr
+++ b/nova_lint/ui/gc_scope_comes_last.stderr
@@ -8,34 +8,34 @@ LL | fn test_something_else_after_gc_scope(gc_scope: GcScope<'_, '_>, foo: ()) {
    = note: `#[warn(gc_scope_comes_last)]` on by default
 
 warning: the gc scope should be the last parameter of any function using it
-  --> $DIR/gc_scope_comes_last.rs:38:54
+  --> $DIR/gc_scope_comes_last.rs:39:5
    |
-LL | fn test_multiple_gc_scopes_with_something_in_between(gc_scope1: GcScope<'_, '_>, foo: (), gc_scope2: GcScope<'_, '_>) {
+LL |     gc_scope1: GcScope<'_, '_>,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the gc scope to the last parameter
+
+warning: the gc scope should be the last parameter of any function using it
+  --> $DIR/gc_scope_comes_last.rs:47:5
+   |
+LL |     gc_scope1: NoGcScope<'_, '_>,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider moving the gc scope to the last parameter
+
+warning: the gc scope should be the last parameter of any function using it
+  --> $DIR/gc_scope_comes_last.rs:69:54
+   |
+LL |     fn test_self_and_something_after_gc_scope(&self, gc_scope: &GcScope<'_, '_>, foo: ()) {
    |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider moving the gc scope to the last parameter
 
 warning: the gc scope should be the last parameter of any function using it
-  --> $DIR/gc_scope_comes_last.rs:42:57
+  --> $DIR/gc_scope_comes_last.rs:73:38
    |
-LL | fn test_multiple_no_gc_scopes_with_something_in_between(gc_scope1: NoGcScope<'_, '_>, foo: (), gc_scope2: GcScope<'_, '_>) {
-   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider moving the gc scope to the last parameter
-
-warning: the gc scope should be the last parameter of any function using it
-  --> $DIR/gc_scope_comes_last.rs:61:52
-   |
-LL |   fn test_self_and_something_after_gc_scope(&self, gc_scope: &GcScope<'_, '_>, foo: ()) {
-   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider moving the gc scope to the last parameter
-
-warning: the gc scope should be the last parameter of any function using it
-  --> $DIR/gc_scope_comes_last.rs:65:36
-   |
-LL |   fn test_something_after_gc_scope(gc_scope: &GcScope<'_, '_>, foo: ()) {
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     fn test_something_after_gc_scope(gc_scope: &GcScope<'_, '_>, foo: ()) {
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider moving the gc scope to the last parameter
 

--- a/nova_lint/ui/gc_scope_comes_last.stderr
+++ b/nova_lint/ui/gc_scope_comes_last.stderr
@@ -1,5 +1,5 @@
 warning: the gc scope should be the last parameter of any function using it
-  --> $DIR/gc_scope_comes_last.rs:34:39
+  --> $DIR/gc_scope_comes_last.rs:26:39
    |
 LL | fn test_something_else_after_gc_scope(gc_scope: GcScope<'_, '_>, foo: ()) {
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | fn test_something_else_after_gc_scope(gc_scope: GcScope<'_, '_>, foo: ()) {
    = note: `#[warn(gc_scope_comes_last)]` on by default
 
 warning: the gc scope should be the last parameter of any function using it
-  --> $DIR/gc_scope_comes_last.rs:39:5
+  --> $DIR/gc_scope_comes_last.rs:31:5
    |
 LL |     gc_scope1: GcScope<'_, '_>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     gc_scope1: GcScope<'_, '_>,
    = help: consider moving the gc scope to the last parameter
 
 warning: the gc scope should be the last parameter of any function using it
-  --> $DIR/gc_scope_comes_last.rs:47:5
+  --> $DIR/gc_scope_comes_last.rs:39:5
    |
 LL |     gc_scope1: NoGcScope<'_, '_>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,18 +24,18 @@ LL |     gc_scope1: NoGcScope<'_, '_>,
    = help: consider moving the gc scope to the last parameter
 
 warning: the gc scope should be the last parameter of any function using it
-  --> $DIR/gc_scope_comes_last.rs:69:54
+  --> $DIR/gc_scope_comes_last.rs:61:54
    |
-LL |     fn test_self_and_something_after_gc_scope(&self, gc_scope: &GcScope<'_, '_>, foo: ()) {
-   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     fn test_self_and_something_after_gc_scope(&self, gc_scope: GcScope<'_, '_>, foo: ()) {
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider moving the gc scope to the last parameter
 
 warning: the gc scope should be the last parameter of any function using it
-  --> $DIR/gc_scope_comes_last.rs:73:38
+  --> $DIR/gc_scope_comes_last.rs:65:38
    |
-LL |     fn test_something_after_gc_scope(gc_scope: &GcScope<'_, '_>, foo: ()) {
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     fn test_something_after_gc_scope(gc_scope: GcScope<'_, '_>, foo: ()) {
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider moving the gc scope to the last parameter
 

--- a/nova_lint/ui/gc_scope_is_only_passed_by_value.rs
+++ b/nova_lint/ui/gc_scope_is_only_passed_by_value.rs
@@ -1,0 +1,62 @@
+#![allow(dead_code, unused_variables, clippy::disallowed_names)]
+
+type GcScope<'a, 'b> = nova_vm::engine::context::GcScope<'a, 'b>;
+type NoGcScope<'a, 'b> = nova_vm::engine::context::NoGcScope<'a, 'b>;
+
+fn test_owned_qualified_gc_scope_only(gc_scope: nova_vm::engine::context::GcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_owned_gc_scope_only(gc_scope: GcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_owned_qualified_no_gc_scope_only(gc_scope: nova_vm::engine::context::NoGcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_owned_no_gc_scope_only(gc_scope: NoGcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_borrowed_qualified_gc_scope_only(gc_scope: &nova_vm::engine::context::GcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_borrowed_gc_scope_only(gc_scope: &GcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_borrowed_qualified_no_gc_scope_only(
+    gc_scope: &nova_vm::engine::context::NoGcScope<'_, '_>,
+) {
+    unimplemented!()
+}
+
+fn test_borrowed_no_gc_scope_only(gc_scope: &NoGcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_mut_borrowed_qualified_gc_scope_only(
+    gc_scope: &mut nova_vm::engine::context::GcScope<'_, '_>,
+) {
+    unimplemented!()
+}
+
+fn test_mut_borrowed_gc_scope_only(gc_scope: &mut GcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn test_mut_borrowed_qualified_no_gc_scope_only(
+    gc_scope: &mut nova_vm::engine::context::NoGcScope<'_, '_>,
+) {
+    unimplemented!()
+}
+
+fn test_mut_borrowed_no_gc_scope_only(gc_scope: &mut NoGcScope<'_, '_>) {
+    unimplemented!()
+}
+
+fn main() {
+    unimplemented!()
+}

--- a/nova_lint/ui/gc_scope_is_only_passed_by_value.rs
+++ b/nova_lint/ui/gc_scope_is_only_passed_by_value.rs
@@ -57,6 +57,22 @@ fn test_mut_borrowed_no_gc_scope_only(gc_scope: &mut NoGcScope<'_, '_>) {
     unimplemented!()
 }
 
+trait TestTrait {
+    fn test_trait_fn(self);
+}
+
+impl TestTrait for GcScope<'_, '_> {
+    fn test_trait_fn(self) {
+        unimplemented!()
+    }
+}
+
+impl TestTrait for NoGcScope<'_, '_> {
+    fn test_trait_fn(self) {
+        unimplemented!()
+    }
+}
+
 fn main() {
     unimplemented!()
 }

--- a/nova_lint/ui/gc_scope_is_only_passed_by_value.rs
+++ b/nova_lint/ui/gc_scope_is_only_passed_by_value.rs
@@ -58,17 +58,35 @@ fn test_mut_borrowed_no_gc_scope_only(gc_scope: &mut NoGcScope<'_, '_>) {
 }
 
 trait TestTrait {
-    fn test_trait_fn(self);
+    fn test_owned_self(self);
+    fn test_borrowd_self(&self);
+    fn test_mut_borrowd_self(&mut self);
 }
 
 impl TestTrait for GcScope<'_, '_> {
-    fn test_trait_fn(self) {
+    fn test_owned_self(self) {
+        unimplemented!()
+    }
+
+    fn test_borrowd_self(&self) {
+        unimplemented!()
+    }
+
+    fn test_mut_borrowd_self(&mut self) {
         unimplemented!()
     }
 }
 
 impl TestTrait for NoGcScope<'_, '_> {
-    fn test_trait_fn(self) {
+    fn test_owned_self(self) {
+        unimplemented!()
+    }
+
+    fn test_borrowd_self(&self) {
+        unimplemented!()
+    }
+
+    fn test_mut_borrowd_self(&mut self) {
         unimplemented!()
     }
 }

--- a/nova_lint/ui/gc_scope_is_only_passed_by_value.stderr
+++ b/nova_lint/ui/gc_scope_is_only_passed_by_value.stderr
@@ -1,0 +1,67 @@
+error: gc scope should only be passed by value
+  --> $DIR/gc_scope_is_only_passed_by_value.rs:22:52
+   |
+LL | fn test_borrowed_qualified_gc_scope_only(gc_scope: &nova_vm::engine::context::GcScope<'_, '_>) {
+   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the reference
+   = note: `#[deny(gc_scope_is_only_passed_by_value)]` on by default
+
+error: gc scope should only be passed by value
+  --> $DIR/gc_scope_is_only_passed_by_value.rs:26:42
+   |
+LL | fn test_borrowed_gc_scope_only(gc_scope: &GcScope<'_, '_>) {
+   |                                          ^^^^^^^^^^^^^^^^
+   |
+   = help: remove the reference
+
+error: gc scope should only be passed by value
+  --> $DIR/gc_scope_is_only_passed_by_value.rs:31:15
+   |
+LL |     gc_scope: &nova_vm::engine::context::NoGcScope<'_, '_>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the reference
+
+error: gc scope should only be passed by value
+  --> $DIR/gc_scope_is_only_passed_by_value.rs:36:45
+   |
+LL | fn test_borrowed_no_gc_scope_only(gc_scope: &NoGcScope<'_, '_>) {
+   |                                             ^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the reference
+
+error: gc scope should only be passed by value
+  --> $DIR/gc_scope_is_only_passed_by_value.rs:41:15
+   |
+LL |     gc_scope: &mut nova_vm::engine::context::GcScope<'_, '_>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the reference
+
+error: gc scope should only be passed by value
+  --> $DIR/gc_scope_is_only_passed_by_value.rs:46:46
+   |
+LL | fn test_mut_borrowed_gc_scope_only(gc_scope: &mut GcScope<'_, '_>) {
+   |                                              ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the reference
+
+error: gc scope should only be passed by value
+  --> $DIR/gc_scope_is_only_passed_by_value.rs:51:15
+   |
+LL |     gc_scope: &mut nova_vm::engine::context::NoGcScope<'_, '_>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the reference
+
+error: gc scope should only be passed by value
+  --> $DIR/gc_scope_is_only_passed_by_value.rs:56:49
+   |
+LL | fn test_mut_borrowed_no_gc_scope_only(gc_scope: &mut NoGcScope<'_, '_>) {
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the reference
+
+error: aborting due to 8 previous errors
+

--- a/nova_vm/src/ecmascript/builtins/array_buffer/abstract_operations.rs
+++ b/nova_vm/src/ecmascript/builtins/array_buffer/abstract_operations.rs
@@ -238,8 +238,8 @@ pub(crate) fn get_array_buffer_max_byte_length_option(
 /// The default implementation of HostResizeArrayBuffer is to return
 /// NormalCompletion(UNHANDLED).
 pub(crate) fn host_resize_array_buffer(
-    _buffer: ArrayBuffer,
     _agent: &mut Agent,
+    _buffer: ArrayBuffer,
     _new_byte_length: u64,
 ) -> bool {
     false

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_intrinsic_object.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_intrinsic_object.rs
@@ -825,6 +825,10 @@ impl TypedArrayPrototype {
             TypedArray::Int16Array(_) | TypedArray::Uint16Array(_) => {
                 typed_array_length::<u16>(agent, &ta_record, gc.nogc())
             }
+            #[cfg(feature = "proposal-float16array")]
+            TypedArray::Float16Array(_) => {
+                typed_array_length::<f16>(agent, &ta_record, gc.nogc())
+            }
             TypedArray::Int32Array(_)
             | TypedArray::Uint32Array(_)
             | TypedArray::Float32Array(_) => {

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_intrinsic_object.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_intrinsic_object.rs
@@ -826,9 +826,7 @@ impl TypedArrayPrototype {
                 typed_array_length::<u16>(agent, &ta_record, gc.nogc())
             }
             #[cfg(feature = "proposal-float16array")]
-            TypedArray::Float16Array(_) => {
-                typed_array_length::<f16>(agent, &ta_record, gc.nogc())
-            }
+            TypedArray::Float16Array(_) => typed_array_length::<f16>(agent, &ta_record, gc.nogc()),
             TypedArray::Int32Array(_)
             | TypedArray::Uint32Array(_)
             | TypedArray::Float32Array(_) => {

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/math_object.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/math_object.rs
@@ -1180,11 +1180,11 @@ impl MathObject {
 
             let slow_nan = max_slow_path(
                 agent,
-                gc.reborrow(),
                 &mut only_ints,
                 &mut highest_i64,
                 &mut highest_f64,
                 &arguments[i..],
+                gc.reborrow(),
             )?;
             if slow_nan {
                 contained_nan = true;
@@ -1281,11 +1281,11 @@ impl MathObject {
 
             let slow_nan = min_slow_path(
                 agent,
-                gc.reborrow(),
                 &mut only_ints,
                 &mut lowest_i64,
                 &mut lowest_f64,
                 &arguments[i..],
+                gc.reborrow(),
             )?;
             if slow_nan {
                 contained_nan = true;
@@ -1898,11 +1898,11 @@ impl MathObject {
 #[inline(never)]
 fn max_slow_path(
     agent: &mut Agent,
-    mut gc: GcScope,
     only_ints: &mut bool,
     highest_i64: &mut i64,
     highest_f64: &mut f64,
     arguments: &[Value],
+    mut gc: GcScope,
 ) -> JsResult<bool> {
     // First gather remaining arguments into Vec and scope each one to
     // make them safe from GC.
@@ -1942,11 +1942,11 @@ fn max_slow_path(
 #[inline(never)]
 fn min_slow_path(
     agent: &mut Agent,
-    mut gc: GcScope,
     only_ints: &mut bool,
     lowest_i64: &mut i64,
     lowest_f64: &mut f64,
     arguments: &[Value],
+    mut gc: GcScope,
 ) -> JsResult<bool> {
     // First gather remaining arguments into Vec and scope each one to
     // make them safe from GC.

--- a/nova_vm/src/ecmascript/types/spec/property_descriptor.rs
+++ b/nova_vm/src/ecmascript/types/spec/property_descriptor.rs
@@ -142,6 +142,7 @@ impl PropertyDescriptor {
     ///
     /// The abstract operation FromPropertyDescriptor takes argument Desc (a
     /// Property Descriptor or undefined) and returns an Object or undefined.
+    #[allow(unknown_lints, agent_comes_first)]
     pub fn from_property_descriptor<'a>(
         desc: Option<Self>,
         agent: &mut Agent,

--- a/nova_vm/src/engine/context.rs
+++ b/nova_vm/src/engine/context.rs
@@ -153,6 +153,7 @@ impl<'a, 'b> GcScope<'a, 'b> {
 }
 
 impl<'a, 'b> NoGcScope<'a, 'b> {
+    #[allow(unknown_lints, gc_scope_is_only_passed_by_value)]
     #[inline]
     pub(crate) fn from_gc(_: &GcScope<'a, 'b>) -> Self {
         Self {


### PR DESCRIPTION
This is an initial take on #573 using dylint. I implemented three simple `agent_comes_first`, `gc_scope_comes_last` and `gc_scope_is_only_passed_by_value` rules just as a proof-of-concept and it's was actually rather fun and simple to implement!

It seems dylint requires rust nightly to build and test, which is why it's excluded from the main workspace and instead lives as it's entirely own crate with it's own `rust-toolchain`. I tried to get it to work alongside nova without nightly but nightly seems to be required to expose the internals of rust and allow us to use them to build our own clippy rules. 