### PR TITLE
chore(ecmascript): remove TypedArray toSpliced

### DIFF
--- a/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_intrinsic_object.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_intrinsic_object.rs
@@ -2203,15 +2203,6 @@ impl TypedArrayPrototype {
         todo!();
     }
 
-    fn to_spliced<'gc>(
-        _agent: &mut Agent,
-        _this_value: Value,
-        _: ArgumentsList,
-        _gc: GcScope<'gc, '_>,
-    ) -> JsResult<Value<'gc>> {
-        todo!();
-    }
-
     /// ### [23.2.3.35 %TypedArray%.prototype.values ( )](https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-%symbol.tostringtag%)
     fn values<'gc>(
         agent: &mut Agent,


### PR DESCRIPTION
It looks like toSpliced and splice don’t exist on TypedArray!
There was no splice, but toSpliced did exist, so I removed it!

ref: https://github.com/tc39/proposal-change-array-by-copy/issues/88