### PR TITLE
feat(vm): Use 32-bit integers for jump slots

### DIFF
--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -1313,7 +1313,7 @@ impl Vm {
                 let (compiled_initializer_bytecode, has_constructor_parent) = executable
                     .fetch_class_initializer_bytecode(
                         agent,
-                        class_initializer_bytecode_index as usize,
+                        class_initializer_bytecode_index,
                         gc.nogc(),
                     );
 

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -69,7 +69,7 @@ use crate::{
     heap::{CompactionLists, HeapMarkAndSweep, WellKnownSymbolIndexes, WorkQueues},
 };
 
-use super::{executable::get_instruction, iterator::ActiveIterator};
+use super::iterator::ActiveIterator;
 
 struct EmptyParametersList(ast::FormalParameters<'static>);
 unsafe impl Send for EmptyParametersList {}
@@ -344,7 +344,7 @@ impl Vm {
     ) -> ExecutionResult<'gc> {
         let stack_depth = agent.stack_refs.borrow().len();
         let instructions = executable.get_instructions(agent);
-        while let Some(instr) = get_instruction(instructions, &mut self.ip) {
+        while let Some(instr) = Instr::consume_instruction(instructions, &mut self.ip) {
             if agent.check_gc() {
                 with_vm_gc(agent, &mut self, |agent, gc| agent.gc(gc), gc.reborrow());
             }
@@ -410,14 +410,8 @@ impl Vm {
         }
         match instr.kind {
             Instruction::ArrayCreate => {
-                let result = array_create(
-                    agent,
-                    0,
-                    instr.args[0].unwrap() as usize,
-                    None,
-                    gc.into_nogc(),
-                )?
-                .into_value();
+                let result = array_create(agent, 0, instr.get_first_index(), None, gc.into_nogc())?
+                    .into_value();
                 vm.stack.push(result.unbind());
             }
             Instruction::ArrayPush => {
@@ -490,7 +484,7 @@ impl Vm {
             }
             Instruction::ResolveBinding => {
                 let identifier =
-                    executable.fetch_identifier(agent, instr.args[0].unwrap() as usize, gc.nogc());
+                    executable.fetch_identifier(agent, instr.get_first_index(), gc.nogc());
 
                 let reference = resolve_binding(agent, identifier.unbind(), None, gc)?;
 
@@ -514,8 +508,7 @@ impl Vm {
                 vm.result = Some(result.unbind());
             }
             Instruction::LoadConstant => {
-                let constant =
-                    executable.fetch_constant(agent, instr.args[0].unwrap() as usize, gc.nogc());
+                let constant = executable.fetch_constant(agent, instr.get_first_index(), gc.nogc());
                 vm.stack.push(constant.unbind());
             }
             Instruction::Load => {
@@ -542,8 +535,7 @@ impl Vm {
                 vm.result = Some(*vm.stack.last().expect("Trying to get from empty stack"));
             }
             Instruction::StoreConstant => {
-                let constant =
-                    executable.fetch_constant(agent, instr.args[0].unwrap() as usize, gc.nogc());
+                let constant = executable.fetch_constant(agent, instr.get_first_index(), gc.nogc());
                 vm.result = Some(constant.unbind());
             }
             Instruction::UnaryMinus => {
@@ -619,13 +611,10 @@ impl Vm {
                 .unwrap();
             }
             Instruction::ObjectDefineMethod => {
-                let FunctionExpression { expression, .. } = executable.fetch_function_expression(
-                    agent,
-                    instr.args[0].unwrap() as usize,
-                    gc.nogc(),
-                );
+                let FunctionExpression { expression, .. } =
+                    executable.fetch_function_expression(agent, instr.get_first_index(), gc.nogc());
                 let function_expression = expression.get();
-                let enumerable = instr.args[1].unwrap() != 0;
+                let enumerable = instr.get_second_bool();
                 // 1. Let propKey be ? Evaluation of ClassElementName.
                 let prop_key = vm.stack.pop().unwrap();
                 let prop_key = with_vm_gc(
@@ -719,13 +708,10 @@ impl Vm {
                 // c. Return unused.
             }
             Instruction::ObjectDefineGetter => {
-                let FunctionExpression { expression, .. } = executable.fetch_function_expression(
-                    agent,
-                    instr.args[0].unwrap() as usize,
-                    gc.nogc(),
-                );
+                let FunctionExpression { expression, .. } =
+                    executable.fetch_function_expression(agent, instr.get_first_index(), gc.nogc());
                 let function_expression = expression.get();
-                let enumerable = instr.args[1].unwrap() != 0;
+                let enumerable = instr.get_second_bool();
                 // 1. Let propKey be ? Evaluation of ClassElementName.
                 let prop_key = vm.stack.pop().unwrap();
                 let prop_key = with_vm_gc(
@@ -815,13 +801,10 @@ impl Vm {
                 // c. Return unused.
             }
             Instruction::ObjectDefineSetter => {
-                let FunctionExpression { expression, .. } = executable.fetch_function_expression(
-                    agent,
-                    instr.args[0].unwrap() as usize,
-                    gc.nogc(),
-                );
+                let FunctionExpression { expression, .. } =
+                    executable.fetch_function_expression(agent, instr.get_first_index(), gc.nogc());
                 let function_expression = expression.get();
-                let enumerable = instr.args[1].unwrap() != 0;
+                let enumerable = instr.get_second_bool();
                 // 1. Let propKey be ? Evaluation of ClassElementName.
                 let prop_key = vm.stack.pop().unwrap();
                 let prop_key = with_vm_gc(
@@ -1004,7 +987,7 @@ impl Vm {
                     .unwrap()
                     .bind(gc.nogc());
 
-                let num_excluded_items = usize::from(instr.args[0].unwrap());
+                let num_excluded_items = instr.get_first_index();
                 let mut excluded_items = PropertyKeySet::new(gc.nogc());
                 assert!(vm.reference.is_none());
                 for _ in 0..num_excluded_items {
@@ -1037,8 +1020,7 @@ impl Vm {
                 let ArrowFunctionExpression {
                     expression,
                     identifier,
-                } = executable
-                    .fetch_arrow_function_expression(agent, instr.args[0].unwrap() as usize);
+                } = executable.fetch_arrow_function_expression(agent, instr.get_first_index());
                 let function_expression = expression.get();
                 let identifier = *identifier;
                 // 2. Let env be the LexicalEnvironment of the running execution context.
@@ -1130,11 +1112,7 @@ impl Vm {
                     expression,
                     identifier,
                     ..
-                } = executable.fetch_function_expression(
-                    agent,
-                    instr.args[0].unwrap() as usize,
-                    gc.nogc(),
-                );
+                } = executable.fetch_function_expression(agent, instr.get_first_index(), gc.nogc());
                 let function_expression = expression.get();
                 let identifier = *identifier;
 
@@ -1196,11 +1174,7 @@ impl Vm {
                 let function = ordinary_function_create(agent, params, gc.nogc());
                 let FunctionExpression {
                     compiled_bytecode, ..
-                } = executable.fetch_function_expression(
-                    agent,
-                    instr.args[0].unwrap() as usize,
-                    gc.nogc(),
-                );
+                } = executable.fetch_function_expression(agent, instr.get_first_index(), gc.nogc());
                 if let Some(compiled_bytecode) = compiled_bytecode {
                     agent[function].compiled_bytecode = Some(compiled_bytecode.unbind());
                 }
@@ -1273,16 +1247,10 @@ impl Vm {
                     expression,
                     compiled_bytecode,
                     ..
-                } = executable.fetch_function_expression(
-                    agent,
-                    instr.args[0].unwrap() as usize,
-                    gc.nogc(),
-                );
+                } = executable.fetch_function_expression(agent, instr.get_first_index(), gc.nogc());
                 let function_expression = expression.get();
                 let compiled_bytecode = *compiled_bytecode;
-                let has_constructor_parent = instr.args[1].unwrap();
-                assert!(has_constructor_parent <= 1);
-                let has_constructor_parent = has_constructor_parent == 1;
+                let has_constructor_parent = instr.get_second_bool();
 
                 let class_name = String::try_from(vm.stack.pop().unwrap()).unwrap();
                 let function_prototype = if has_constructor_parent {
@@ -1341,7 +1309,7 @@ impl Vm {
                 vm.result = Some(function.into_value().unbind());
             }
             Instruction::ClassDefineDefaultConstructor => {
-                let class_initializer_bytecode_index = instr.args[0].unwrap();
+                let class_initializer_bytecode_index = instr.get_first_index();
                 let (compiled_initializer_bytecode, has_constructor_parent) = executable
                     .fetch_class_initializer_bytecode(
                         agent,
@@ -1679,7 +1647,7 @@ impl Vm {
             }
             Instruction::EvaluatePropertyAccessWithIdentifierKey => {
                 let property_name_string =
-                    executable.fetch_identifier(agent, instr.args[0].unwrap() as usize, gc.nogc());
+                    executable.fetch_identifier(agent, instr.get_first_index(), gc.nogc());
                 let base_value = vm.result.take().unwrap().bind(gc.nogc());
                 let strict = agent
                     .running_execution_context()
@@ -1695,12 +1663,12 @@ impl Vm {
                 });
             }
             Instruction::Jump => {
-                let ip = instr.args[0].unwrap() as usize;
+                let ip = instr.get_jump_slot();
                 vm.ip = ip;
             }
             Instruction::JumpIfNot => {
                 let result = vm.result.take().unwrap();
-                let ip = instr.args[0].unwrap() as usize;
+                let ip = instr.get_jump_slot();
                 if !to_boolean(agent, result) {
                     vm.ip = ip;
                 }
@@ -1711,7 +1679,7 @@ impl Vm {
                     unreachable!()
                 };
                 if result {
-                    let ip = instr.args[0].unwrap() as usize;
+                    let ip = instr.get_jump_slot();
                     vm.ip = ip;
                 }
             }
@@ -1909,9 +1877,8 @@ impl Vm {
                     .bind(gc.nogc());
             }
             Instruction::InitializeVariableEnvironment => {
-                let num_variables = instr.args[0].unwrap();
-                assert!(instr.args[1].unwrap() <= 1);
-                let strict = instr.args[1].unwrap() == 1;
+                let num_variables = instr.get_first_index();
+                let strict = instr.get_second_bool();
 
                 // 10.2.11 FunctionDeclarationInstantiation
                 // 28.b. Let varEnv be NewDeclarativeEnvironment(env).
@@ -1979,8 +1946,7 @@ impl Vm {
             }
             Instruction::CreateMutableBinding => {
                 let lex_env = agent.current_lexical_environment(gc.nogc());
-                let name =
-                    executable.fetch_identifier(agent, instr.args[0].unwrap() as usize, gc.nogc());
+                let name = executable.fetch_identifier(agent, instr.get_first_index(), gc.nogc());
 
                 unwrap_try(lex_env.try_create_mutable_binding(
                     agent,
@@ -1992,8 +1958,7 @@ impl Vm {
             }
             Instruction::CreateImmutableBinding => {
                 let lex_env = agent.current_lexical_environment(gc.nogc());
-                let name =
-                    executable.fetch_identifier(agent, instr.args[0].unwrap() as usize, gc.nogc());
+                let name = executable.fetch_identifier(agent, instr.get_first_index(), gc.nogc());
                 lex_env
                     .create_immutable_binding(agent, name, true, gc.nogc())
                     .unwrap();
@@ -2003,7 +1968,7 @@ impl Vm {
                 return Err(JsError::new(result));
             }
             Instruction::ThrowError => {
-                let exception_type_immediate = instr.args[0].unwrap();
+                let exception_type_immediate = instr.get_first_arg();
                 let message = String::try_from(vm.result.take().unwrap()).unwrap();
 
                 let exception_type = ExceptionType::try_from(exception_type_immediate).unwrap();
@@ -2016,7 +1981,7 @@ impl Vm {
             }
             Instruction::PushExceptionJumpTarget => {
                 vm.exception_jump_target_stack.push(ExceptionJumpTarget {
-                    ip: instr.args[0].unwrap() as usize,
+                    ip: instr.get_jump_slot(),
                     lexical_environment: agent.current_lexical_environment(gc.nogc()).unbind(),
                 });
             }
@@ -2035,7 +2000,7 @@ impl Vm {
                 vm.result = Some(result.into());
             }
             Instruction::BeginSimpleArrayBindingPattern => {
-                let lexical = instr.args[1].unwrap() == 1;
+                let lexical = instr.get_second_bool();
                 let env = if lexical {
                     // Lexical binding, const [] = a; or let [] = a;
                     Some(
@@ -2051,7 +2016,7 @@ impl Vm {
                 vm.iterator_stack.pop().unwrap();
             }
             Instruction::BeginSimpleObjectBindingPattern => {
-                let lexical = instr.args[0].unwrap() == 1;
+                let lexical = instr.get_first_bool();
                 let env = if lexical {
                     // Lexical binding, const {} = a; or let {} = a;
                     Some(
@@ -2079,7 +2044,7 @@ impl Vm {
                 unreachable!("BeginArrayBindingPattern should take care of stepping over these");
             }
             Instruction::StringConcat => {
-                let argument_count = instr.args[0].unwrap() as usize;
+                let argument_count = instr.get_first_index();
                 let first_arg_index = vm.stack.len() - argument_count;
                 let mut length = 0;
                 let all_easy = vm.stack[first_arg_index..]
@@ -2277,7 +2242,7 @@ impl Vm {
                         // Iterator finished: pop the iterator from the stack
                         // and jump to escape the iterator loop.
                         vm.iterator_stack.pop();
-                        vm.ip = instr.args[0].unwrap() as usize;
+                        vm.ip = instr.get_jump_slot();
                     }
                 } else {
                     // Iterator threw an error: pop the iterator from the stack
@@ -2390,7 +2355,7 @@ impl Vm {
     }
 
     fn get_call_args<'gc>(&mut self, instr: &Instr, _gc: NoGcScope<'gc, '_>) -> Vec<Value<'gc>> {
-        let instr_arg0 = instr.args[0].unwrap();
+        let instr_arg0 = instr.get_first_arg();
         let arg_count = if instr_arg0 != IndexType::MAX {
             instr_arg0 as usize
         } else {

--- a/nova_vm/src/engine/bytecode/vm/binding_methods.rs
+++ b/nova_vm/src/engine/bytecode/vm/binding_methods.rs
@@ -111,11 +111,8 @@ pub(super) fn execute_simple_array_binding<'a>(
                     vm,
                     |agent, mut gc| {
                         let value = value.scope(agent, gc.nogc());
-                        let binding_id = executable.fetch_identifier(
-                            agent,
-                            instr.args[0].unwrap() as usize,
-                            gc.nogc(),
-                        );
+                        let binding_id =
+                            executable.fetch_identifier(agent, instr.get_first_index(), gc.nogc());
                         let lhs = resolve_binding(
                             agent,
                             binding_id.unbind(),
@@ -213,17 +210,14 @@ pub(super) fn execute_simple_object_binding<'a>(
                     agent,
                     vm,
                     |agent, mut gc| {
-                        let binding_id = executable.fetch_identifier(
-                            agent,
-                            instr.args[0].unwrap() as usize,
-                            gc.nogc(),
-                        );
+                        let binding_id =
+                            executable.fetch_identifier(agent, instr.get_first_index(), gc.nogc());
                         let property_key = if instr.kind == Instruction::BindingPatternBind {
                             binding_id.into()
                         } else {
                             let key_value = executable.fetch_constant(
                                 agent,
-                                instr.args[1].unwrap() as usize,
+                                instr.get_second_index(),
                                 gc.nogc(),
                             );
                             // SAFETY: It should be impossible for binding pattern
@@ -273,7 +267,7 @@ pub(super) fn execute_simple_object_binding<'a>(
                         let property_key = unsafe {
                             PropertyKey::from_value_unchecked(executable.fetch_constant(
                                 agent,
-                                instr.args[0].unwrap() as usize,
+                                instr.get_first_index(),
                                 gc.nogc(),
                             ))
                         };
@@ -301,11 +295,8 @@ pub(super) fn execute_simple_object_binding<'a>(
                     vm,
                     |agent, mut gc| {
                         // 1. Let lhs be ? ResolveBinding(StringValue of BindingIdentifier, environment).
-                        let binding_id = executable.fetch_identifier(
-                            agent,
-                            instr.args[0].unwrap() as usize,
-                            gc.nogc(),
-                        );
+                        let binding_id =
+                            executable.fetch_identifier(agent, instr.get_first_index(), gc.nogc());
                         // TODO: Properly handle potential GC.
                         let lhs = resolve_binding(
                             agent,

--- a/nova_vm/src/heap/heap_gc.rs
+++ b/nova_vm/src/heap/heap_gc.rs
@@ -1121,8 +1121,10 @@ fn sweep(
         weak_refs,
         #[cfg(feature = "weak-refs")]
         weak_sets,
-        alloc_counter: _,
+        alloc_counter,
     } = heap;
+    // Reset the allocation counter.
+    *alloc_counter = 0;
     let Environments {
         declarative,
         function,


### PR DESCRIPTION
Couldn't run Kraken benchmark's `ai-astar.js` without larger jump slots.