### PR TITLE
chore(ecmascript): refactor reverse and copy_within

### DIFF
--- a/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_intrinsic_object.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_intrinsic_object.rs
@@ -790,10 +790,10 @@ impl TypedArrayPrototype {
                 start.unbind(),
                 end.unbind(),
                 gc,
-            )?
+            )
         );
         // 18. Return O.
-        Ok(o.into_value())
+        o.map(|o| o.into_value())
     }
 
     /// ### [23.2.3.7 %TypedArray%.prototype.entries ( )](https://tc39.es/ecma262/#sec-%typedarray%.prototype.entries)
@@ -954,10 +954,10 @@ impl TypedArrayPrototype {
                 this_arg.unbind(),
                 ta_record.unbind(),
                 gc,
-            )?
+            )
         );
 
-        Ok(a.into_value())
+        a.map(|a| a.into_value())
     }
 
     /// ### 23.2.3.11 %TypedArray%.prototype.find ( predicate [ , thisArg ] )(https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.find)


### PR DESCRIPTION
~~depends on PR: https://github.com/trynova/nova/pull/663~~

~~The implementations of each method have been moved into the ones defined in Viewable.~~
~~For example, operations like retrieving the length have become simpler by using Viewable.~~

I refactored the code, but now I’m thinking that since with_typed_array_viewable allows you to use methods on T: Viewable, it might not be necessary to extract them into separate functions.
Let me know if you have any thoughts on this.