### PR TITLE
chore: auto-impl `IntoValue` for `Into<Value>`

### DIFF
--- a/nova_vm/src/ecmascript/builtins/array.rs
+++ b/nova_vm/src/ecmascript/builtins/array.rs
@@ -23,7 +23,7 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            BUILTIN_STRING_MEMORY, InternalMethods, InternalSlots, IntoObject, IntoValue, Object,
+            BUILTIN_STRING_MEMORY, InternalMethods, InternalSlots, IntoObject, Object,
             OrdinaryObject, PropertyDescriptor, PropertyKey, Value,
         },
     },
@@ -185,12 +185,6 @@ unsafe impl Bindable for Array<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for Array<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/array_buffer.rs
+++ b/nova_vm/src/ecmascript/builtins/array_buffer.rs
@@ -9,9 +9,7 @@ mod data;
 use crate::{
     ecmascript::{
         execution::{Agent, JsResult, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         Scoped,
@@ -180,12 +178,6 @@ unsafe impl Bindable for ArrayBuffer<'_> {
 
 impl<'a> IntoObject<'a> for ArrayBuffer<'a> {
     fn into_object(self) -> Object<'a> {
-        self.into()
-    }
-}
-
-impl<'a> IntoValue<'a> for ArrayBuffer<'a> {
-    fn into_value(self) -> Value<'a> {
         self.into()
     }
 }

--- a/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
@@ -85,12 +85,6 @@ impl<'a> From<BuiltinConstructorIndex<'a>> for BuiltinConstructorFunction<'a> {
     }
 }
 
-impl<'a> IntoValue<'a> for BuiltinConstructorFunction<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
-    }
-}
-
 impl<'a> IntoObject<'a> for BuiltinConstructorFunction<'a> {
     fn into_object(self) -> Object<'a> {
         self.into()

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -473,12 +473,6 @@ impl<'a> From<BuiltinFunctionIndex<'a>> for BuiltinFunction<'a> {
     }
 }
 
-impl<'a> IntoValue<'a> for BuiltinFunction<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
-    }
-}
-
 impl<'a> IntoObject<'a> for BuiltinFunction<'a> {
     fn into_object(self) -> Object<'a> {
         self.into()

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/async_generator_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/async_generator_objects.rs
@@ -21,9 +21,7 @@ use crate::{
             promise_objects::promise_abstract_operations::promise_capability_records::PromiseCapability,
         },
         execution::{Agent, ExecutionContext, ProtoIntrinsics, agent::JsError},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         Executable, ExecutionResult, Scoped, SuspendedVm,
@@ -331,12 +329,6 @@ unsafe impl Bindable for AsyncGenerator<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for AsyncGenerator<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_objects.rs
@@ -13,9 +13,7 @@ use crate::{
             Agent, ExecutionContext, JsResult, ProtoIntrinsics,
             agent::{ExceptionType, JsError},
         },
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         Executable, ExecutionResult, SuspendedVm, Vm,
@@ -292,12 +290,6 @@ unsafe impl Bindable for Generator<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for Generator<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
@@ -13,7 +13,7 @@ use crate::{
         builtins::{control_abstraction_objects::promise_objects::promise_abstract_operations::promise_capability_records::PromiseCapability, ArgumentsList},
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            function_create_backing_object, function_internal_define_own_property, function_internal_delete, function_internal_get, function_internal_get_own_property, function_internal_has_property, function_internal_own_property_keys, function_internal_set, Function, FunctionInternalProperties, InternalMethods, InternalSlots, IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value
+            function_create_backing_object, function_internal_define_own_property, function_internal_delete, function_internal_get, function_internal_get_own_property, function_internal_has_property, function_internal_own_property_keys, function_internal_set, Function, FunctionInternalProperties, InternalMethods, InternalSlots, IntoFunction, IntoObject, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value
         },
     },
     heap::{
@@ -106,12 +106,6 @@ impl<'a> IntoObject<'a> for BuiltinPromiseResolvingFunction<'a> {
 impl<'a> From<BuiltinPromiseResolvingFunction<'a>> for Value<'a> {
     fn from(value: BuiltinPromiseResolvingFunction<'a>) -> Self {
         Self::BuiltinPromiseResolvingFunction(value)
-    }
-}
-
-impl<'a> IntoValue<'a> for BuiltinPromiseResolvingFunction<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/data_view.rs
+++ b/nova_vm/src/ecmascript/builtins/data_view.rs
@@ -7,9 +7,7 @@ use core::ops::{Index, IndexMut};
 use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         Scoped,
@@ -105,12 +103,6 @@ impl<'a> From<DataViewIndex<'a>> for DataView<'a> {
 impl<'a> IntoBaseIndex<'a, DataViewHeapData<'a>> for DataView<'a> {
     fn into_base_index(self) -> DataViewIndex<'a> {
         self.0
-    }
-}
-
-impl<'a> IntoValue<'a> for DataView<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/date.rs
+++ b/nova_vm/src/ecmascript/builtins/date.rs
@@ -11,9 +11,7 @@ use data::DateValue;
 use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         Scoped,
@@ -73,12 +71,6 @@ unsafe impl Bindable for Date<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for Date<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -76,12 +76,6 @@ impl<'a> From<ECMAScriptFunctionIndex<'a>> for ECMAScriptFunction<'a> {
     }
 }
 
-impl<'a> IntoValue<'a> for ECMAScriptFunction<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
-    }
-}
-
 impl<'a> IntoObject<'a> for ECMAScriptFunction<'a> {
     fn into_object(self) -> Object<'a> {
         self.into()

--- a/nova_vm/src/ecmascript/builtins/embedder_object.rs
+++ b/nova_vm/src/ecmascript/builtins/embedder_object.rs
@@ -7,9 +7,7 @@ use core::ops::{Index, IndexMut};
 use crate::{
     ecmascript::{
         execution::Agent,
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         context::{Bindable, NoGcScope},
@@ -51,12 +49,6 @@ unsafe impl Bindable for EmbedderObject<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for EmbedderObject<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/error.rs
+++ b/nova_vm/src/ecmascript/builtins/error.rs
@@ -54,12 +54,6 @@ unsafe impl Bindable for Error<'_> {
     }
 }
 
-impl<'a> IntoValue<'a> for Error<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
-    }
-}
-
 impl<'a> From<Error<'a>> for Value<'a> {
     fn from(value: Error<'a>) -> Self {
         Value::Error(value)

--- a/nova_vm/src/ecmascript/builtins/finalization_registry.rs
+++ b/nova_vm/src/ecmascript/builtins/finalization_registry.rs
@@ -7,9 +7,7 @@ use core::ops::{Index, IndexMut};
 use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         context::{Bindable, NoGcScope},
@@ -51,12 +49,6 @@ unsafe impl Bindable for FinalizationRegistry<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for FinalizationRegistry<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_iterator_objects/array_iterator.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_iterator_objects/array_iterator.rs
@@ -7,9 +7,7 @@ use core::ops::{Index, IndexMut};
 use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         context::{Bindable, NoGcScope},
@@ -61,12 +59,6 @@ unsafe impl Bindable for ArrayIterator<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for ArrayIterator<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_iterator_objects/map_iterator.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_iterator_objects/map_iterator.rs
@@ -11,9 +11,7 @@ use crate::{
             map::Map,
         },
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         context::{Bindable, NoGcScope},
@@ -61,12 +59,6 @@ unsafe impl Bindable for MapIterator<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for MapIterator<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_iterator_objects/set_iterator.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_iterator_objects/set_iterator.rs
@@ -11,9 +11,7 @@ use crate::{
             set::Set,
         },
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         context::{Bindable, NoGcScope},
@@ -61,12 +59,6 @@ unsafe impl Bindable for SetIterator<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for SetIterator<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/map.rs
+++ b/nova_vm/src/ecmascript/builtins/map.rs
@@ -8,9 +8,7 @@ use crate::{
     Heap,
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         context::{Bindable, NoGcScope},
@@ -51,12 +49,6 @@ unsafe impl Bindable for Map<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for Map<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -33,12 +33,6 @@ pub mod data;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Module<'a>(u32, PhantomData<&'a ()>);
 
-impl<'a> IntoValue<'a> for Module<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
-    }
-}
-
 impl<'a> IntoObject<'a> for Module<'a> {
     fn into_object(self) -> Object<'a> {
         self.into()

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -66,12 +66,6 @@ impl<'a> IntoObject<'a> for PrimitiveObject<'a> {
     }
 }
 
-impl<'a> IntoValue<'a> for PrimitiveObject<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
-    }
-}
-
 impl<'a> TryFrom<Object<'a>> for PrimitiveObject<'a> {
     type Error = ();
 
@@ -594,15 +588,9 @@ impl<'a> TryFrom<PrimitiveObjectData<'a>> for Symbol<'a> {
     }
 }
 
-impl<'a> IntoValue<'a> for PrimitiveObjectData<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into_primitive().into_value()
-    }
-}
-
 impl<'a> From<PrimitiveObjectData<'a>> for Value<'a> {
     fn from(value: PrimitiveObjectData<'a>) -> Self {
-        value.into_value()
+        value.into_primitive().into_value()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/promise.rs
+++ b/nova_vm/src/ecmascript/builtins/promise.rs
@@ -11,9 +11,7 @@ use crate::engine::rootable::{HeapRootData, HeapRootRef, Rootable, Scopable};
 use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     heap::{
         CreateHeapData, Heap, HeapMarkAndSweep,
@@ -80,12 +78,6 @@ unsafe impl Bindable for Promise<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for Promise<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -81,12 +81,6 @@ unsafe impl Bindable for Proxy<'_> {
     }
 }
 
-impl<'a> IntoValue<'a> for Proxy<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
-    }
-}
-
 impl<'a> IntoObject<'a> for Proxy<'a> {
     fn into_object(self) -> Object<'a> {
         self.into()

--- a/nova_vm/src/ecmascript/builtins/regexp.rs
+++ b/nova_vm/src/ecmascript/builtins/regexp.rs
@@ -11,7 +11,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            BUILTIN_STRING_MEMORY, InternalMethods, InternalSlots, IntoObject, IntoValue, Object,
+            BUILTIN_STRING_MEMORY, InternalMethods, InternalSlots, IntoObject, Object,
             ObjectHeapData, OrdinaryObject, PropertyDescriptor, PropertyKey, Value,
         },
     },
@@ -93,12 +93,6 @@ impl<'a> TryFrom<Value<'a>> for RegExp<'a> {
             Value::RegExp(regexp) => Ok(regexp),
             _ => Err(()),
         }
-    }
-}
-
-impl<'a> IntoValue<'a> for RegExp<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/set.rs
+++ b/nova_vm/src/ecmascript/builtins/set.rs
@@ -8,9 +8,7 @@ use crate::{
     Heap,
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         context::{Bindable, NoGcScope},
@@ -52,12 +50,6 @@ unsafe impl Bindable for Set<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for Set<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/shared_array_buffer.rs
+++ b/nova_vm/src/ecmascript/builtins/shared_array_buffer.rs
@@ -7,9 +7,7 @@ use core::ops::{Index, IndexMut};
 use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         context::{Bindable, NoGcScope},
@@ -51,12 +49,6 @@ unsafe impl Bindable for SharedArrayBuffer<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for SharedArrayBuffer<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/text_processing/string_objects/string_iterator_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/text_processing/string_objects/string_iterator_objects.rs
@@ -75,12 +75,6 @@ impl<'a> StringIterator<'a> {
     }
 }
 
-impl<'a> IntoValue<'a> for StringIterator<'a> {
-    fn into_value(self) -> Value<'a> {
-        Value::StringIterator(self)
-    }
-}
-
 impl<'a> IntoObject<'a> for StringIterator<'a> {
     fn into_object(self) -> Object<'a> {
         Object::StringIterator(self)
@@ -95,7 +89,7 @@ impl<'a> From<StringIterator<'a>> for Object<'a> {
 
 impl<'a> From<StringIterator<'a>> for Value<'a> {
     fn from(iter: StringIterator<'a>) -> Self {
-        iter.into_value()
+        Value::StringIterator(iter)
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/typed_array.rs
+++ b/nova_vm/src/ecmascript/builtins/typed_array.rs
@@ -240,12 +240,6 @@ impl<'a> From<TypedArray<'a>> for TypedArrayIndex<'a> {
     }
 }
 
-impl<'a> IntoValue<'a> for TypedArray<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
-    }
-}
-
 impl<'a> IntoObject<'a> for TypedArray<'a> {
     fn into_object(self) -> Object<'a> {
         self.into()

--- a/nova_vm/src/ecmascript/builtins/weak_map.rs
+++ b/nova_vm/src/ecmascript/builtins/weak_map.rs
@@ -8,9 +8,7 @@ use crate::{
     Heap,
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         context::{Bindable, NoGcScope},
@@ -52,12 +50,6 @@ unsafe impl Bindable for WeakMap<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for WeakMap<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/weak_ref.rs
+++ b/nova_vm/src/ecmascript/builtins/weak_ref.rs
@@ -7,9 +7,7 @@ use core::ops::{Index, IndexMut};
 use crate::{
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         context::{Bindable, NoGcScope},
@@ -51,12 +49,6 @@ unsafe impl Bindable for WeakRef<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for WeakRef<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/weak_set.rs
+++ b/nova_vm/src/ecmascript/builtins/weak_set.rs
@@ -8,9 +8,7 @@ use crate::{
     Heap,
     ecmascript::{
         execution::{Agent, ProtoIntrinsics},
-        types::{
-            InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, Value,
-        },
+        types::{InternalMethods, InternalSlots, IntoObject, Object, OrdinaryObject, Value},
     },
     engine::{
         context::{Bindable, NoGcScope},
@@ -52,12 +50,6 @@ unsafe impl Bindable for WeakSet<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for WeakSet<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/types/language/bigint.rs
+++ b/nova_vm/src/ecmascript/types/language/bigint.rs
@@ -6,7 +6,7 @@ mod data;
 mod operators;
 
 use super::{
-    IntoPrimitive, IntoValue, Primitive, String, Value,
+    IntoPrimitive, Primitive, String, Value,
     into_numeric::IntoNumeric,
     numeric::Numeric,
     value::{BIGINT_DISCRIMINANT, SMALL_BIGINT_DISCRIMINANT},
@@ -29,15 +29,6 @@ pub use data::BigIntHeapData;
 use num_bigint::{Sign, ToBigInt};
 use operators::{left_shift_bigint, left_shift_i64, right_shift_bigint, right_shift_i64};
 use std::ops::{BitAnd, BitOr, BitXor};
-
-impl<'a> IntoValue<'a> for BigInt<'a> {
-    fn into_value(self) -> Value<'a> {
-        match self {
-            BigInt::BigInt(data) => Value::BigInt(data.unbind()),
-            BigInt::SmallBigInt(data) => Value::SmallBigInt(data),
-        }
-    }
-}
 
 impl<'a> IntoPrimitive<'a> for BigInt<'a> {
     fn into_primitive(self) -> Primitive<'a> {
@@ -117,12 +108,6 @@ unsafe impl Bindable for HeapBigInt<'_> {
     #[inline(always)]
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
-    }
-}
-
-impl<'a> IntoValue<'a> for HeapBigInt<'a> {
-    fn into_value(self) -> Value<'a> {
-        Value::BigInt(self.unbind())
     }
 }
 

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -12,7 +12,7 @@ use super::{
         BUILTIN_PROMISE_COLLECTOR_FUNCTION_DISCRIMINANT,
         BUILTIN_PROMISE_RESOLVING_FUNCTION_DISCRIMINANT, BUILTIN_PROXY_REVOKER_FUNCTION,
         ECMASCRIPT_FUNCTION_DISCRIMINANT,
-    }, InternalMethods, IntoObject, IntoValue, Object, OrdinaryObject, InternalSlots, PropertyKey, Value, String
+    }, InternalMethods, IntoObject, Object, OrdinaryObject, InternalSlots, PropertyKey, Value, String
 };
 use crate::engine::{context::{ Bindable, GcScope, NoGcScope}, TryResult};
 use crate::{
@@ -67,12 +67,6 @@ impl core::fmt::Debug for Function<'_> {
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
         }
-    }
-}
-
-impl<'a> IntoValue<'a> for Function<'a> {
-    fn into_value(self) -> Value<'a> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/types/language/into_value.rs
+++ b/nova_vm/src/ecmascript/types/language/into_value.rs
@@ -11,8 +11,12 @@ where
     fn into_value(self) -> Value<'a>;
 }
 
-impl IntoValue<'static> for bool {
-    fn into_value(self) -> Value<'static> {
-        Value::Boolean(self)
+impl<'a, T> IntoValue<'a> for T
+where
+    T: Into<Value<'a>> + 'a + Sized + Copy,
+{
+    #[inline]
+    fn into_value(self) -> Value<'a> {
+        self.into()
     }
 }

--- a/nova_vm/src/ecmascript/types/language/number.rs
+++ b/nova_vm/src/ecmascript/types/language/number.rs
@@ -95,16 +95,6 @@ impl<'a> IntoPrimitive<'a> for HeapNumber<'a> {
     }
 }
 
-impl<'a> IntoValue<'a> for Number<'a> {
-    fn into_value(self) -> Value<'a> {
-        match self {
-            Number::Number(idx) => Value::Number(idx.unbind()),
-            Number::Integer(data) => Value::Integer(data),
-            Number::SmallF64(data) => Value::SmallF64(data),
-        }
-    }
-}
-
 impl<'a> IntoNumeric<'a> for HeapNumber<'a> {
     fn into_numeric(self) -> Numeric<'a> {
         Numeric::Number(self)

--- a/nova_vm/src/ecmascript/types/language/numeric.rs
+++ b/nova_vm/src/ecmascript/types/language/numeric.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use super::{
-    IntoPrimitive, IntoValue, Number, Primitive, Value,
+    IntoPrimitive, Number, Primitive, Value,
     bigint::{HeapBigInt, SmallBigInt},
     number::HeapNumber,
     value::{
@@ -96,18 +96,6 @@ unsafe impl Bindable for Numeric<'_> {
     }
 }
 
-impl<'a> IntoValue<'a> for Numeric<'a> {
-    fn into_value(self) -> Value<'a> {
-        match self {
-            Numeric::Number(data) => Value::Number(data.unbind()),
-            Numeric::Integer(data) => Value::Integer(data),
-            Numeric::SmallF64(data) => Value::SmallF64(data),
-            Numeric::BigInt(data) => Value::BigInt(data.unbind()),
-            Numeric::SmallBigInt(data) => Value::SmallBigInt(data),
-        }
-    }
-}
-
 impl<'a> IntoPrimitive<'a> for Numeric<'a> {
     fn into_primitive(self) -> Primitive<'a> {
         match self {
@@ -121,8 +109,14 @@ impl<'a> IntoPrimitive<'a> for Numeric<'a> {
 }
 
 impl<'a> From<Numeric<'a>> for Value<'a> {
-    fn from(value: Numeric<'a>) -> Self {
-        value.into_value()
+    fn from(num: Numeric<'a>) -> Self {
+        match num {
+            Numeric::Number(data) => Value::Number(data.unbind()),
+            Numeric::Integer(data) => Value::Integer(data),
+            Numeric::SmallF64(data) => Value::SmallF64(data),
+            Numeric::BigInt(data) => Value::BigInt(data.unbind()),
+            Numeric::SmallBigInt(data) => Value::SmallBigInt(data),
+        }
     }
 }
 

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -32,7 +32,7 @@ use super::value::{
 #[cfg(feature = "weak-refs")]
 use super::value::{WEAK_MAP_DISCRIMINANT, WEAK_REF_DISCRIMINANT, WEAK_SET_DISCRIMINANT};
 use super::{
-    Function, IntoValue, Value,
+    Function, Value,
     value::{
         ARGUMENTS_DISCRIMINANT, ARRAY_DISCRIMINANT, ARRAY_ITERATOR_DISCRIMINANT,
         ASYNC_FROM_SYNC_ITERATOR_DISCRIMINANT, ASYNC_GENERATOR_DISCRIMINANT,
@@ -195,86 +195,6 @@ pub enum Object<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct OrdinaryObject<'a>(pub(crate) ObjectIndex<'a>);
 
-impl<'a> IntoValue<'a> for Object<'a> {
-    fn into_value(self) -> Value<'a> {
-        match self {
-            Object::Object(data) => Value::Object(data.unbind()),
-            Object::BoundFunction(data) => Value::BoundFunction(data.unbind()),
-            Object::BuiltinFunction(data) => Value::BuiltinFunction(data.unbind()),
-            Object::ECMAScriptFunction(data) => Value::ECMAScriptFunction(data.unbind()),
-            Object::BuiltinGeneratorFunction => todo!(),
-            Object::BuiltinConstructorFunction(data) => {
-                Value::BuiltinConstructorFunction(data.unbind())
-            }
-            Object::BuiltinPromiseResolvingFunction(data) => {
-                Value::BuiltinPromiseResolvingFunction(data.unbind())
-            }
-            Object::BuiltinPromiseCollectorFunction => todo!(),
-            Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => Value::PrimitiveObject(data.unbind()),
-            Object::Arguments(data) => Value::Arguments(data.unbind()),
-            Object::Array(data) => Value::Array(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => Value::ArrayBuffer(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => Value::DataView(data.unbind()),
-            #[cfg(feature = "date")]
-            Object::Date(data) => Value::Date(data.unbind()),
-            Object::Error(data) => Value::Error(data.unbind()),
-            Object::FinalizationRegistry(data) => Value::FinalizationRegistry(data.unbind()),
-            Object::Map(data) => Value::Map(data.unbind()),
-            Object::Promise(data) => Value::Promise(data.unbind()),
-            Object::Proxy(data) => Value::Proxy(data.unbind()),
-            #[cfg(feature = "regexp")]
-            Object::RegExp(data) => Value::RegExp(data.unbind()),
-            #[cfg(feature = "set")]
-            Object::Set(data) => Value::Set(data.unbind()),
-            #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => Value::SharedArrayBuffer(data.unbind()),
-            #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => Value::WeakMap(data.unbind()),
-            #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => Value::WeakRef(data.unbind()),
-            #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => Value::WeakSet(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::Int8Array(data) => Value::Int8Array(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::Uint8Array(data) => Value::Uint8Array(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::Uint8ClampedArray(data) => Value::Uint8ClampedArray(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::Int16Array(data) => Value::Int16Array(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::Uint16Array(data) => Value::Uint16Array(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::Int32Array(data) => Value::Int32Array(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::Uint32Array(data) => Value::Uint32Array(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::BigInt64Array(data) => Value::BigInt64Array(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::BigUint64Array(data) => Value::BigUint64Array(data.unbind()),
-            #[cfg(feature = "proposal-float16array")]
-            Object::Float16Array(data) => Value::Float16Array(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::Float32Array(data) => Value::Float32Array(data.unbind()),
-            #[cfg(feature = "array-buffer")]
-            Object::Float64Array(data) => Value::Float64Array(data.unbind()),
-            Object::AsyncFromSyncIterator => todo!(),
-            Object::AsyncGenerator(data) => Value::AsyncGenerator(data),
-            Object::ArrayIterator(data) => Value::ArrayIterator(data.unbind()),
-            #[cfg(feature = "set")]
-            Object::SetIterator(data) => Value::SetIterator(data.unbind()),
-            Object::MapIterator(data) => Value::MapIterator(data.unbind()),
-            Object::StringIterator(data) => Value::StringIterator(data.unbind()),
-            Object::Generator(data) => Value::Generator(data.unbind()),
-            Object::Module(data) => Value::Module(data.unbind()),
-            Object::EmbedderObject(data) => Value::EmbedderObject(data.unbind()),
-        }
-    }
-}
-
 // SAFETY: Property implemented as a lifetime transmute.
 unsafe impl Bindable for Object<'_> {
     type Of<'a> = Object<'a>;
@@ -314,12 +234,6 @@ impl<'a> IntoObject<'a> for Object<'a> {
 
 impl<'a> IntoObject<'a> for OrdinaryObject<'a> {
     fn into_object(self) -> Object<'a> {
-        self.into()
-    }
-}
-
-impl<'a> IntoValue<'a> for OrdinaryObject<'a> {
-    fn into_value(self) -> Value<'a> {
         self.into()
     }
 }

--- a/nova_vm/src/ecmascript/types/language/primitive.rs
+++ b/nova_vm/src/ecmascript/types/language/primitive.rs
@@ -134,24 +134,6 @@ impl<'a> TryFrom<Value<'a>> for HeapPrimitive<'a> {
     }
 }
 
-impl<'a> IntoValue<'a> for Primitive<'a> {
-    fn into_value(self) -> Value<'a> {
-        match self {
-            Primitive::Undefined => Value::Undefined,
-            Primitive::Null => Value::Null,
-            Primitive::Boolean(data) => Value::Boolean(data),
-            Primitive::String(data) => Value::String(data.unbind()),
-            Primitive::SmallString(data) => Value::SmallString(data),
-            Primitive::Symbol(data) => Value::Symbol(data.unbind()),
-            Primitive::Number(data) => Value::Number(data.unbind()),
-            Primitive::Integer(data) => Value::Integer(data),
-            Primitive::SmallF64(data) => Value::SmallF64(data),
-            Primitive::BigInt(data) => Value::BigInt(data.unbind()),
-            Primitive::SmallBigInt(data) => Value::SmallBigInt(data),
-        }
-    }
-}
-
 impl Primitive<'_> {
     pub fn is_boolean(self) -> bool {
         matches!(self, Self::Boolean(_))
@@ -197,8 +179,20 @@ unsafe impl Bindable for Primitive<'_> {
 }
 
 impl<'a> From<Primitive<'a>> for Value<'a> {
-    fn from(value: Primitive<'a>) -> Self {
-        value.into_value()
+    fn from(primitive: Primitive<'a>) -> Self {
+        match primitive {
+            Primitive::Undefined => Value::Undefined,
+            Primitive::Null => Value::Null,
+            Primitive::Boolean(data) => Value::Boolean(data),
+            Primitive::String(data) => Value::String(data.unbind()),
+            Primitive::SmallString(data) => Value::SmallString(data),
+            Primitive::Symbol(data) => Value::Symbol(data.unbind()),
+            Primitive::Number(data) => Value::Number(data.unbind()),
+            Primitive::Integer(data) => Value::Integer(data),
+            Primitive::SmallF64(data) => Value::SmallF64(data),
+            Primitive::BigInt(data) => Value::BigInt(data.unbind()),
+            Primitive::SmallBigInt(data) => Value::SmallBigInt(data),
+        }
     }
 }
 

--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -164,15 +164,6 @@ impl<'a> TryFrom<Value<'a>> for HeapString<'a> {
     }
 }
 
-impl<'a> IntoValue<'a> for String<'a> {
-    fn into_value(self) -> Value<'a> {
-        match self {
-            String::String(idx) => Value::String(idx),
-            String::SmallString(data) => Value::SmallString(data),
-        }
-    }
-}
-
 impl<'a> IntoPrimitive<'a> for String<'a> {
     fn into_primitive(self) -> Primitive<'a> {
         match self {
@@ -241,12 +232,6 @@ impl From<SmallString> for Value<'static> {
 impl From<SmallString> for String<'static> {
     fn from(value: SmallString) -> Self {
         Self::SmallString(value)
-    }
-}
-
-impl IntoValue<'static> for SmallString {
-    fn into_value(self) -> Value<'static> {
-        self.into()
     }
 }
 

--- a/nova_vm/src/ecmascript/types/language/symbol.rs
+++ b/nova_vm/src/ecmascript/types/language/symbol.rs
@@ -20,7 +20,7 @@ use crate::{
     },
 };
 
-use super::{BUILTIN_STRING_MEMORY, IntoPrimitive, IntoValue, Primitive, Value};
+use super::{BUILTIN_STRING_MEMORY, IntoPrimitive, Primitive, Value};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
@@ -80,12 +80,6 @@ unsafe impl Bindable for Symbol<'_> {
     }
 }
 
-impl<'a> IntoValue<'a> for Symbol<'a> {
-    fn into_value(self) -> Value<'a> {
-        Value::Symbol(self.unbind())
-    }
-}
-
 impl<'a> IntoPrimitive<'a> for Symbol<'a> {
     fn into_primitive(self) -> Primitive<'a> {
         Primitive::Symbol(self.unbind())
@@ -93,8 +87,8 @@ impl<'a> IntoPrimitive<'a> for Symbol<'a> {
 }
 
 impl<'a> From<Symbol<'a>> for Value<'a> {
-    fn from(value: Symbol<'a>) -> Self {
-        value.into_value()
+    fn from(symbol: Symbol<'a>) -> Self {
+        Value::Symbol(symbol.unbind())
     }
 }
 

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -1179,7 +1179,11 @@ impl TryFrom<f64> for Value<'static> {
 
 impl<'a> From<Number<'a>> for Value<'a> {
     fn from(value: Number<'a>) -> Self {
-        value.into_value()
+        match value {
+            Number::Number(idx) => Value::Number(idx.unbind()),
+            Number::Integer(data) => Value::Integer(data),
+            Number::SmallF64(data) => Value::SmallF64(data),
+        }
     }
 }
 
@@ -1223,13 +1227,6 @@ impl_value_from_n!(u16);
 impl_value_from_n!(i16);
 impl_value_from_n!(u32);
 impl_value_from_n!(i32);
-
-impl<'a> IntoValue<'a> for Value<'a> {
-    #[inline(always)]
-    fn into_value(self) -> Value<'a> {
-        self
-    }
-}
 
 impl Rootable for Value<'_> {
     type RootRepr = ValueRootRepr;


### PR DESCRIPTION
## What This PR Does

Adds an automatic trait implementation for `IntoValue<'a>` for types that satisfy `Into<Value<'a>>`. Doing this removes a lot of redundant code.

We should probably make follow-up PRs that do something similar for `IntoObject` and `IntoPrimitive`