### PR TITLE
build: run test262 with new dev-fast profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
           shared-key: warm
           save-if: ${{ github.ref == 'main' }}
       - name: Install Dylint
-        run: cargo install cargo-dylint dylint-link
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-dylint dylint-link
       - name: Check formatting
         run: cargo fmt --check
       - name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,14 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Build
-        run: cargo build
+        run: cargo build --profile dev-fast
       - name: Test
-        run: cargo test
+        run: cargo test --profile dev-fast
         timeout-minutes: 20
       - name: Checkout test262 submodule
         run: git submodule update --init
       - name: Test262
-        run: cargo run --bin test262 -- --noprogress
+        run: cargo run --bin test262 --profile dev-fast -- --noprogress
         timeout-minutes: 15
       - name: Build binaries and examples
-        run: cargo build --bins --examples
+        run: cargo build --bins --examples --profile dev-fast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Dylint
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-dylint dylint-link
+          tool: cargo-dylint,dylint-link
       - name: Check formatting
         run: cargo fmt --check
       - name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,14 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  typos:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Spell check
+        uses: crate-ci/typos@master
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -22,10 +30,13 @@ jobs:
         with:
           toolchain: nightly-2024-11-28
           components: rustfmt, clippy, llvm-tools-preview, rustc-dev
+      - name: Cache on ${{ github.ref_name }}
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: warm
+          save-if: ${{ github.ref == 'main' }}
       - name: Install Dylint
         run: cargo install cargo-dylint dylint-link
-      - name: Spell check
-        uses: crate-ci/typos@master
       - name: Check formatting
         run: cargo fmt --check
       - name: Clippy
@@ -47,8 +58,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Cache on ${{ github.ref_name }}
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: test262
+          save-if: ${{ github.ref == 'main' }}
       - name: Build
-        run: cargo build --profile dev-fast
+        run: cargo build --tests --profile dev-fast
       - name: Test
         run: cargo test --profile dev-fast
         timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -89,3 +93,5 @@ jobs:
       - name: Run Test262
         run: cargo run --bin test262 --profile dev-fast -- --noprogress
         timeout-minutes: 15
+        env:
+          RUST_BACKTRACE: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: warm
-          save-if: ${{ github.ref == 'main' }}
       - name: Install Dylint
         uses: taiki-e/install-action@v2
         with:
@@ -52,7 +51,25 @@ jobs:
         run: cargo dylint --all
 
   build:
-    name: Build
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
+        with:
+          cache-key: warm
+          save-cache: ${{ github.ref_name == 'main' }}
+      - name: Check
+        run: cargo check --all-targets
+      - name: Build
+        run: cargo build --tests --bins --examples
+      - name: Test
+        run: cargo test 
+        env:
+          RUST_BACKTRACE: 1
+
+  test262:
+    name: Test262
     # TODO: Run CI on all three platforms.
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -65,15 +82,10 @@ jobs:
         with:
           shared-key: test262
           save-if: ${{ github.ref == 'main' }}
-      - name: Build
-        run: cargo build --tests --profile dev-fast
-      - name: Test
-        run: cargo test --profile dev-fast
-        timeout-minutes: 20
       - name: Checkout test262 submodule
         run: git submodule update --init
-      - name: Test262
+      - name: Build nova-cli
+        run: cargo build -p nova-cli --profile dev-fast
+      - name: Run Test262
         run: cargo run --bin test262 --profile dev-fast -- --noprogress
         timeout-minutes: 15
-      - name: Build binaries and examples
-        run: cargo build --bins --examples --profile dev-fast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,8 @@ jobs:
           save-if: ${{ github.ref == 'main' }}
       - name: Checkout test262 submodule
         run: git submodule update --init
-      - name: Build nova-cli
-        run: cargo build -p nova-cli --profile dev-fast
+      - name: Build nova cli
+        run: cargo build -p nova_cli --profile dev-fast
       - name: Run Test262
         run: cargo run --bin test262 --profile dev-fast -- --noprogress
         timeout-minutes: 15

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target
 Cargo.lock
 /.vscode
+# e.g. `test.js` for local testing/development
+/*.js

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,11 @@ libraries = [{ path = "nova_lint" }]
 
 [profile.release]
 lto = true
+
+# This profile has all the same safety checks as dev builds. It trades slightly
+# longer compile times for faster runs, which is worth it when running test262.
+[profile.dev-fast]
+inherits = "dev"
+opt-level = 2
+lto = "thin"
+debug = "limited"

--- a/tests/test262_runner.rs
+++ b/tests/test262_runner.rs
@@ -842,6 +842,7 @@ fn main() {
         if cfg!(windows) {
             path.set_extension("exe");
         }
+        assert!(path.exists(), "nova_cli binary is missing. Please run `cargo build -p nova_cli`");
         assert!(path.is_file());
         path
     };

--- a/tests/test262_runner.rs
+++ b/tests/test262_runner.rs
@@ -842,7 +842,10 @@ fn main() {
         if cfg!(windows) {
             path.set_extension("exe");
         }
-        assert!(path.exists(), "nova_cli binary is missing. Please run `cargo build -p nova_cli`");
+        assert!(
+            path.exists(),
+            "nova_cli binary is missing. Please run `cargo build -p nova_cli`"
+        );
         assert!(path.is_file());
         path
     };


### PR DESCRIPTION
## What This PR Does
Adds a `dev-fast` build profile and uses it to run Test262 in CI.

Using this profile trades slightly longer compile times for much faster run times. It takes ~10s longer to build dev builds while taking half the time of release builds, but runs tests 300x faster than dev while only being marginally slower than release builds.

Below are build/test times collected (quite non-scientifically) from my local machine (m1 mac pro, 16gb).
* Each build is "clean" (`cargo clean && cargo build --profile <profile>`).
* Test262 times are in "real" time (`/usr/bin/time -h cargo run --bin test262 --profile <profile>`)

|         | dev      | dev-fast | release |
|---------|----------|----------|---------|
| build   | 27.07s   | 39.83s   | 1m 06s  |
| test262 | 1m32.19s | 33.70s   | 33.58s  |

## Other Changes
- Move spell checking to separate job
- split build + unit testing and test262 into separate jobs. The latter uses a more expensive profile, and its faster to use dev profile for the former.
- add caching for lint and test262 jobs
- use `cargo binstall` to install dylink. Avoids re-compiling it on each run.
- new pushes to a PR branch will cancel in-progress jobs
- test failures will print stack traces (both unit and test262)
