### PR TITLE
feat(ecmascript): Implement `Atomics.pause` proposal

### DIFF
--- a/nova_vm/Cargo.toml
+++ b/nova_vm/Cargo.toml
@@ -70,13 +70,20 @@ annex-b-date = ["date"]
 annex-b-regexp = ["regexp"]
 
 # Enables all currently supported proposals
-proposals = ["proposal-float16array", "proposal-math-sum", "proposal-is-error"]
+proposals = [
+    "proposal-float16array",
+    "proposal-math-sum",
+    "proposal-is-error",
+    "proposal-atomics-microwait",
+]
 # Enables the [Float16Array proposal](https://tc39.es/proposal-float16array/)
 proposal-float16array = []
 # Enables the [Math.sumPrecise proposal](https://tc39.es/proposal-math-sum/)
 proposal-math-sum = []
 # Enables the [Error.isError proposal](https://tc39.es/proposal-is-error/)
 proposal-is-error = []
+# Enables the [Atomics.pause proposal](https://tc39.es/proposal-atomics-microwait/)
+proposal-atomics-microwait = ["atomics"]
 
 [build-dependencies]
 small_string = { path = "../small_string" }

--- a/nova_vm/src/builtin_strings
+++ b/nova_vm/src/builtin_strings
@@ -299,6 +299,7 @@ padStart
 parse
 parseFloat
 parseInt
+pause
 PI
 pop
 POSITIVE_INFINITY

--- a/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
@@ -292,6 +292,8 @@ impl AtomicsObject {
             ));
         }
 
+        // Consider this the "internal upper bound" on the maximum amount of
+        // time paused.
         let n = n.to_uint32(agent, gc).unwrap_or(1);
 
         // TODO: This should be implemented in a similar manner to `eval`

--- a/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
@@ -295,7 +295,8 @@ impl AtomicsObject {
         // Consider this the "internal upper bound" on the maximum amount of
         // time paused.
         let n = if let Value::Integer(n) = n {
-            u16::try_from(n.into_i64()).unwrap_or(u16::MAX)
+            let n = n.into_i64();
+            u16::try_from(n).unwrap_or(if n > 0 { u16::MAX } else { 1 })
         } else {
             1
         };

--- a/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
@@ -273,6 +273,7 @@ impl AtomicsObject {
     /// > NOTE: Due to the overhead of function calls, it is reasonable that an
     /// > inlined call to this method in an optimizing compiler waits a
     /// > different amount of time than a non-inlined call.
+    #[cfg(feature = "proposal-atomics-microwait")]
     fn pause<'gc>(
         agent: &mut Agent,
         _this_value: Value,

--- a/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
@@ -294,7 +294,7 @@ impl AtomicsObject {
 
         // Consider this the "internal upper bound" on the maximum amount of
         // time paused.
-        let n = n.to_uint32(agent, gc).unwrap_or(1);
+        let n = n.to_uint16(agent, gc).unwrap_or(1);
 
         // TODO: This should be implemented in a similar manner to `eval`
         // where we compile calls to `Atomics.pause` as a `pause` instruction

--- a/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
@@ -3,6 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::ecmascript::builtins::Behaviour;
+#[cfg(feature = "proposal-atomics-microwait")]
+use crate::ecmascript::execution::agent::ExceptionType;
 use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
@@ -120,6 +122,17 @@ impl Builtin for AtomicsObjectXor {
     const LENGTH: u8 = 3;
 
     const BEHAVIOUR: Behaviour = Behaviour::Regular(AtomicsObject::xor);
+}
+
+#[cfg(feature = "proposal-atomics-microwait")]
+struct AtomicsObjectPause;
+#[cfg(feature = "proposal-atomics-microwait")]
+impl Builtin for AtomicsObjectPause {
+    const NAME: String<'static> = BUILTIN_STRING_MEMORY.pause;
+
+    const LENGTH: u8 = 1;
+
+    const BEHAVIOUR: Behaviour = Behaviour::Regular(AtomicsObject::pause);
 }
 
 impl AtomicsObject {
@@ -240,13 +253,73 @@ impl AtomicsObject {
         Err(agent.todo("Atomics.xor", gc.into_nogc()))
     }
 
+    /// ### [1 Atomics.pause ( [ N ] )](https://tc39.es/proposal-atomics-microwait/#Atomics.pause)
+    ///
+    /// > NOTE: This method is designed for programs implementing spin-wait
+    /// > loops, such as spinlock fast paths inside of mutexes, to provide a
+    /// > hint to the CPU that it is spinning while waiting on a value. It has
+    /// > no observable behaviour other than timing.
+    /// >
+    /// > Implementations are expected to implement a pause or yield instruction
+    /// > if the best practices of the underlying architecture recommends such
+    /// > instructions in spin loops. For example, the [Intel Optimization Manual](https://www.intel.com/content/www/us/en/content-details/671488/intel-64-and-ia-32-architectures-optimization-reference-manual-volume-1.html)
+    /// > recommends the **pause** instruction.
+    ///
+    /// > NOTE: The N parameter controls how long an implementation pauses.
+    /// > Larger values result in longer waits. Implementations are encouraged
+    /// > to have an internal upper bound on the maximum amount of time paused
+    /// > on the order of tens to hundreds of nanoseconds.
+    ///
+    /// > NOTE: Due to the overhead of function calls, it is reasonable that an
+    /// > inlined call to this method in an optimizing compiler waits a
+    /// > different amount of time than a non-inlined call.
+    #[cfg(feature = "proposal-atomics-microwait")]
+    fn pause<'gc>(
+        agent: &mut Agent,
+        _this_value: Value,
+        arguments: ArgumentsList,
+        gc: GcScope<'gc, '_>,
+    ) -> JsResult<'gc, Value<'gc>> {
+        let nogc = gc.into_nogc();
+        let n = arguments.get(0);
+
+        // 1. If N is neither undefined nor an integral Number, throw a TypeError exception.
+        if !n.is_undefined() && !n.is_integer() {
+            return Err(agent.throw_exception_with_static_message(
+                ExceptionType::TypeError,
+                "Atomics.pause called with non-integral Number",
+                nogc,
+            ));
+        }
+
+        // TODO: This should be implemented in a similar manner to `eval`
+        // where we compile calls to `Atomics.pause` as a `pause` instruction
+        // directly in the bytecode to comply with the above note and the
+        // following step:
+        // 2. If the execution environment of the ECMAScript implementation supports
+        // signaling to the operating system or CPU that the current executing
+        // code is in a spin-wait loop, such as executing a pause CPU instruction,
+        // send that signal. When N is not undefined, it determines the number
+        // of times that signal is sent. The number of times the signal is sent
+        // for an integral Number N is less than or equal to the number times it
+        // is sent for N + 1 if both N and N + 1 have the same sign.
+
+        // 3. Return undefined.
+        Ok(Value::Undefined)
+    }
+
     pub(crate) fn create_intrinsic(agent: &mut Agent, realm: Realm<'static>) {
         let intrinsics = agent.get_realm_record_by_id(realm).intrinsics();
         let object_prototype = intrinsics.object_prototype();
         let this = intrinsics.atomics();
 
-        OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
-            .with_property_capacity(14)
+        let mut property_capacity = 14;
+        if cfg!(feature = "proposal-atomics-microwait") {
+            property_capacity += 1;
+        }
+
+        let builder = OrdinaryObjectBuilder::new_intrinsic_object(agent, realm, this)
+            .with_property_capacity(property_capacity)
             .with_prototype(object_prototype)
             .with_builtin_function_property::<AtomicsObjectAdd>()
             .with_builtin_function_property::<AtomicsObjectAnd>()
@@ -268,7 +341,11 @@ impl AtomicsObject {
                     .with_enumerable(false)
                     .with_configurable(true)
                     .build()
-            })
-            .build();
+            });
+
+        #[cfg(feature = "proposal-atomics-microwait")]
+        let builder = builder.with_builtin_function_property::<AtomicsObjectPause>();
+
+        builder.build();
     }
 }


### PR DESCRIPTION
Literally just a nop in our case. Added a todo for compiling it to a byte code instruction and a processor specific `pause` (https://doc.rust-lang.org/std/hint/fn.spin_loop.html probably as it compiles to `_mm_pause`/`pause`).