### PR TITLE
chore(tests): Fix test262.fyi failures

### DIFF
--- a/nova_vm/src/ecmascript/types/language/number.rs
+++ b/nova_vm/src/ecmascript/types/language/number.rs
@@ -539,7 +539,6 @@ impl<'a> Number<'a> {
                 false
             }
             (Number::Integer(x), Number::SmallF64(y)) => {
-                eprintln!("{} == {}", y.into_f64(), x.into_i64());
                 debug_assert!(
                     y.into_f64().to_bits() == (-0.0f64).to_bits()
                         || (x.into_i64() as f64) != y.into_f64()

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -471,7 +471,7 @@ impl Vm {
                     lexical_environment,
                 } => {
                     if agent.options.print_internals {
-                        println!("Error: {:?}", err.value());
+                        eprintln!("Error: {:?}", err.value());
                         eprintln!("Jumping to catch block in {ip}\n");
                     }
                     self.ip = ip as usize;

--- a/tests/parse_expectations.js
+++ b/tests/parse_expectations.js
@@ -1,11 +1,11 @@
-const exepctationResultKeys = Object.keys(
+const expectationResultKeys = Object.keys(
   JSON.parse(readTextFile("./tests/expectations.json")),
 );
 
 const baseMap = new Map();
 const baseKeys = [];
 
-for (const key of exepctationResultKeys) {
+for (const key of expectationResultKeys) {
   const lastIndex = key.lastIndexOf("/");
   const baseKey = key.substring(0, lastIndex);
   const entry = baseMap.get(baseKey);


### PR DESCRIPTION
A stderr debug print had been left in by me, and that was being picked up by test262.fyi but not by our tests, hence the discrepancy.