### PR TITLE
perf(vm): Skip unreachable code, remove redundant Jumps, avoid Push/PopReference when binding literals to variables

### DIFF
--- a/nova_vm/src/engine/bytecode/bytecode_compiler.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler.rs
@@ -2359,6 +2359,11 @@ impl<'s> CompileEvaluation<'s> for ast::ContinueStatement<'s> {
 
 impl<'s> CompileEvaluation<'s> for ast::Statement<'s> {
     fn compile(&'s self, ctx: &mut CompileContext<'_, 's, '_, '_>) {
+        if ctx.is_terminal() {
+            // OPTIMISATION: If the previous statement was terminal, then later
+            // statements cannot be executed and do not need to be compiled.
+            return;
+        }
         match self {
             ast::Statement::ExpressionStatement(x) => x.compile(ctx),
             ast::Statement::ReturnStatement(x) => x.compile(ctx),

--- a/nova_vm/src/engine/bytecode/bytecode_compiler.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler.rs
@@ -43,14 +43,14 @@ impl<'a, T: CompileEvaluation<'a>> CompileLabelledEvaluation<'a> for T {
 }
 
 pub(crate) fn is_reference(expression: &ast::Expression) -> bool {
-    match expression.get_inner_expression() {
+    matches!(
+        expression.get_inner_expression(),
         ast::Expression::Identifier(_)
-        | ast::Expression::ComputedMemberExpression(_)
-        | ast::Expression::StaticMemberExpression(_)
-        | ast::Expression::PrivateFieldExpression(_)
-        | ast::Expression::Super(_) => true,
-        _ => false,
-    }
+            | ast::Expression::ComputedMemberExpression(_)
+            | ast::Expression::StaticMemberExpression(_)
+            | ast::Expression::PrivateFieldExpression(_)
+            | ast::Expression::Super(_)
+    )
 }
 
 pub(crate) fn is_boolean_literal_true(expression: &ast::Expression) -> bool {

--- a/nova_vm/src/engine/bytecode/bytecode_compiler.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler.rs
@@ -1221,7 +1221,7 @@ impl<'s> CompileEvaluation<'s> for ast::IfStatement<'s> {
         // jump over consequent if test fails
         let jump_to_else = ctx.add_instruction_with_jump_slot(Instruction::JumpIfNot);
         self.consequent.compile(ctx);
-        let mut jump_over_else: Option<JumpIndex> = None;
+        let mut jump_over_else = None;
         if let Some(alternate) = &self.alternate {
             // Optimisation: If the an else branch exists, the consequent
             // branch needs to end in a jump over it. But if the consequent

--- a/nova_vm/src/engine/bytecode/bytecode_compiler/compile_context.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler/compile_context.rs
@@ -363,6 +363,9 @@ impl<'agent, 'script, 'gc, 'scope> CompileContext<'agent, 'script, 'gc, 'scope> 
         jump_to_catch: JumpIndex,
         incoming_control_flows: Option<Box<ControlFlowFinallyEntry<'script>>>,
     ) {
+        // TODO: there's a possible optimisation here to find an incoming
+        // control flow from a directly preceding Jump instruction, and
+        // generating that control flow block here directly.
         // A catch-version of finally stores the caught error and rethrows
         // it after performing the finally-work.
         self.set_jump_target_here(jump_to_catch);

--- a/nova_vm/src/engine/bytecode/bytecode_compiler/executable_context.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler/executable_context.rs
@@ -46,8 +46,7 @@ impl<'agent, 'gc, 'scope> ExecutableContext<'agent, 'gc, 'scope> {
         Self {
             agent,
             gc,
-            // Note: when no instructions exist, we are indeed terminal.
-            last_instruction_is_terminal: true,
+            last_instruction_is_terminal: false,
             instructions: Vec::new(),
             constants: Vec::new(),
             function_expressions: Vec::new(),

--- a/tests/expectations.json
+++ b/tests/expectations.json
@@ -14766,7 +14766,6 @@
   "staging/explicit-resource-management/await-using-throws-suppressed-error-from-try-and-disposal.js": "FAIL",
   "staging/explicit-resource-management/await-using-throws-suppressed-error-of-undefined.js": "FAIL",
   "staging/explicit-resource-management/await-using-user-code-throws-after.js": "CRASH",
-  "staging/explicit-resource-management/await-using-user-code-throws-before.js": "CRASH",
   "staging/explicit-resource-management/await-using-with-no-async-dispose-method.js": "CRASH",
   "staging/explicit-resource-management/await-using-with-sync-dispose-method.js": "CRASH",
   "staging/explicit-resource-management/call-dispose-methods.js": "CRASH",

--- a/tests/metrics.json
+++ b/tests/metrics.json
@@ -1,8 +1,8 @@
 {
   "results": {
-    "crash": 4533,
+    "crash": 4532,
     "fail": 10966,
-    "pass": 31595,
+    "pass": 31596,
     "skip": 34,
     "timeout": 4,
     "unresolved": 0


### PR DESCRIPTION
Just a bit of this and that minor bytecode perf work.