### PR TITLE
fix(ecmascript): Propagate 'use strict' directives to script execution contexts

### DIFF
--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -353,7 +353,8 @@ pub fn script_evaluation<'a>(
     let script = script.bind(gc.nogc());
     let script_record = &agent[script];
     let realm_id = script_record.realm;
-    let is_strict_mode = script_record.ecmascript_code.source_type.is_strict();
+    let is_strict_mode = script_record.ecmascript_code.source_type.is_strict()
+        || script_record.ecmascript_code.has_use_strict_directive();
     let source_code = script_record.source_code;
     let realm = agent.get_realm_record_by_id(realm_id);
 


### PR DESCRIPTION
A `"use strict"` directive at the script top level didn't actually make the script run as strict.