### PR TITLE
fix(small_string)!: SmallString::from_str_unchecked

### DIFF
--- a/nova_vm/build.rs
+++ b/nova_vm/build.rs
@@ -70,9 +70,9 @@ fn gen_builtin_strings() -> io::Result<Vec<u8>> {
         output.push_str("    r#");
         output.push_str(&replace_invalid_key_characters(string));
         if SmallString::try_from(string.as_str()).is_ok() {
-            output.push_str(": crate::ecmascript::types::String::SmallString(SmallString::from_str_unchecked(\"");
+            output.push_str(": crate::ecmascript::types::String::SmallString(unsafe { SmallString::from_str_unchecked(\"");
             output.push_str(string.as_str());
-            output.push_str("\")),\n");
+            output.push_str("\") }),\n");
         } else {
             output.push_str(
                 ": crate::ecmascript::types::String::String(HeapString(StringIndex::from_index(",

--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -311,11 +311,13 @@ impl<'a> String<'a> {
         }
     }
 
+    /// # Panics
+    /// If `message` is longer than 7 bytes.
     pub const fn from_small_string(message: &'static str) -> String<'static> {
         assert!(
-            message.len() < 8 && (message.is_empty() || message.as_bytes()[message.len() - 1] != 0)
+            message.as_bytes().len() < 8 && (message.is_empty() || message.as_bytes()[message.len() - 1] != 0)
         );
-        String::SmallString(SmallString::from_str_unchecked(message))
+        String::SmallString(unsafe { SmallString::from_str_unchecked(message) })
     }
 
     pub fn concat<'gc>(
@@ -410,7 +412,8 @@ impl<'a> String<'a> {
                 // SAFETY: Since SmallStrings are guaranteed UTF-8, `&data[..len]` is the result of
                 // concatenating UTF-8 strings, which is always valid UTF-8.
                 let str_slice = unsafe { core::str::from_utf8_unchecked(&data[..len]) };
-                SmallString::from_str_unchecked(str_slice).into()
+                // SAFETY: small statuses are guaranteed to be 7 bytes or fewer.
+                unsafe { SmallString::from_str_unchecked(str_slice) }.into()
             }
             Status::String(string) => agent.heap.create(string).bind(gc),
         }

--- a/small_string/lib.rs
+++ b/small_string/lib.rs
@@ -7,11 +7,14 @@ use std::borrow::Cow;
 
 use wtf8::{CodePoint, Wtf8};
 
+/// Maximum number of bytes a [SmallString] can inline.
+const MAX_LEN: usize = 7;
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SmallString {
     /// The string will be padded to 7 bytes with the 0xFF byte, which is never
     /// contained in valid UTF-8 or WTF-8.
-    bytes: [u8; 7],
+    bytes: [u8; MAX_LEN],
 }
 
 impl Ord for SmallString {
@@ -23,6 +26,20 @@ impl Ord for SmallString {
 impl PartialOrd for SmallString {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl PartialEq<str> for SmallString {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        self.as_bytes().eq(other.as_bytes())
+    }
+}
+
+impl PartialEq<&str> for SmallString {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        self.eq(*other)
     }
 }
 
@@ -48,7 +65,7 @@ impl SmallString {
                 break;
             }
             position += 1;
-            if position == 7 {
+            if position == MAX_LEN as u8 {
                 break;
             }
         }
@@ -251,12 +268,12 @@ impl SmallString {
     }
 
     #[inline]
-    pub const fn data(&self) -> &[u8; 7] {
+    pub const fn data(&self) -> &[u8; MAX_LEN] {
         &self.bytes
     }
 
     #[inline]
-    pub const fn data_mut(&mut self) -> &mut [u8; 7] {
+    pub const fn data_mut(&mut self) -> &mut [u8; MAX_LEN] {
         &mut self.bytes
     }
 
@@ -265,12 +282,18 @@ impl SmallString {
         matches!(self.bytes, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
     }
 
-    pub const fn from_str_unchecked(string: &str) -> Self {
+    /// Create a [SmallString] from a [str] without checking that it is small
+    /// enough to fit in the inline buffer.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that `string` 7 bytes or fewer long.
+    pub const unsafe fn from_str_unchecked(string: &str) -> Self {
         let string_bytes = string.as_bytes();
 
         // We have only 7 bytes to work with, so we must fail to convert if the
         // string is longer than that.
-        debug_assert!(string_bytes.len() < 8);
+        unsafe { std::hint::assert_unchecked(string_bytes.len() <= MAX_LEN) };
 
         match string_bytes.len() {
             0 => Self {
@@ -349,14 +372,31 @@ impl SmallString {
         }
     }
 
-    pub const fn from_wtf8_unchecked(string: &Wtf8) -> Self {
+    /// Inline a [Wtf8] into a [SmallString].
+    ///
+    /// # Panics
+    ///
+    /// If `string` is longer than 7 bytes.
+    #[inline]
+    pub fn from_wtf8(string: &Wtf8) -> Self {
+        assert!(string.len() <= MAX_LEN);
+        unsafe { Self::from_wtf8_unchecked(string) }
+    }
+
+    /// Create a [SmallString] from a [Wtf8] without checking that it is small
+    /// enough to fit in the inline buffer.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that `string` 7 bytes or fewer long.
+    pub const unsafe fn from_wtf8_unchecked(string: &Wtf8) -> Self {
         // SAFETY: The backing data of a WTF8 buffer is indeed a u8 buffer.
         // This is very sketchy but completely safe.
         let string_bytes = unsafe { core::mem::transmute::<&Wtf8, &[u8]>(string) };
 
         // We have only 7 bytes to work with, so we must fail to convert if the
         // string is longer than that.
-        debug_assert!(string_bytes.len() < 8);
+        unsafe { std::hint::assert_unchecked(string_bytes.len() <= MAX_LEN) };
 
         match string_bytes.len() {
             0 => Self {
@@ -436,7 +476,7 @@ impl SmallString {
     }
 
     pub fn from_char(ch: char) -> Self {
-        let mut bytes = [0xFF; 7];
+        let mut bytes = [0xFF; MAX_LEN];
         ch.encode_utf8(&mut bytes);
         SmallString { bytes }
     }
@@ -445,7 +485,7 @@ impl SmallString {
         if let Some(char) = ch.to_char() {
             Self::from_char(char)
         } else {
-            let mut bytes = [0xFFu8; 7];
+            let mut bytes = [0xFFu8; MAX_LEN];
 
             // Lone surrogate: these are U+D800 to U+DFFF.
             let p = ch.to_u32();
@@ -464,8 +504,9 @@ impl TryFrom<&str> for SmallString {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         // We have only 7 bytes to work with, so we must fail to convert if the
         // string is longer than that.
-        if value.len() < 8 {
-            Ok(Self::from_str_unchecked(value))
+        if value.as_bytes().len() <= MAX_LEN {
+            // SAFETY: we just checked that the string is 7 bytes or fewer.
+            Ok(unsafe { Self::from_str_unchecked(value) })
         } else {
             Err(())
         }
@@ -477,8 +518,9 @@ impl TryFrom<&Wtf8> for SmallString {
     fn try_from(value: &Wtf8) -> Result<Self, Self::Error> {
         // We have only 7 bytes to work with, so we must fail to convert if the
         // string is longer than that.
-        if value.len() < 8 {
-            Ok(Self::from_wtf8_unchecked(value))
+        if value.len() <= MAX_LEN {
+            // SAFETY: we just checked that the string is 7 bytes or fewer.
+            Ok(unsafe { Self::from_wtf8_unchecked(value) })
         } else {
             Err(())
         }
@@ -527,4 +569,21 @@ fn test_ascii() {
     for s in non_ascii {
         assert!(!SmallString::try_from(s).unwrap().is_ascii());
     }
+}
+
+#[test]
+fn str_conversion() {
+    let unicode = "🤗";
+    let str = SmallString::try_from(unicode).unwrap();
+    assert_eq!(str.len(), 4);
+    assert_eq!(str, unicode);
+
+    let str = SmallString::try_from(Wtf8::from_str(unicode)).unwrap();
+    assert_eq!(str.len(), 4);
+    assert_eq!(str, unicode);
+
+    // less than 7 characters, but more than 7 bytes
+    let too_large_unicode = "🤗🤗🤗";
+    assert!(SmallString::try_from(too_large_unicode).is_err());
+    assert!(SmallString::try_from(Wtf8::from_str(too_large_unicode)).is_err());
 }


### PR DESCRIPTION
## What This PR Does
- fix: several calls to `SmallStr::from_str_unchecked` were checking string length (not byte length) before calling `SmallStr::from_str_unchecked`. This would cause panics if given a UTF-8 string with <= 7 characters but >= 7 bytes.
- perf!: use `assert_unchecked` in `SmallStr::from_str_unchecked` and `SmallStr::from_wtf8_unchecked` to elide panic branch when given too-large strings. This required a contract change; these functions are now `unsafe`.
  > note: this lines up with other `from_<foo>_unchecked` APIs on `core::str`
- feat: implement `PartialEq` for `str` and `&str`
- refactor: use a `MAX_LEN` constant instead of referring to the magic number `7` everywhere