### PR TITLE
perf(vm): ObjectCreateWithShape

### DIFF
--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -339,6 +339,24 @@ impl<'a> OrdinaryObject<'a> {
         Self::create_object_internal(agent, shape, entries)
     }
 
+    pub(crate) fn create_object_with_shape_and_data_properties(
+        agent: &mut Agent,
+        shape: ObjectShape<'a>,
+        values: &[Value<'a>],
+    ) -> Self {
+        // SAFETY: Option<Value> uses a niche in Value enum at discriminant 0.
+        let values = unsafe { core::mem::transmute::<&[Value<'a>], &[Option<Value<'a>>]>(values) };
+        let ElementsVector {
+            elements_index: values,
+            cap,
+            len,
+            len_writable: extensible,
+        } = agent.heap.elements.allocate_property_storage(values, None);
+        agent
+            .heap
+            .create(ObjectHeapData::new(shape, values, cap, len, extensible))
+    }
+
     /// Creates a new "intrinsic" object. An intrinsic object owns its Object
     /// Shape uniquely and thus any changes to the object properties mutate the
     /// Shape directly.

--- a/nova_vm/src/engine/bytecode/bytecode_compiler.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler.rs
@@ -16,7 +16,9 @@ mod template_literals;
 mod with_statement;
 
 use super::{FunctionExpression, Instruction, SendableRef, executable::ArrowFunctionExpression};
-use crate::ecmascript::execution::agent::ExceptionType;
+use crate::ecmascript::{
+    builtins::ordinary::shape::ObjectShape, execution::agent::ExceptionType, types::IntoObject,
+};
 #[cfg(feature = "regexp")]
 use crate::ecmascript::{
     syntax_directed_operations::{
@@ -436,8 +438,107 @@ impl<'s> CompileEvaluation<'s> for ast::Function<'s> {
     }
 }
 
+fn create_object_with_shape<'s>(
+    expr: &'s ast::ObjectExpression<'s>,
+    ctx: &mut CompileContext<'_, 's, '_, '_>,
+) {
+    let proto_prop = expr.properties.iter().find(|prop| {
+        let ast::ObjectPropertyKind::ObjectProperty(prop) = prop else {
+            unreachable!()
+        };
+        prop.key.is_specific_static_name("__proto__")
+            && prop.kind == ast::PropertyKind::Init
+            && !prop.shorthand
+    });
+    let prototype = if let Some(proto_prop) = proto_prop {
+        let ast::ObjectPropertyKind::ObjectProperty(proto_prop) = proto_prop else {
+            unreachable!()
+        };
+        if proto_prop.value.is_null() {
+            None
+        } else {
+            Some(
+                ctx.get_agent()
+                    .current_realm_record()
+                    .intrinsics()
+                    .object_prototype()
+                    .into_object(),
+            )
+        }
+    } else {
+        Some(
+            ctx.get_agent()
+                .current_realm_record()
+                .intrinsics()
+                .object_prototype()
+                .into_object(),
+        )
+    };
+    let mut shape = ObjectShape::get_shape_for_prototype(ctx.get_agent_mut(), prototype);
+    for prop in expr.properties.iter() {
+        let ast::ObjectPropertyKind::ObjectProperty(prop) = prop else {
+            unreachable!()
+        };
+        if !prop.shorthand && prop.key.is_specific_static_name("__proto__") {
+            continue;
+        }
+        let ast::PropertyKey::StaticIdentifier(id) = &prop.key else {
+            unreachable!()
+        };
+        let identifier = ctx.create_property_key(&id.name);
+        shape = shape.get_child_shape(ctx.get_agent_mut(), identifier);
+        if is_anonymous_function_definition(&prop.value) {
+            ctx.add_instruction_with_constant(Instruction::StoreConstant, identifier);
+            ctx.name_identifier = Some(NamedEvaluationParameter::Result);
+        }
+        prop.value.compile(ctx);
+        if is_reference(&prop.value) {
+            ctx.add_instruction(Instruction::GetValue);
+        }
+        ctx.add_instruction(Instruction::Load);
+    }
+    ctx.add_instruction_with_shape(Instruction::ObjectCreateWithShape, shape);
+}
+
 impl<'s> CompileEvaluation<'s> for ast::ObjectExpression<'s> {
     fn compile(&'s self, ctx: &mut CompileContext<'_, 's, '_, '_>) {
+        if !self.properties.is_empty()
+            && self.properties.iter().all(|prop| {
+                !prop.is_spread() && {
+                    let ast::ObjectPropertyKind::ObjectProperty(prop) = prop else {
+                        unreachable!()
+                    };
+                    prop.kind == ast::PropertyKind::Init
+                        && !prop.method
+                        && prop.key.is_identifier()
+                        && (prop.key.is_specific_static_name("__proto__") && !prop.shorthand)
+                            .then(|| prop.value.is_null_or_undefined())
+                            .unwrap_or(true)
+                }
+            })
+        {
+            let mut dedup_keys = self
+                .properties
+                .iter()
+                .map(|prop| {
+                    let ast::ObjectPropertyKind::ObjectProperty(prop) = prop else {
+                        unreachable!()
+                    };
+                    let ast::PropertyKey::StaticIdentifier(key) = &prop.key else {
+                        unreachable!()
+                    };
+                    key.name.as_str()
+                })
+                .collect::<Vec<_>>();
+            dedup_keys.sort();
+            dedup_keys.dedup();
+            // Check that there are no duplicates.
+            if dedup_keys.len() == self.properties.len() {
+                // Can create Object Shape beforehand and calculate
+                create_object_with_shape(self, ctx);
+                return;
+            }
+        }
         // TODO: Consider preparing the properties onto the stack and creating
         // the object with a known size.
         ctx.add_instruction(Instruction::ObjectCreate);

--- a/nova_vm/src/engine/bytecode/bytecode_compiler/compile_context.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler/compile_context.rs
@@ -7,7 +7,7 @@ use wtf8::Wtf8Buf;
 
 use crate::{
     ecmascript::{
-        builtins::regexp::RegExp,
+        builtins::{ordinary::shape::ObjectShape, regexp::RegExp},
         execution::Agent,
         syntax_directed_operations::function_definitions::CompileFunctionBodyData,
         types::{BigInt, Number, PropertyKey, String, Value},
@@ -1008,6 +1008,15 @@ impl<'agent, 'script, 'gc, 'scope> CompileContext<'agent, 'script, 'gc, 'scope> 
                 function_expression,
                 immediate,
             )
+    }
+
+    pub(super) fn add_instruction_with_shape(
+        &mut self,
+        instruction: Instruction,
+        shape: ObjectShape<'gc>,
+    ) {
+        self.executable
+            .add_instruction_with_shape(instruction, shape);
     }
 
     pub(super) fn add_arrow_function_expression(

--- a/nova_vm/src/engine/bytecode/bytecode_compiler/executable_context.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler/executable_context.rs
@@ -8,7 +8,10 @@ use wtf8::Wtf8Buf;
 
 use crate::{
     ecmascript::{
-        builtins::regexp::{RegExp, reg_exp_create_literal},
+        builtins::{
+            ordinary::shape::ObjectShape,
+            regexp::{RegExp, reg_exp_create_literal},
+        },
         execution::Agent,
         types::{BigInt, IntoValue, Number, PropertyKey, String, Value},
     },
@@ -35,6 +38,8 @@ pub(super) struct ExecutableContext<'agent, 'gc, 'scope> {
     instructions: Vec<u8>,
     /// Constants being built
     constants: Vec<Value<'gc>>,
+    /// Object Shapes being built
+    shapes: Vec<ObjectShape<'gc>>,
     /// Function expressions being built
     function_expressions: Vec<FunctionExpression<'gc>>,
     /// Arrow function expressions being built
@@ -50,6 +55,7 @@ impl<'agent, 'gc, 'scope> ExecutableContext<'agent, 'gc, 'scope> {
             current_instruction_pointer_is_unreachable: false,
             instructions: Vec::new(),
             constants: Vec::new(),
+            shapes: Vec::new(),
             function_expressions: Vec::new(),
             arrow_function_expressions: Vec::new(),
             class_initializer_bytecodes: Vec::new(),
@@ -114,6 +120,7 @@ impl<'agent, 'gc, 'scope> ExecutableContext<'agent, 'gc, 'scope> {
         self.agent.heap.create(ExecutableHeapData {
             instructions: self.instructions.into_boxed_slice(),
             constants: self.constants.unbind().into_boxed_slice(),
+            shapes: self.shapes.unbind().into_boxed_slice(),
             function_expressions: self.function_expressions.unbind().into_boxed_slice(),
             arrow_function_expressions: self.arrow_function_expressions.into_boxed_slice(),
             class_initializer_bytecodes: self
@@ -185,6 +192,21 @@ impl<'agent, 'gc, 'scope> ExecutableContext<'agent, 'gc, 'scope> {
         duplicate.unwrap_or_else(|| {
             let index = self.constants.len();
             self.constants.push(identifier.into_value());
+            index
+        })
+    }
+
+    pub(super) fn add_shape(&mut self, shape: ObjectShape<'gc>) -> usize {
+        let duplicate = self
+            .shapes
+            .iter()
+            .enumerate()
+            .find(|item| item.1.eq(&shape))
+            .map(|(idx, _)| idx);
+
+        duplicate.unwrap_or_else(|| {
+            let index = self.shapes.len();
+            self.shapes.push(shape);
             index
         })
     }
@@ -297,6 +319,18 @@ impl<'agent, 'gc, 'scope> ExecutableContext<'agent, 'gc, 'scope> {
         // Note: add_index would have panicked if this was not a lossless
         // conversion.
         index as IndexType
+    }
+
+    pub(super) fn add_instruction_with_shape(
+        &mut self,
+        instruction: Instruction,
+        shape: ObjectShape<'gc>,
+    ) {
+        debug_assert_eq!(instruction.argument_count(), 1);
+        debug_assert!(instruction.has_shape_index());
+        self.push_instruction(instruction);
+        let shape = self.add_shape(shape.into());
+        self.add_index(shape);
     }
 
     pub(super) fn add_arrow_function_expression(

--- a/nova_vm/src/engine/bytecode/instructions.rs
+++ b/nova_vm/src/engine/bytecode/instructions.rs
@@ -219,6 +219,9 @@ pub enum Instruction {
     LogicalNot,
     /// Store OrdinaryObjectCreate(%Object.prototype%) on the stack.
     ObjectCreate,
+    /// Store a new as the result Object created with the given shape, with its
+    /// properties coming from the stack.
+    ObjectCreateWithShape,
     /// Call CreateDataPropertyOrThrow(object, key, value) with value being the
     /// result value, key being the top stack value and object being the second
     /// stack value. The object is not popped from the stack.
@@ -527,6 +530,7 @@ impl Instruction {
             | Self::LoadConstant
             | Self::MakePrivateReference
             | Self::MakeSuperPropertyReferenceWithIdentifierKey
+            | Self::ObjectCreateWithShape
             | Self::ClassInitializePrivateValue
             | Self::ResolveBinding
             | Self::StoreConstant
@@ -557,6 +561,10 @@ impl Instruction {
                 | Self::LoadConstant
                 | Self::StoreConstant
         )
+    }
+
+    pub fn has_shape_index(self) -> bool {
+        matches!(self, Self::ObjectCreateWithShape)
     }
 
     pub fn has_identifier_index(self) -> bool {
@@ -1177,6 +1185,7 @@ impl TryFrom<u8> for Instruction {
         const EMPTY: u8 = Instruction::Empty.as_u8();
         const LOGICALNOT: u8 = Instruction::LogicalNot.as_u8();
         const OBJECTCREATE: u8 = Instruction::ObjectCreate.as_u8();
+        const OBJECTCREATEWITHSHAPE: u8 = Instruction::ObjectCreateWithShape.as_u8();
         const OBJECTDEFINEPROPERTY: u8 = Instruction::ObjectDefineProperty.as_u8();
         const OBJECTDEFINEMETHOD: u8 = Instruction::ObjectDefineMethod.as_u8();
         const OBJECTDEFINEGETTER: u8 = Instruction::ObjectDefineGetter.as_u8();
@@ -1383,6 +1392,7 @@ impl TryFrom<u8> for Instruction {
             EMPTY => Ok(Instruction::Empty),
             LOGICALNOT => Ok(Instruction::LogicalNot),
             OBJECTCREATE => Ok(Instruction::ObjectCreate),
+            OBJECTCREATEWITHSHAPE => Ok(Instruction::ObjectCreateWithShape),
             OBJECTDEFINEPROPERTY => Ok(Instruction::ObjectDefineProperty),
             OBJECTDEFINEMETHOD => Ok(Instruction::ObjectDefineMethod),
             OBJECTDEFINEGETTER => Ok(Instruction::ObjectDefineGetter),

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -1131,6 +1131,19 @@ impl Vm {
                 );
                 vm.stack.push(object.into_value().unbind())
             }
+            Instruction::ObjectCreateWithShape => {
+                let shape =
+                    executable.fetch_object_shape(agent, instr.get_first_index(), gc.into_nogc());
+                let len = shape.get_length(agent);
+                let first_property_index = vm.stack.len() - len as usize;
+                let obj = OrdinaryObject::create_object_with_shape_and_data_properties(
+                    agent,
+                    shape,
+                    &vm.stack[first_property_index..],
+                );
+                vm.stack.truncate(first_property_index);
+                vm.result = Some(obj.unbind().into_value());
+            }
             Instruction::CopyDataProperties => {
                 let source = vm.result.take().unwrap();
                 let Value::Object(target) = *vm.stack.last().unwrap() else {

--- a/nova_vm/src/heap/element_array.rs
+++ b/nova_vm/src/heap/element_array.rs
@@ -2239,6 +2239,16 @@ impl ElementArrays {
         self.allocate_object_property_storage(length, &values, descriptors)
     }
 
+    pub(crate) fn allocate_property_storage<'a>(
+        &mut self,
+        values: &[Option<Value<'a>>],
+        descriptors: Option<AHashMap<u32, ElementDescriptor<'static>>>,
+    ) -> ElementsVector<'a> {
+        let length = values.len();
+        self.allocate_object_property_storage(length, values, descriptors)
+            .unbind()
+    }
+
     pub(crate) fn allocate_object_property_storage_from_entries_slice<'a>(
         &mut self,
         entries: &[ObjectEntry<'a>],


### PR DESCRIPTION
Nice optimisation for the usual object literal creation strategy: if the Object shape can be statically determined and all properties are (unique) data properties, we'll create the object with the shape predetermined and properties assigned in one go.