### PR TITLE
ci(release): Add linux arm target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
             asset-name: nova-linux-amd64
 
+          # Linux (ARM)
+          - os: ubuntu-24.04-arm
+            rust-target: aarch64-unknown-linux-gnu
+            asset-name: nova-linux-arm64
+
           # macOS (Intel)
           - os: macos-13
             rust-target: x86_64-apple-darwin


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/#how-to-use-the-runners