### PR TITLE
perf(engine): Unbox SourceCode's internal Allocator

### DIFF
--- a/nova_vm/src/ecmascript/abstract_operations/testing_and_comparison.rs
+++ b/nova_vm/src/ecmascript/abstract_operations/testing_and_comparison.rs
@@ -4,23 +4,22 @@
 
 //! ## [7.2 Testing and Comparison Operations](https://tc39.es/ecma262/#sec-testing-and-comparison-operations)
 
-use crate::ecmascript::abstract_operations::type_conversion::to_numeric_primitive;
-use crate::ecmascript::builtins::proxy::abstract_operations::{
-    NonRevokedProxy, validate_non_revoked_proxy,
-};
-use crate::ecmascript::types::{Numeric, Primitive, PropertyKey};
-use crate::engine::TryResult;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::Scopable;
-use crate::heap::WellKnownSymbolIndexes;
 use crate::{
     ecmascript::{
+        abstract_operations::type_conversion::to_numeric_primitive,
+        builtins::proxy::abstract_operations::{NonRevokedProxy, validate_non_revoked_proxy},
         execution::{Agent, JsResult, agent::ExceptionType},
         types::{
-            Function, InternalMethods, IntoValue, Number, Object, String, Value, bigint::BigInt,
+            Function, InternalMethods, IntoValue, Number, Numeric, Object, Primitive, PropertyKey,
+            String, Value, bigint::BigInt,
         },
     },
-    heap::PrimitiveHeapIndexable,
+    engine::{
+        TryResult,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::Scopable,
+    },
+    heap::{PrimitiveHeapIndexable, WellKnownSymbolIndexes},
 };
 
 use super::operations_on_objects::get;

--- a/nova_vm/src/ecmascript/builtins/array_buffer/abstract_operations.rs
+++ b/nova_vm/src/ecmascript/builtins/array_buffer/abstract_operations.rs
@@ -3,17 +3,18 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{ArrayBuffer, ArrayBufferHeapData};
-use crate::ecmascript::abstract_operations::type_conversion::to_index;
-use crate::ecmascript::types::{Numeric, Viewable};
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::heap::CreateHeapData;
 use crate::{
     Heap,
     ecmascript::{
-        abstract_operations::operations_on_objects::get,
+        abstract_operations::{operations_on_objects::get, type_conversion::to_index},
         execution::{Agent, JsResult, agent::ExceptionType},
-        types::{BUILTIN_STRING_MEMORY, DataBlock, Function, IntoFunction, Number, Object, Value},
+        types::{
+            BUILTIN_STRING_MEMORY, DataBlock, Function, IntoFunction, Number, Numeric, Object,
+            Value, Viewable,
+        },
     },
+    engine::context::{Bindable, GcScope, NoGcScope},
+    heap::CreateHeapData,
 };
 
 // TODO: Implement the contents of the `DetachKey` struct?

--- a/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
@@ -6,11 +6,6 @@ use core::ops::{Index, IndexMut};
 
 use oxc_span::Span;
 
-use crate::ecmascript::types::{function_try_get, function_try_has_property, function_try_set};
-use crate::engine::TryResult;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::{HeapRootData, HeapRootRef, Rootable};
-use crate::heap::HeapSweepWeakReference;
 use crate::{
     ecmascript::{
         execution::{
@@ -28,13 +23,17 @@ use crate::{
             function_create_backing_object, function_internal_define_own_property,
             function_internal_delete, function_internal_get, function_internal_get_own_property,
             function_internal_has_property, function_internal_own_property_keys,
-            function_internal_set,
+            function_internal_set, function_try_get, function_try_has_property, function_try_set,
         },
     },
-    engine::Executable,
+    engine::{
+        Executable, TryResult,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::{HeapRootData, HeapRootRef, Rootable},
+    },
     heap::{
-        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, ObjectEntry,
-        ObjectEntryPropertyDescriptor, WorkQueues, indexes::BuiltinConstructorIndex,
+        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, HeapSweepWeakReference,
+        ObjectEntry, ObjectEntryPropertyDescriptor, WorkQueues, indexes::BuiltinConstructorIndex,
     },
 };
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/async_function_objects/async_function_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/async_function_objects/async_function_constructor.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::engine::context::{Bindable, GcScope};
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -13,6 +12,7 @@ use crate::{
         },
         types::{BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Object, String, Value},
     },
+    engine::context::{Bindable, GcScope},
     heap::IntrinsicConstructorIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/async_generator_function_objects/async_generator_function_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/async_generator_function_objects/async_generator_function_constructor.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::types::IntoValue;
-use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -12,8 +10,9 @@ use crate::{
         fundamental_objects::function_objects::function_constructor::{
             DynamicFunctionKind, create_dynamic_function,
         },
-        types::{BUILTIN_STRING_MEMORY, Function, IntoObject, Object, String, Value},
+        types::{BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Object, String, Value},
     },
+    engine::context::GcScope,
     heap::IntrinsicConstructorIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_function_objects/generator_function_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_function_objects/generator_function_constructor.rs
@@ -2,11 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::operations_on_objects::try_define_property_or_throw;
-use crate::engine::context::{Bindable, GcScope};
-use crate::engine::unwrap_try;
 use crate::{
     ecmascript::{
+        abstract_operations::operations_on_objects::try_define_property_or_throw,
         builders::builtin_function_builder::BuiltinFunctionBuilder,
         builtins::{
             ArgumentsList, Behaviour, Builtin, BuiltinIntrinsicConstructor,
@@ -20,6 +18,10 @@ use crate::{
             BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Object, PropertyDescriptor,
             String, Value,
         },
+    },
+    engine::{
+        context::{Bindable, GcScope},
+        unwrap_try,
     },
     heap::IntrinsicConstructorIndexes,
 };

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_objects.rs
@@ -4,10 +4,6 @@
 
 use core::ops::{Index, IndexMut};
 
-use crate::ecmascript::types::IntoValue;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::Scopable;
-use crate::heap::HeapSweepWeakReference;
 use crate::{
     ecmascript::{
         abstract_operations::operations_on_iterator_objects::create_iter_result_object,
@@ -15,11 +11,16 @@ use crate::{
             Agent, ExecutionContext, JsResult, ProtoIntrinsics,
             agent::{ExceptionType, JsError},
         },
-        types::{InternalMethods, InternalSlots, Object, OrdinaryObject, Value},
+        types::{InternalMethods, InternalSlots, IntoValue, Object, OrdinaryObject, Value},
     },
-    engine::{Executable, ExecutionResult, SuspendedVm, rootable::HeapRootData},
+    engine::{
+        Executable, ExecutionResult, SuspendedVm,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::{HeapRootData, Scopable},
+    },
     heap::{
-        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, WorkQueues,
+        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, HeapSweepWeakReference,
+        WorkQueues,
         indexes::{BaseIndex, GeneratorIndex},
     },
 };

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/generator_prototype.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::engine::context::{Bindable, GcScope};
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -10,6 +9,7 @@ use crate::{
         execution::{Agent, JsResult, Realm, agent::ExceptionType},
         types::{BUILTIN_STRING_MEMORY, IntoValue, String, Value},
     },
+    engine::context::{Bindable, GcScope},
     heap::{IntrinsicFunctionIndexes, WellKnownSymbolIndexes},
 };
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/async_iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/async_iterator_prototype.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::engine::context::{Bindable, GcScope};
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -10,6 +9,7 @@ use crate::{
         execution::{Agent, JsResult, Realm},
         types::{BUILTIN_STRING_MEMORY, PropertyKey, String, Value},
     },
+    engine::context::{Bindable, GcScope},
     heap::WellKnownSymbolIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/iteration/iterator_prototype.rs
@@ -2,27 +2,28 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::operations_on_iterator_objects::{
-    IteratorRecord, get_iterator_direct, if_abrupt_close_iterator, iterator_close_with_error,
-    iterator_close_with_value, iterator_step_value,
-};
-use crate::ecmascript::abstract_operations::operations_on_objects::{
-    call, setter_that_ignores_prototype_properties, throw_not_callable,
-};
-use crate::ecmascript::abstract_operations::testing_and_comparison::is_callable;
-use crate::ecmascript::abstract_operations::type_conversion::to_boolean;
-use crate::ecmascript::builtins::{Array, BuiltinGetter, BuiltinSetter};
-use crate::ecmascript::execution::agent::ExceptionType;
-use crate::ecmascript::types::{IntoObject, IntoValue, Object};
-use crate::engine::ScopableCollection;
-use crate::engine::context::{Bindable, GcScope};
-use crate::engine::rootable::Scopable;
 use crate::{
     ecmascript::{
+        abstract_operations::{
+            operations_on_iterator_objects::{
+                IteratorRecord, get_iterator_direct, if_abrupt_close_iterator,
+                iterator_close_with_error, iterator_close_with_value, iterator_step_value,
+            },
+            operations_on_objects::{
+                call, setter_that_ignores_prototype_properties, throw_not_callable,
+            },
+            testing_and_comparison::is_callable,
+            type_conversion::to_boolean,
+        },
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
-        builtins::{ArgumentsList, Behaviour, Builtin},
-        execution::{Agent, JsResult, Realm},
-        types::{BUILTIN_STRING_MEMORY, PropertyKey, String, Value},
+        builtins::{ArgumentsList, Array, Behaviour, Builtin, BuiltinGetter, BuiltinSetter},
+        execution::{Agent, JsResult, Realm, agent::ExceptionType},
+        types::{BUILTIN_STRING_MEMORY, IntoObject, IntoValue, Object, PropertyKey, String, Value},
+    },
+    engine::{
+        ScopableCollection,
+        context::{Bindable, GcScope},
+        rootable::Scopable,
     },
     heap::WellKnownSymbolIndexes,
 };

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_capability_records.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_capability_records.rs
@@ -4,13 +4,9 @@
 
 //! ## [27.2.1.1 PromiseCapability Records]()
 
-use crate::ecmascript::abstract_operations::operations_on_objects::try_get;
-use crate::engine::TryResult;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::Scopable;
 use crate::{
     ecmascript::{
-        abstract_operations::operations_on_objects::get,
+        abstract_operations::operations_on_objects::{get, try_get},
         builtins::promise::{
             Promise,
             data::{PromiseHeapData, PromiseState},
@@ -20,6 +16,11 @@ use crate::{
             agent::{ExceptionType, PromiseRejectionTrackerOperation},
         },
         types::{BUILTIN_STRING_MEMORY, Function, IntoValue, Object, Value},
+    },
+    engine::{
+        TryResult,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::Scopable,
     },
     heap::{CompactionLists, CreateHeapData, HeapMarkAndSweep, WorkQueues},
 };

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_jobs.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_jobs.rs
@@ -4,27 +4,31 @@
 
 //! ## [27.2.2 Promise Jobs](https://tc39.es/ecma262/#sec-promise-jobs)
 
-use crate::ecmascript::abstract_operations::operations_on_iterator_objects::{
-    create_iter_result_object, iterator_close_with_error,
-};
-use crate::ecmascript::scripts_and_modules::module::module_semantics::cyclic_module_records::{
-    async_module_execution_fulfilled, async_module_execution_rejected,
-};
-use crate::ecmascript::scripts_and_modules::module::{
-    import_get_module_namespace, link_and_evaluate,
-};
-use crate::engine::Global;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::Scopable;
 use crate::{
     ecmascript::{
-        abstract_operations::operations_on_objects::{call_function, get_function_realm},
+        abstract_operations::{
+            operations_on_iterator_objects::{
+                create_iter_result_object, iterator_close_with_error,
+            },
+            operations_on_objects::{call_function, get_function_realm},
+        },
         builtins::{ArgumentsList, promise::Promise},
         execution::{
             Agent, JsResult,
             agent::{InnerJob, Job, JsError},
         },
+        scripts_and_modules::module::{
+            import_get_module_namespace, link_and_evaluate,
+            module_semantics::cyclic_module_records::{
+                async_module_execution_fulfilled, async_module_execution_rejected,
+            },
+        },
         types::{Function, IntoValue, Object, Value},
+    },
+    engine::{
+        Global,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::Scopable,
     },
     heap::CreateHeapData,
 };

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
@@ -4,21 +4,30 @@
 
 use core::ops::{Index, IndexMut};
 
-use crate::ecmascript::types::{function_try_get, function_try_has_property, function_try_set};
-use crate::engine::context::{ Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::{HeapRootData, HeapRootRef, Rootable};
-use crate::engine::TryResult;
-use crate::heap::{CompactionLists, HeapSweepWeakReference, WorkQueues};
 use crate::{
     ecmascript::{
-        builtins::{control_abstraction_objects::promise_objects::promise_abstract_operations::promise_capability_records::PromiseCapability, ArgumentsList},
+        builtins::{
+            ArgumentsList,
+            promise_objects::promise_abstract_operations::promise_capability_records::PromiseCapability,
+        },
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            function_create_backing_object, function_internal_define_own_property, function_internal_delete, function_internal_get, function_internal_get_own_property, function_internal_has_property, function_internal_own_property_keys, function_internal_set, Function, FunctionInternalProperties, InternalMethods, InternalSlots, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value
+            Function, FunctionInternalProperties, InternalMethods, InternalSlots, Object,
+            OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
+            function_create_backing_object, function_internal_define_own_property,
+            function_internal_delete, function_internal_get, function_internal_get_own_property,
+            function_internal_has_property, function_internal_own_property_keys,
+            function_internal_set, function_try_get, function_try_has_property, function_try_set,
         },
     },
+    engine::{
+        TryResult,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::{HeapRootData, HeapRootRef, Rootable},
+    },
     heap::{
-        indexes::BaseIndex, CreateHeapData, Heap, HeapMarkAndSweep,
+        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, HeapSweepWeakReference,
+        WorkQueues, indexes::BaseIndex,
     },
 };
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_prototype.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
 use crate::{
     ecmascript::{
         abstract_operations::operations_on_objects::invoke,
@@ -20,6 +19,7 @@ use crate::{
         },
         types::{BUILTIN_STRING_MEMORY, Function, IntoValue, String, Value},
     },
+    engine::context::{Bindable, GcScope, NoGcScope},
     heap::{CreateHeapData, WellKnownSymbolIndexes},
 };
 

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -26,7 +26,8 @@ use crate::{
         },
         scripts_and_modules::{ScriptOrModule, source_code::SourceCode},
         syntax_directed_operations::function_definitions::{
-            evaluate_async_function_body, evaluate_function_body, evaluate_generator_body,
+            evaluate_async_function_body, evaluate_async_generator_body, evaluate_function_body,
+            evaluate_generator_body,
         },
         types::{
             BUILTIN_STRING_MEMORY, ECMAScriptFunctionHeapData, Function,
@@ -35,24 +36,17 @@ use crate::{
             function_create_backing_object, function_internal_define_own_property,
             function_internal_delete, function_internal_get, function_internal_get_own_property,
             function_internal_has_property, function_internal_own_property_keys,
-            function_internal_set,
+            function_internal_set, function_try_get, function_try_has_property, function_try_set,
         },
     },
-    engine::{Executable, rootable::Scopable},
+    engine::{
+        Executable, TryResult,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::{HeapRootData, HeapRootRef, Rootable, Scopable},
+    },
     heap::{
         CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, HeapSweepWeakReference,
         WorkQueues, indexes::ECMAScriptFunctionIndex,
-    },
-};
-use crate::{
-    ecmascript::{
-        syntax_directed_operations::function_definitions::evaluate_async_generator_body,
-        types::{function_try_get, function_try_has_property, function_try_set},
-    },
-    engine::{
-        TryResult,
-        context::{Bindable, GcScope, NoGcScope},
-        rootable::{HeapRootData, HeapRootRef, Rootable},
     },
 };
 

--- a/nova_vm/src/ecmascript/builtins/error.rs
+++ b/nova_vm/src/ecmascript/builtins/error.rs
@@ -8,22 +8,23 @@ use core::ops::{Index, IndexMut};
 
 pub(crate) use data::ErrorHeapData;
 
-use crate::ecmascript::types::IntoObject;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::{HeapRootData, HeapRootRef, Rootable};
-use crate::engine::{TryResult, unwrap_try};
-use crate::heap::HeapSweepWeakReference;
 use crate::{
     ecmascript::{
         execution::{Agent, JsResult, ProtoIntrinsics, agent::ExceptionType},
         types::{
-            BUILTIN_STRING_MEMORY, InternalMethods, InternalSlots, IntoValue, Object,
+            BUILTIN_STRING_MEMORY, InternalMethods, InternalSlots, IntoObject, IntoValue, Object,
             OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
         },
     },
+    engine::{
+        TryResult,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::{HeapRootData, HeapRootRef, Rootable},
+        unwrap_try,
+    },
     heap::{
-        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, ObjectEntry,
-        ObjectEntryPropertyDescriptor, WorkQueues, indexes::ErrorIndex,
+        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, HeapSweepWeakReference,
+        ObjectEntry, ObjectEntryPropertyDescriptor, WorkQueues, indexes::ErrorIndex,
     },
 };
 

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/boolean_objects/boolean_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/boolean_objects/boolean_constructor.rs
@@ -2,28 +2,21 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::type_conversion::to_boolean;
-use crate::ecmascript::builders::builtin_function_builder::BuiltinFunctionBuilder;
-use crate::ecmascript::builtins::ArgumentsList;
-use crate::ecmascript::builtins::Behaviour;
-use crate::ecmascript::builtins::Builtin;
-use crate::ecmascript::builtins::BuiltinIntrinsicConstructor;
-use crate::ecmascript::builtins::ordinary::ordinary_create_from_constructor;
-use crate::ecmascript::builtins::primitive_objects::PrimitiveObject;
-use crate::ecmascript::builtins::primitive_objects::PrimitiveObjectData;
-use crate::ecmascript::execution::Agent;
-use crate::ecmascript::execution::JsResult;
-use crate::ecmascript::execution::ProtoIntrinsics;
-use crate::ecmascript::execution::Realm;
-use crate::ecmascript::types::BUILTIN_STRING_MEMORY;
-use crate::ecmascript::types::Function;
-use crate::ecmascript::types::IntoObject;
-use crate::ecmascript::types::IntoValue;
-use crate::ecmascript::types::Object;
-use crate::ecmascript::types::{String, Value};
-use crate::engine::context::Bindable;
-use crate::engine::context::GcScope;
-use crate::heap::IntrinsicConstructorIndexes;
+use crate::{
+    ecmascript::{
+        abstract_operations::type_conversion::to_boolean,
+        builders::builtin_function_builder::BuiltinFunctionBuilder,
+        builtins::{
+            ArgumentsList, Behaviour, Builtin, BuiltinIntrinsicConstructor,
+            ordinary::ordinary_create_from_constructor,
+            primitive_objects::{PrimitiveObject, PrimitiveObjectData},
+        },
+        execution::{Agent, JsResult, ProtoIntrinsics, Realm},
+        types::{BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Object, String, Value},
+    },
+    engine::context::{Bindable, GcScope},
+    heap::IntrinsicConstructorIndexes,
+};
 
 pub(crate) struct BooleanConstructor;
 

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/aggregate_error_constructors.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/aggregate_error_constructors.rs
@@ -2,16 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::operations_on_objects::{
-    create_array_from_scoped_list, throw_not_callable,
-};
-use crate::engine::context::{Bindable, GcScope};
-use crate::engine::rootable::Scopable;
 use crate::{
     ecmascript::{
         abstract_operations::{
             operations_on_iterator_objects::{get_iterator, iterator_to_list},
-            operations_on_objects::define_property_or_throw,
+            operations_on_objects::{
+                create_array_from_scoped_list, define_property_or_throw, throw_not_callable,
+            },
             type_conversion::to_string,
         },
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -24,6 +21,10 @@ use crate::{
             BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Object, PropertyDescriptor,
             PropertyKey, String, Value,
         },
+    },
+    engine::{
+        context::{Bindable, GcScope},
+        rootable::Scopable,
     },
     heap::IntrinsicConstructorIndexes,
 };

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/error_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/error_constructor.rs
@@ -2,35 +2,31 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::operations_on_objects::get;
-use crate::ecmascript::abstract_operations::operations_on_objects::has_property;
-use crate::ecmascript::abstract_operations::type_conversion::to_string;
-use crate::ecmascript::builders::builtin_function_builder::BuiltinFunctionBuilder;
-use crate::ecmascript::builtins::ArgumentsList;
-use crate::ecmascript::builtins::Behaviour;
-use crate::ecmascript::builtins::Builtin;
-use crate::ecmascript::builtins::BuiltinIntrinsicConstructor;
-use crate::ecmascript::builtins::error::Error;
-use crate::ecmascript::builtins::ordinary::ordinary_create_from_constructor;
-use crate::ecmascript::execution::Agent;
-use crate::ecmascript::execution::JsResult;
-use crate::ecmascript::execution::ProtoIntrinsics;
-use crate::ecmascript::execution::Realm;
-use crate::ecmascript::execution::agent::ExceptionType;
-use crate::ecmascript::types::BUILTIN_STRING_MEMORY;
-use crate::ecmascript::types::Function;
-use crate::ecmascript::types::IntoObject;
-use crate::ecmascript::types::IntoValue;
-use crate::ecmascript::types::Object;
-use crate::ecmascript::types::PropertyKey;
-use crate::ecmascript::types::String;
-use crate::ecmascript::types::Value;
-use crate::engine::context::Bindable;
-use crate::engine::context::GcScope;
 #[cfg(feature = "proposal-is-error")]
 use crate::engine::context::NoGcScope;
-use crate::engine::rootable::Scopable;
-use crate::heap::IntrinsicConstructorIndexes;
+use crate::{
+    ecmascript::{
+        abstract_operations::{
+            operations_on_objects::{get, has_property},
+            type_conversion::to_string,
+        },
+        builders::builtin_function_builder::BuiltinFunctionBuilder,
+        builtins::{
+            ArgumentsList, Behaviour, Builtin, BuiltinIntrinsicConstructor, error::Error,
+            ordinary::ordinary_create_from_constructor,
+        },
+        execution::{Agent, JsResult, ProtoIntrinsics, Realm, agent::ExceptionType},
+        types::{
+            BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Object, PropertyKey, String,
+            Value,
+        },
+    },
+    engine::{
+        context::{Bindable, GcScope},
+        rootable::Scopable,
+    },
+    heap::IntrinsicConstructorIndexes,
+};
 
 pub(crate) struct ErrorConstructor;
 

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/native_error_constructors.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/native_error_constructors.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::engine::context::{Bindable, GcScope};
-use crate::engine::rootable::Scopable;
 use crate::{
     ecmascript::{
         abstract_operations::type_conversion::to_string,
@@ -14,6 +12,10 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics, Realm, agent::ExceptionType},
         types::{BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Object, String, Value},
+    },
+    engine::{
+        context::{Bindable, GcScope},
+        rootable::Scopable,
     },
     heap::IntrinsicConstructorIndexes,
 };

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/function_objects/function_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/function_objects/function_prototype.rs
@@ -2,33 +2,32 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::operations_on_objects::{
-    try_get, try_has_own_property,
-};
-use crate::ecmascript::abstract_operations::type_conversion::to_integer_or_infinity_number;
-use crate::ecmascript::builtins::SetFunctionNamePrefix;
-use crate::engine::TryResult;
-use crate::engine::context::{Bindable, GcScope};
-use crate::engine::rootable::Scopable;
 use crate::{
     ecmascript::{
         abstract_operations::{
             operations_on_objects::{
                 call_function, create_list_from_array_like, get, has_own_property,
-                ordinary_has_instance,
+                ordinary_has_instance, try_get, try_has_own_property,
             },
             testing_and_comparison::is_callable,
+            type_conversion::to_integer_or_infinity_number,
         },
         builders::builtin_function_builder::BuiltinFunctionBuilder,
         builtins::{
             ArgumentsList, Behaviour, Builtin, BuiltinFunction, BuiltinIntrinsic,
-            BuiltinIntrinsicConstructor, bound_function::bound_function_create, set_function_name,
+            BuiltinIntrinsicConstructor, SetFunctionNamePrefix,
+            bound_function::bound_function_create, set_function_name,
         },
         execution::{Agent, JsResult, Realm, agent::ExceptionType},
         types::{
             BUILTIN_STRING_MEMORY, Function, InternalSlots, IntoFunction, IntoObject, IntoValue,
             Number, OrdinaryObject, PropertyKey, String, Value,
         },
+    },
+    engine::{
+        TryResult,
+        context::{Bindable, GcScope},
+        rootable::Scopable,
     },
     heap::{
         IntrinsicConstructorIndexes, IntrinsicFunctionIndexes, ObjectEntry,

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/symbol_objects/symbol_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/symbol_objects/symbol_constructor.rs
@@ -2,28 +2,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::type_conversion::to_string;
-use crate::ecmascript::builders::builtin_function_builder::BuiltinFunctionBuilder;
-use crate::ecmascript::builtins::ArgumentsList;
-use crate::ecmascript::builtins::Behaviour;
-use crate::ecmascript::builtins::Builtin;
-use crate::ecmascript::builtins::BuiltinIntrinsicConstructor;
-use crate::ecmascript::execution::Agent;
-use crate::ecmascript::execution::JsResult;
-use crate::ecmascript::execution::Realm;
-use crate::ecmascript::execution::agent::ExceptionType;
-use crate::ecmascript::types::IntoObject;
-
-use crate::ecmascript::types::BUILTIN_STRING_MEMORY;
-use crate::ecmascript::types::IntoValue;
-use crate::ecmascript::types::Object;
-use crate::ecmascript::types::String;
-use crate::ecmascript::types::SymbolHeapData;
-use crate::ecmascript::types::Value;
-use crate::engine::context::{Bindable, GcScope};
-use crate::heap::CreateHeapData;
-use crate::heap::IntrinsicConstructorIndexes;
-use crate::heap::WellKnownSymbolIndexes;
+use crate::{
+    ecmascript::{
+        abstract_operations::type_conversion::to_string,
+        builders::builtin_function_builder::BuiltinFunctionBuilder,
+        builtins::{ArgumentsList, Behaviour, Builtin, BuiltinIntrinsicConstructor},
+        execution::{Agent, JsResult, Realm, agent::ExceptionType},
+        types::{
+            BUILTIN_STRING_MEMORY, IntoObject, IntoValue, Object, String, SymbolHeapData, Value,
+        },
+    },
+    engine::context::{Bindable, GcScope},
+    heap::{CreateHeapData, IntrinsicConstructorIndexes, WellKnownSymbolIndexes},
+};
 
 pub(crate) struct SymbolConstructor;
 

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/symbol_objects/symbol_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/symbol_objects/symbol_prototype.rs
@@ -2,15 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::builtins::Behaviour;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
-        builtins::{ArgumentsList, Builtin, BuiltinGetter},
+        builtins::{ArgumentsList, Behaviour, Builtin, BuiltinGetter},
         execution::{Agent, JsResult, Realm, agent::ExceptionType},
         types::{BUILTIN_STRING_MEMORY, IntoValue, PropertyKey, String, Symbol, Value},
     },
+    engine::context::{Bindable, GcScope, NoGcScope},
     heap::WellKnownSymbolIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/array_objects/array_prototype.rs
@@ -6,27 +6,19 @@ use core::cmp::Ordering;
 
 use wtf8::Wtf8Buf;
 
-use crate::ecmascript::abstract_operations::operations_on_objects::{
-    invoke, try_create_data_property_or_throw, try_length_of_array_like,
-};
-use crate::ecmascript::abstract_operations::type_conversion::{
-    try_to_integer_or_infinity, try_to_string,
-};
-use crate::ecmascript::types::InternalMethods;
-use crate::engine::context::{Bindable, GcScope};
-use crate::engine::rootable::{Rootable, Scopable};
-use crate::engine::{ScopableCollection, Scoped, TryResult, unwrap_try};
 use crate::{
     SmallInteger,
     ecmascript::{
         abstract_operations::{
             operations_on_objects::{
                 call_function, create_data_property_or_throw, delete_property_or_throw, get,
-                has_property, length_of_array_like, set,
+                has_property, invoke, length_of_array_like, set, try_create_data_property_or_throw,
+                try_length_of_array_like,
             },
             testing_and_comparison::{is_array, is_callable, is_strictly_equal, same_value_zero},
             type_conversion::{
                 to_boolean, to_integer_or_infinity, to_number, to_object, to_string,
+                try_to_integer_or_infinity, try_to_string,
             },
         },
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
@@ -39,9 +31,15 @@ use crate::{
             agent::{ExceptionType, JsError},
         },
         types::{
-            BUILTIN_STRING_MEMORY, Function, IntoFunction, IntoObject, IntoValue, Number, Object,
-            PropertyKey, String, Value,
+            BUILTIN_STRING_MEMORY, Function, InternalMethods, IntoFunction, IntoObject, IntoValue,
+            Number, Object, PropertyKey, String, Value,
         },
+    },
+    engine::{
+        ScopableCollection, Scoped, TryResult,
+        context::{Bindable, GcScope},
+        rootable::{Rootable, Scopable},
+        unwrap_try,
     },
     heap::{Heap, IntrinsicFunctionIndexes, WellKnownSymbolIndexes},
 };

--- a/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_constructors.rs
+++ b/nova_vm/src/ecmascript/builtins/indexed_collections/typed_array_objects/typed_array_constructors.rs
@@ -2,37 +2,38 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::operations_on_iterator_objects::{
-    get_iterator_from_method, iterator_to_list,
-};
-use crate::ecmascript::abstract_operations::operations_on_objects::{
-    get_method, throw_not_callable,
-};
-use crate::ecmascript::abstract_operations::type_conversion::{to_index, try_to_index};
-use crate::ecmascript::builtins::ArrayBuffer;
-use crate::ecmascript::builtins::indexed_collections::typed_array_objects::abstract_operations::{
-    allocate_typed_array, initialize_typed_array_from_array_buffer,
-    initialize_typed_array_from_array_like, initialize_typed_array_from_list,
-    initialize_typed_array_from_typed_array,
-};
-use crate::ecmascript::builtins::typed_array::TypedArray;
-use crate::ecmascript::execution::agent::ExceptionType;
-use crate::ecmascript::types::{Function, IntoValue, PropertyKey, U8Clamped, Viewable};
-use crate::engine::TryResult;
-use crate::engine::context::{Bindable, GcScope};
-use crate::engine::rootable::Scopable;
-use crate::heap::WellKnownSymbolIndexes;
 use crate::{
     ecmascript::{
+        abstract_operations::{
+            operations_on_iterator_objects::{get_iterator_from_method, iterator_to_list},
+            operations_on_objects::{get_method, throw_not_callable},
+            type_conversion::{to_index, try_to_index},
+        },
         builders::{
             builtin_function_builder::BuiltinFunctionBuilder,
             ordinary_object_builder::OrdinaryObjectBuilder,
         },
-        builtins::{ArgumentsList, Behaviour, Builtin, BuiltinIntrinsicConstructor},
-        execution::{Agent, JsResult, Realm},
-        types::{BUILTIN_STRING_MEMORY, IntoObject, Object, String, Value},
+        builtins::{
+            ArgumentsList, ArrayBuffer, Behaviour, Builtin, BuiltinIntrinsicConstructor,
+            indexed_collections::typed_array_objects::abstract_operations::{
+                allocate_typed_array, initialize_typed_array_from_array_buffer,
+                initialize_typed_array_from_array_like, initialize_typed_array_from_list,
+                initialize_typed_array_from_typed_array,
+            },
+            typed_array::TypedArray,
+        },
+        execution::{Agent, JsResult, Realm, agent::ExceptionType},
+        types::{
+            BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Object, PropertyKey, String,
+            U8Clamped, Value, Viewable,
+        },
     },
-    heap::IntrinsicConstructorIndexes,
+    engine::{
+        TryResult,
+        context::{Bindable, GcScope},
+        rootable::Scopable,
+    },
+    heap::{IntrinsicConstructorIndexes, WellKnownSymbolIndexes},
 };
 
 pub(crate) struct TypedArrayConstructors;

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_iterator_objects/map_iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_iterator_objects/map_iterator_prototype.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::builtins::Behaviour;
-use crate::engine::context::{Bindable, GcScope};
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -12,12 +10,13 @@ use crate::{
         },
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
         builtins::{
-            ArgumentsList, Builtin,
+            ArgumentsList, Behaviour, Builtin,
             indexed_collections::array_objects::array_iterator_objects::array_iterator::CollectionIteratorKind,
         },
         execution::{Agent, JsResult, Realm, agent::ExceptionType},
         types::{BUILTIN_STRING_MEMORY, IntoValue, String, Value},
     },
+    engine::context::{Bindable, GcScope},
     heap::WellKnownSymbolIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/map_objects/map_prototype.rs
@@ -6,8 +6,6 @@ use core::{hash::Hasher, ops::Index};
 
 use ahash::AHasher;
 
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::Scopable;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -23,6 +21,10 @@ use crate::{
         },
         execution::{Agent, JsResult, Realm, agent::ExceptionType},
         types::{BUILTIN_STRING_MEMORY, HeapNumber, IntoValue, PropertyKey, String, Value},
+    },
+    engine::{
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::Scopable,
     },
     heap::{Heap, IntrinsicFunctionIndexes, PrimitiveHeap, WellKnownSymbolIndexes},
 };

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_iterator_objects/set_iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_iterator_objects/set_iterator_prototype.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::builtins::Behaviour;
-use crate::engine::context::{Bindable, GcScope};
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -12,12 +10,13 @@ use crate::{
         },
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
         builtins::{
-            ArgumentsList, Builtin,
+            ArgumentsList, Behaviour, Builtin,
             indexed_collections::array_objects::array_iterator_objects::array_iterator::CollectionIteratorKind,
         },
         execution::{Agent, JsResult, Realm, agent::ExceptionType},
         types::{BUILTIN_STRING_MEMORY, IntoValue, String, Value},
     },
+    engine::context::{Bindable, GcScope},
     heap::WellKnownSymbolIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/set_objects/set_prototype.rs
@@ -6,8 +6,6 @@ use core::hash::Hasher;
 
 use ahash::AHasher;
 
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::Scopable;
 use crate::{
     ecmascript::{
         abstract_operations::{
@@ -18,12 +16,18 @@ use crate::{
         builtins::{
             ArgumentsList, Behaviour, Builtin, BuiltinGetter, BuiltinIntrinsic,
             indexed_collections::array_objects::array_iterator_objects::array_iterator::CollectionIteratorKind,
-            keyed_collections::map_objects::map_prototype::canonicalize_keyed_collection_key,
-            keyed_collections::set_objects::set_iterator_objects::set_iterator::SetIterator,
+            keyed_collections::{
+                map_objects::map_prototype::canonicalize_keyed_collection_key,
+                set_objects::set_iterator_objects::set_iterator::SetIterator,
+            },
             set::{Set, data::SetData},
         },
         execution::{Agent, JsResult, Realm, agent::ExceptionType},
         types::{BUILTIN_STRING_MEMORY, IntoValue, Number, PropertyKey, String, Value},
+    },
+    engine::{
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::Scopable,
     },
     heap::{Heap, IntrinsicFunctionIndexes, PrimitiveHeap, WellKnownSymbolIndexes},
 };

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/weak_map_objects/weak_map_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/weak_map_objects/weak_map_constructor.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -10,6 +9,7 @@ use crate::{
         execution::{Agent, JsResult, Realm},
         types::{BUILTIN_STRING_MEMORY, IntoObject, Object, String, Value},
     },
+    engine::context::GcScope,
     heap::IntrinsicConstructorIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/weak_map_objects/weak_map_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/weak_map_objects/weak_map_prototype.rs
@@ -2,15 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::types::IntoValue;
-use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
         builtins::{ArgumentsList, Behaviour, Builtin},
         execution::{Agent, JsResult, Realm},
-        types::{BUILTIN_STRING_MEMORY, String, Value},
+        types::{BUILTIN_STRING_MEMORY, IntoValue, String, Value},
     },
+    engine::context::GcScope,
     heap::WellKnownSymbolIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/weak_set_objects/weak_set_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/weak_set_objects/weak_set_constructor.rs
@@ -2,32 +2,32 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::operations_on_iterator_objects::{
-    IteratorRecord, get_iterator, if_abrupt_close_iterator, iterator_step_value,
-};
-use crate::ecmascript::abstract_operations::operations_on_objects::{
-    call_function, get, throw_not_callable,
-};
-use crate::ecmascript::abstract_operations::testing_and_comparison::is_callable;
-use crate::ecmascript::builtins::Array;
-use crate::ecmascript::builtins::array::ArrayHeap;
-use crate::ecmascript::builtins::ordinary::ordinary_create_from_constructor;
-use crate::ecmascript::builtins::weak_set::WeakSet;
-use crate::ecmascript::execution::agent::ExceptionType;
-use crate::ecmascript::execution::{ProtoIntrinsics, can_be_held_weakly, throw_not_weak_key_error};
-use crate::ecmascript::types::{Function, IntoValue};
-use crate::engine::Scoped;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::Scopable;
-use crate::heap::Heap;
 use crate::{
     ecmascript::{
+        abstract_operations::{
+            operations_on_iterator_objects::{
+                IteratorRecord, get_iterator, if_abrupt_close_iterator, iterator_step_value,
+            },
+            operations_on_objects::{call_function, get, throw_not_callable},
+            testing_and_comparison::is_callable,
+        },
         builders::builtin_function_builder::BuiltinFunctionBuilder,
-        builtins::{ArgumentsList, Behaviour, Builtin, BuiltinIntrinsicConstructor},
-        execution::{Agent, JsResult, Realm},
-        types::{BUILTIN_STRING_MEMORY, IntoObject, Object, String, Value},
+        builtins::{
+            ArgumentsList, Array, Behaviour, Builtin, BuiltinIntrinsicConstructor,
+            array::ArrayHeap, ordinary::ordinary_create_from_constructor, weak_set::WeakSet,
+        },
+        execution::{
+            Agent, JsResult, ProtoIntrinsics, Realm, agent::ExceptionType, can_be_held_weakly,
+            throw_not_weak_key_error,
+        },
+        types::{BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Object, String, Value},
     },
-    heap::IntrinsicConstructorIndexes,
+    engine::{
+        Scoped,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::Scopable,
+    },
+    heap::{Heap, IntrinsicConstructorIndexes},
 };
 
 pub(crate) struct WeakSetConstructor;

--- a/nova_vm/src/ecmascript/builtins/keyed_collections/weak_set_objects/weak_set_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/keyed_collections/weak_set_objects/weak_set_prototype.rs
@@ -2,18 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::builtins::weak_set::WeakSet;
-use crate::ecmascript::execution::agent::ExceptionType;
-use crate::ecmascript::execution::{can_be_held_weakly, throw_not_weak_key_error};
-use crate::ecmascript::types::IntoValue;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
-        builtins::{ArgumentsList, Behaviour, Builtin},
-        execution::{Agent, JsResult, Realm},
-        types::{BUILTIN_STRING_MEMORY, String, Value},
+        builtins::{ArgumentsList, Behaviour, Builtin, weak_set::WeakSet},
+        execution::{
+            Agent, JsResult, Realm, agent::ExceptionType, can_be_held_weakly,
+            throw_not_weak_key_error,
+        },
+        types::{BUILTIN_STRING_MEMORY, IntoValue, String, Value},
     },
+    engine::context::{Bindable, GcScope, NoGcScope},
     heap::WellKnownSymbolIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/managing_memory/finalization_registry_objects/finalization_registry_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/managing_memory/finalization_registry_objects/finalization_registry_constructor.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -10,6 +9,7 @@ use crate::{
         execution::{Agent, JsResult, Realm},
         types::{BUILTIN_STRING_MEMORY, IntoObject, Object, String, Value},
     },
+    engine::context::GcScope,
     heap::IntrinsicConstructorIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/managing_memory/finalization_registry_objects/finalization_registry_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/managing_memory/finalization_registry_objects/finalization_registry_prototype.rs
@@ -2,15 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::types::IntoValue;
-use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
         builtins::{ArgumentsList, Behaviour, Builtin},
         execution::{Agent, JsResult, Realm},
-        types::{BUILTIN_STRING_MEMORY, String, Value},
+        types::{BUILTIN_STRING_MEMORY, IntoValue, String, Value},
     },
+    engine::context::GcScope,
     heap::WellKnownSymbolIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/managing_memory/weak_ref_objects/weak_ref_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/managing_memory/weak_ref_objects/weak_ref_prototype.rs
@@ -2,18 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::builtins::weak_ref::WeakRef;
-use crate::ecmascript::execution::add_to_kept_objects;
-use crate::ecmascript::execution::agent::ExceptionType;
-use crate::ecmascript::types::IntoValue;
-use crate::engine::context::{Bindable, GcScope};
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
-        builtins::{ArgumentsList, Behaviour, Builtin},
-        execution::{Agent, JsResult, Realm},
-        types::{BUILTIN_STRING_MEMORY, String, Value},
+        builtins::{ArgumentsList, Behaviour, Builtin, weak_ref::WeakRef},
+        execution::{Agent, JsResult, Realm, add_to_kept_objects, agent::ExceptionType},
+        types::{BUILTIN_STRING_MEMORY, IntoValue, String, Value},
     },
+    engine::context::{Bindable, GcScope},
     heap::WellKnownSymbolIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/bigint_objects/bigint_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/bigint_objects/bigint_constructor.rs
@@ -5,36 +5,30 @@
 use num_bigint::ToBigInt;
 use num_traits::Pow;
 
-use crate::ecmascript::abstract_operations::testing_and_comparison::is_integral_number;
-use crate::ecmascript::abstract_operations::type_conversion::PreferredType;
-use crate::ecmascript::abstract_operations::type_conversion::to_big_int;
-use crate::ecmascript::abstract_operations::type_conversion::to_big_int_primitive;
-use crate::ecmascript::abstract_operations::type_conversion::to_index;
-use crate::ecmascript::abstract_operations::type_conversion::to_primitive;
-use crate::ecmascript::builders::builtin_function_builder::BuiltinFunctionBuilder;
-use crate::ecmascript::builtins::ArgumentsList;
-use crate::ecmascript::builtins::Behaviour;
-use crate::ecmascript::builtins::Builtin;
-use crate::ecmascript::builtins::BuiltinIntrinsicConstructor;
-use crate::ecmascript::execution::Agent;
-use crate::ecmascript::execution::JsResult;
-use crate::ecmascript::execution::Realm;
-use crate::ecmascript::execution::agent::ExceptionType;
-use crate::ecmascript::types::BUILTIN_STRING_MEMORY;
-use crate::ecmascript::types::BigInt;
-use crate::ecmascript::types::BigIntHeapData;
-use crate::ecmascript::types::IntoObject;
-use crate::ecmascript::types::IntoValue;
-use crate::ecmascript::types::Number;
-use crate::ecmascript::types::Object;
-use crate::ecmascript::types::{String, Value};
-
-use crate::SmallInteger;
-use crate::engine::context::{Bindable, GcScope};
-use crate::engine::rootable::Scopable;
-use crate::engine::small_bigint::SmallBigInt;
-use crate::heap::CreateHeapData;
-use crate::heap::IntrinsicConstructorIndexes;
+use crate::{
+    SmallInteger,
+    ecmascript::{
+        abstract_operations::{
+            testing_and_comparison::is_integral_number,
+            type_conversion::{
+                PreferredType, to_big_int, to_big_int_primitive, to_index, to_primitive,
+            },
+        },
+        builders::builtin_function_builder::BuiltinFunctionBuilder,
+        builtins::{ArgumentsList, Behaviour, Builtin, BuiltinIntrinsicConstructor},
+        execution::{Agent, JsResult, Realm, agent::ExceptionType},
+        types::{
+            BUILTIN_STRING_MEMORY, BigInt, BigIntHeapData, IntoObject, IntoValue, Number, Object,
+            String, Value,
+        },
+    },
+    engine::{
+        context::{Bindable, GcScope},
+        rootable::Scopable,
+        small_bigint::SmallBigInt,
+    },
+    heap::{CreateHeapData, IntrinsicConstructorIndexes},
+};
 
 /// ### [21.1.2.1 BigInt ( value )](https://tc39.es/ecma262/#sec-bigint-constructor)
 pub struct BigIntConstructor;

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/bigint_objects/bigint_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/bigint_objects/bigint_prototype.rs
@@ -2,16 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::type_conversion::to_integer_or_infinity;
-use crate::ecmascript::builtins::Behaviour;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::Scopable;
 use crate::{
     ecmascript::{
+        abstract_operations::type_conversion::to_integer_or_infinity,
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
-        builtins::{ArgumentsList, Builtin, primitive_objects::PrimitiveObjectData},
+        builtins::{ArgumentsList, Behaviour, Builtin, primitive_objects::PrimitiveObjectData},
         execution::{Agent, JsResult, Realm, agent::ExceptionType},
         types::{BUILTIN_STRING_MEMORY, BigInt, IntoValue, String, Value},
+    },
+    engine::{
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::Scopable,
     },
     heap::WellKnownSymbolIndexes,
 };

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/date_objects/date_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/date_objects/date_constructor.rs
@@ -4,39 +4,32 @@
 
 use std::time::SystemTime;
 
-use crate::ecmascript::builtins::Behaviour;
-use crate::ecmascript::builtins::Builtin;
-use crate::ecmascript::builtins::BuiltinIntrinsicConstructor;
-use crate::ecmascript::builtins::date::Date;
-use crate::ecmascript::builtins::ordinary::ordinary_create_from_constructor;
-use crate::ecmascript::builtins::{
-    ArgumentsList,
-    date::data::{DateValue, time_clip},
-};
-use crate::ecmascript::execution::Agent;
-use crate::ecmascript::execution::JsResult;
-use crate::ecmascript::execution::ProtoIntrinsics;
-use crate::ecmascript::execution::Realm;
-use crate::ecmascript::types::BUILTIN_STRING_MEMORY;
-use crate::ecmascript::types::Function;
-use crate::ecmascript::types::IntoObject;
-use crate::ecmascript::types::IntoValue;
-use crate::ecmascript::types::Number;
-use crate::ecmascript::types::Object;
-use crate::ecmascript::types::{String, Value};
-use crate::ecmascript::{
-    abstract_operations::type_conversion::to_number,
-    numbers_and_dates::date_objects::date_prototype::{
-        make_date, make_day, make_full_year, make_time, utc,
-    },
-};
-use crate::engine::context::Bindable;
-use crate::engine::context::GcScope;
-use crate::heap::IntrinsicConstructorIndexes;
-use crate::{SmallInteger, ecmascript::abstract_operations::type_conversion::to_primitive};
 use crate::{
-    ecmascript::builders::builtin_function_builder::BuiltinFunctionBuilder,
-    engine::rootable::Scopable,
+    SmallInteger,
+    ecmascript::{
+        abstract_operations::type_conversion::{to_number, to_primitive},
+        builders::builtin_function_builder::BuiltinFunctionBuilder,
+        builtins::{
+            ArgumentsList, Behaviour, Builtin, BuiltinIntrinsicConstructor,
+            date::{
+                Date,
+                data::{DateValue, time_clip},
+            },
+            ordinary::ordinary_create_from_constructor,
+        },
+        execution::{Agent, JsResult, ProtoIntrinsics, Realm},
+        numbers_and_dates::date_objects::date_prototype::{
+            make_date, make_day, make_full_year, make_time, utc,
+        },
+        types::{
+            BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Number, Object, String, Value,
+        },
+    },
+    engine::{
+        context::{Bindable, GcScope},
+        rootable::Scopable,
+    },
+    heap::IntrinsicConstructorIndexes,
 };
 
 use super::date_prototype::{MS_PER_MINUTE, to_date_string};

--- a/nova_vm/src/ecmascript/builtins/numbers_and_dates/number_objects/number_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/numbers_and_dates/number_objects/number_prototype.rs
@@ -2,20 +2,21 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::builtins::Behaviour;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::Scopable;
 use crate::{
     SmallInteger,
     ecmascript::{
         abstract_operations::type_conversion::to_integer_or_infinity,
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
         builtins::{
-            ArgumentsList, Builtin,
+            ArgumentsList, Behaviour, Builtin,
             primitive_objects::{PrimitiveObject, PrimitiveObjectData, PrimitiveObjectHeapData},
         },
         execution::{Agent, JsResult, Realm, agent::ExceptionType},
         types::{BUILTIN_STRING_MEMORY, IntoValue, Number, String, Value},
+    },
+    engine::{
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::Scopable,
     },
 };
 

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -4,12 +4,6 @@
 
 use core::ops::{Index, IndexMut};
 
-use crate::ecmascript::types::{IntoPrimitive, Primitive};
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::{HeapRootData, HeapRootRef, Rootable};
-use crate::engine::small_bigint::SmallBigInt;
-use crate::engine::{TryResult, unwrap_try};
-use crate::heap::HeapSweepWeakReference;
 use crate::{
     SmallInteger,
     ecmascript::{
@@ -21,16 +15,23 @@ use crate::{
         types::{
             BIGINT_DISCRIMINANT, BOOLEAN_DISCRIMINANT, BUILTIN_STRING_MEMORY, BigInt,
             FLOAT_DISCRIMINANT, HeapNumber, HeapString, INTEGER_DISCRIMINANT, InternalMethods,
-            InternalSlots, IntoObject, IntoValue, NUMBER_DISCRIMINANT, Number, Object,
-            OrdinaryObject, PropertyDescriptor, PropertyKey, SMALL_BIGINT_DISCRIMINANT,
-            SMALL_STRING_DISCRIMINANT, STRING_DISCRIMINANT, SYMBOL_DISCRIMINANT, String, Symbol,
-            Value, bigint::HeapBigInt,
+            InternalSlots, IntoObject, IntoPrimitive, IntoValue, NUMBER_DISCRIMINANT, Number,
+            Object, OrdinaryObject, Primitive, PropertyDescriptor, PropertyKey,
+            SMALL_BIGINT_DISCRIMINANT, SMALL_STRING_DISCRIMINANT, STRING_DISCRIMINANT,
+            SYMBOL_DISCRIMINANT, String, Symbol, Value, bigint::HeapBigInt,
         },
     },
-    engine::small_f64::SmallF64,
+    engine::{
+        TryResult,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::{HeapRootData, HeapRootRef, Rootable},
+        small_bigint::SmallBigInt,
+        small_f64::SmallF64,
+        unwrap_try,
+    },
     heap::{
-        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, WorkQueues,
-        indexes::PrimitiveObjectIndex,
+        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, HeapSweepWeakReference,
+        WorkQueues, indexes::PrimitiveObjectIndex,
     },
 };
 use small_string::SmallString;

--- a/nova_vm/src/ecmascript/builtins/promise.rs
+++ b/nova_vm/src/ecmascript/builtins/promise.rs
@@ -7,19 +7,18 @@ use std::convert::Infallible;
 
 use data::PromiseState;
 
-use crate::ecmascript::execution::JsResult;
-use crate::ecmascript::execution::agent::JsError;
-use crate::ecmascript::types::IntoValue;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::{HeapRootData, HeapRootRef, Rootable, Scopable};
-use crate::heap::{CompactionLists, HeapSweepWeakReference, WorkQueues};
 use crate::{
     ecmascript::{
-        execution::{Agent, ProtoIntrinsics},
-        types::{InternalMethods, InternalSlots, Object, OrdinaryObject, Value},
+        execution::{Agent, JsResult, ProtoIntrinsics, agent::JsError},
+        types::{InternalMethods, InternalSlots, IntoValue, Object, OrdinaryObject, Value},
+    },
+    engine::{
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::{HeapRootData, HeapRootRef, Rootable, Scopable},
     },
     heap::{
-        CreateHeapData, Heap, HeapMarkAndSweep,
+        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, HeapSweepWeakReference,
+        WorkQueues,
         indexes::{BaseIndex, PromiseIndex},
     },
 };

--- a/nova_vm/src/ecmascript/builtins/reflection/proxy_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/reflection/proxy_constructor.rs
@@ -2,17 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::builtins::proxy::proxy_create;
-use crate::ecmascript::execution::agent::ExceptionType;
-use crate::ecmascript::types::IntoValue;
-use crate::engine::context::{Bindable, GcScope};
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
-        builtins::{ArgumentsList, Behaviour, Builtin, BuiltinIntrinsicConstructor},
-        execution::{Agent, JsResult, Realm},
-        types::{BUILTIN_STRING_MEMORY, Object, String, Value},
+        builtins::{
+            ArgumentsList, Behaviour, Builtin, BuiltinIntrinsicConstructor, proxy::proxy_create,
+        },
+        execution::{Agent, JsResult, Realm, agent::ExceptionType},
+        types::{BUILTIN_STRING_MEMORY, IntoValue, Object, String, Value},
     },
+    engine::context::{Bindable, GcScope},
     heap::IntrinsicConstructorIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/structured_data/array_buffer_objects/array_buffer_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/array_buffer_objects/array_buffer_prototype.rs
@@ -2,15 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::type_conversion::try_to_index;
-use crate::engine::TryResult;
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::Scopable;
 use crate::{
     ecmascript::{
         abstract_operations::{
             operations_on_objects::construct,
-            type_conversion::{to_index, to_integer_or_infinity},
+            type_conversion::{to_index, to_integer_or_infinity, try_to_index},
         },
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
         builtins::{
@@ -21,6 +17,11 @@ use crate::{
         types::{
             BUILTIN_STRING_MEMORY, IntoFunction, IntoValue, Object, PropertyKey, String, Value,
         },
+    },
+    engine::{
+        TryResult,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::Scopable,
     },
     heap::WellKnownSymbolIndexes,
 };

--- a/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/atomics_object.rs
@@ -2,17 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::builtins::Behaviour;
 #[cfg(feature = "proposal-atomics-microwait")]
 use crate::ecmascript::execution::agent::ExceptionType;
-use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
-        builtins::{ArgumentsList, Builtin},
+        builtins::{ArgumentsList, Behaviour, Builtin},
         execution::{Agent, JsResult, Realm},
         types::{BUILTIN_STRING_MEMORY, String, Value},
     },
+    engine::context::GcScope,
     heap::WellKnownSymbolIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/structured_data/data_view_objects/data_view_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/data_view_objects/data_view_constructor.rs
@@ -2,11 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::builtins::array_buffer::{
-    ViewedArrayBufferByteLength, ViewedArrayBufferByteOffset,
-};
-use crate::engine::context::{Bindable, GcScope};
-use crate::engine::rootable::Scopable;
 use crate::{
     ecmascript::{
         abstract_operations::type_conversion::to_index,
@@ -14,8 +9,8 @@ use crate::{
         builtins::{
             ArgumentsList, Behaviour, Builtin, BuiltinIntrinsicConstructor,
             array_buffer::{
-                Ordering, array_buffer_byte_length, is_detached_buffer,
-                is_fixed_length_array_buffer,
+                Ordering, ViewedArrayBufferByteLength, ViewedArrayBufferByteOffset,
+                array_buffer_byte_length, is_detached_buffer, is_fixed_length_array_buffer,
             },
             data_view::DataView,
             ordinary::ordinary_create_from_constructor,
@@ -23,6 +18,10 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics, Realm, agent::ExceptionType},
         types::{BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Object, String, Value},
+    },
+    engine::{
+        context::{Bindable, GcScope},
+        rootable::Scopable,
     },
     heap::IntrinsicConstructorIndexes,
 };

--- a/nova_vm/src/ecmascript/builtins/structured_data/data_view_objects/data_view_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/data_view_objects/data_view_prototype.rs
@@ -2,12 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::type_conversion::to_boolean;
-use crate::ecmascript::builtins::data_view::abstract_operations::{get_view_value, set_view_value};
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
 use crate::{
     SmallInteger,
     ecmascript::{
+        abstract_operations::type_conversion::to_boolean,
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
         builtins::{
             ArgumentsList, Behaviour, Builtin, BuiltinGetter,
@@ -15,14 +13,15 @@ use crate::{
             data_view::{
                 DataView,
                 abstract_operations::{
-                    get_view_byte_length, is_view_out_of_bounds,
-                    make_data_view_with_buffer_witness_record,
+                    get_view_byte_length, get_view_value, is_view_out_of_bounds,
+                    make_data_view_with_buffer_witness_record, set_view_value,
                 },
             },
         },
         execution::{Agent, JsResult, Realm, agent::ExceptionType},
         types::{BUILTIN_STRING_MEMORY, IntoValue, Number, PropertyKey, String, Value},
     },
+    engine::context::{Bindable, GcScope, NoGcScope},
     heap::WellKnownSymbolIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/structured_data/shared_array_buffer_objects/shared_array_buffer_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/shared_array_buffer_objects/shared_array_buffer_constructor.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::engine::context::{Bindable, GcScope};
 use crate::{
     ecmascript::{
         builders::builtin_function_builder::BuiltinFunctionBuilder,
@@ -10,6 +9,7 @@ use crate::{
         execution::{Agent, JsResult, Realm},
         types::{BUILTIN_STRING_MEMORY, IntoObject, Object, PropertyKey, String, Value},
     },
+    engine::context::{Bindable, GcScope},
     heap::{IntrinsicConstructorIndexes, WellKnownSymbolIndexes},
 };
 

--- a/nova_vm/src/ecmascript/builtins/structured_data/shared_array_buffer_objects/shared_array_buffer_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/structured_data/shared_array_buffer_objects/shared_array_buffer_prototype.rs
@@ -2,15 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::types::IntoValue;
-use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
         builtins::{ArgumentsList, Behaviour, Builtin, BuiltinGetter},
         execution::{Agent, JsResult, Realm},
-        types::{BUILTIN_STRING_MEMORY, PropertyKey, String, Value},
+        types::{BUILTIN_STRING_MEMORY, IntoValue, PropertyKey, String, Value},
     },
+    engine::context::GcScope,
     heap::WellKnownSymbolIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/text_processing/regexp_objects/regexp_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/text_processing/regexp_objects/regexp_constructor.rs
@@ -2,32 +2,26 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::operations_on_objects::get;
-use crate::ecmascript::abstract_operations::testing_and_comparison::is_reg_exp;
-use crate::ecmascript::builders::builtin_function_builder::BuiltinFunctionBuilder;
-use crate::ecmascript::builtins::ArgumentsList;
-use crate::ecmascript::builtins::Behaviour;
-use crate::ecmascript::builtins::Builtin;
-use crate::ecmascript::builtins::BuiltinGetter;
-use crate::ecmascript::builtins::BuiltinIntrinsicConstructor;
-use crate::ecmascript::builtins::regexp::reg_exp_alloc;
-use crate::ecmascript::builtins::regexp::reg_exp_initialize;
-use crate::ecmascript::execution::Agent;
-use crate::ecmascript::execution::JsResult;
-use crate::ecmascript::execution::Realm;
-
-use crate::ecmascript::types::BUILTIN_STRING_MEMORY;
-use crate::ecmascript::types::Function;
-use crate::ecmascript::types::IntoObject;
-use crate::ecmascript::types::IntoValue;
-use crate::ecmascript::types::Object;
-use crate::ecmascript::types::PropertyKey;
-use crate::ecmascript::types::String;
-use crate::ecmascript::types::Value;
-use crate::engine::context::{Bindable, GcScope};
-use crate::engine::rootable::Scopable;
-use crate::heap::IntrinsicConstructorIndexes;
-use crate::heap::WellKnownSymbolIndexes;
+use crate::{
+    ecmascript::{
+        abstract_operations::{operations_on_objects::get, testing_and_comparison::is_reg_exp},
+        builders::builtin_function_builder::BuiltinFunctionBuilder,
+        builtins::{
+            ArgumentsList, Behaviour, Builtin, BuiltinGetter, BuiltinIntrinsicConstructor,
+            regexp::{reg_exp_alloc, reg_exp_initialize},
+        },
+        execution::{Agent, JsResult, Realm},
+        types::{
+            BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Object, PropertyKey, String,
+            Value,
+        },
+    },
+    engine::{
+        context::{Bindable, GcScope},
+        rootable::Scopable,
+    },
+    heap::{IntrinsicConstructorIndexes, WellKnownSymbolIndexes},
+};
 
 pub struct RegExpConstructor;
 

--- a/nova_vm/src/ecmascript/builtins/text_processing/regexp_objects/regexp_string_iterator_prototype.rs
+++ b/nova_vm/src/ecmascript/builtins/text_processing/regexp_objects/regexp_string_iterator_prototype.rs
@@ -2,16 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::builtins::Behaviour;
-use crate::ecmascript::types::IntoValue;
-use crate::engine::context::GcScope;
 use crate::{
     ecmascript::{
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
-        builtins::{ArgumentsList, Builtin},
+        builtins::{ArgumentsList, Behaviour, Builtin},
         execution::{Agent, JsResult, Realm},
-        types::{BUILTIN_STRING_MEMORY, String, Value},
+        types::{BUILTIN_STRING_MEMORY, IntoValue, String, Value},
     },
+    engine::context::GcScope,
     heap::WellKnownSymbolIndexes,
 };
 

--- a/nova_vm/src/ecmascript/builtins/text_processing/string_objects/string_iterator_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/text_processing/string_objects/string_iterator_objects.rs
@@ -2,26 +2,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::operations_on_iterator_objects::create_iter_result_object;
-use crate::ecmascript::builtins::Behaviour;
-use crate::ecmascript::execution::ProtoIntrinsics;
-use crate::ecmascript::execution::agent::ExceptionType;
-use crate::ecmascript::types::{
-    InternalMethods, InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject,
-};
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::heap::indexes::StringIteratorIndex;
-use crate::heap::{
-    CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, HeapSweepWeakReference, WorkQueues,
-};
 use crate::{
     ecmascript::{
+        abstract_operations::operations_on_iterator_objects::create_iter_result_object,
         builders::ordinary_object_builder::OrdinaryObjectBuilder,
-        builtins::{ArgumentsList, Builtin},
-        execution::{Agent, JsResult, Realm},
-        types::{BUILTIN_STRING_MEMORY, String, Value},
+        builtins::{ArgumentsList, Behaviour, Builtin},
+        execution::{Agent, JsResult, ProtoIntrinsics, Realm, agent::ExceptionType},
+        types::{
+            BUILTIN_STRING_MEMORY, InternalMethods, InternalSlots, IntoObject, IntoValue, Object,
+            OrdinaryObject, String, Value,
+        },
     },
-    heap::WellKnownSymbolIndexes,
+    engine::context::{Bindable, GcScope, NoGcScope},
+    heap::{
+        CompactionLists, CreateHeapData, Heap, HeapMarkAndSweep, HeapSweepWeakReference,
+        WellKnownSymbolIndexes, WorkQueues, indexes::StringIteratorIndex,
+    },
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/nova_vm/src/ecmascript/execution/agent.rs
+++ b/nova_vm/src/ecmascript/execution/agent.rs
@@ -932,15 +932,14 @@ impl Agent {
         let script = match parse_script(self, source_text, realm, false, None, gc.nogc()) {
             Ok(script) => script,
             Err(err) => {
+                let gc = gc.into_nogc();
                 let message =
-                    String::from_string(self, err.first().unwrap().message.to_string(), gc.nogc());
-                return Err(self
-                    .throw_exception_with_message(
-                        ExceptionType::SyntaxError,
-                        message.unbind(),
-                        gc.into_nogc(),
-                    )
-                    .unbind());
+                    String::from_string(self, err.first().unwrap().message.to_string(), gc);
+                return Err(self.throw_exception_with_message(
+                    ExceptionType::SyntaxError,
+                    message,
+                    gc,
+                ));
             }
         };
         script_evaluation(self, script.unbind(), gc)

--- a/nova_vm/src/ecmascript/execution/realm.rs
+++ b/nova_vm/src/ecmascript/execution/realm.rs
@@ -844,9 +844,10 @@ mod test {
     #[cfg(feature = "regexp")]
     fn test_default_realm_sanity() {
         use super::initialize_default_realm;
-        use crate::ecmascript::execution::{Agent, DefaultHostHooks, agent::Options};
-        use crate::heap::indexes::BuiltinFunctionIndex;
-        use crate::heap::indexes::ObjectIndex;
+        use crate::{
+            ecmascript::execution::{Agent, DefaultHostHooks, agent::Options},
+            heap::indexes::{BuiltinFunctionIndex, ObjectIndex},
+        };
 
         let mut agent = Agent::new(Options::default(), &DefaultHostHooks);
         let (mut gc, mut scope) = unsafe { GcScope::create_root() };

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -32,7 +32,7 @@ use core::{
     marker::PhantomData,
     ops::{Index, IndexMut},
 };
-use oxc_ast::ast::{self, BindingIdentifier, VariableDeclarationKind};
+use oxc_ast::ast;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::BoundNames;
 use std::{ptr::NonNull, rc::Rc};
@@ -669,12 +669,12 @@ unsafe fn global_declaration_instantiation<'a>(
         // a. NOTE: Lexically declared names are only instantiated here but not initialized.
         let mut bound_names = vec![];
         let mut const_bound_names = vec![];
-        let mut closure = |identifier: &BindingIdentifier| {
+        let mut closure = |identifier: &ast::BindingIdentifier| {
             bound_names.push(String::from_str(agent, identifier.name.as_str(), gc.nogc()));
         };
         match d {
             LexicallyScopedDeclaration::Variable(decl) => {
-                if decl.kind == VariableDeclarationKind::Const {
+                if decl.kind == ast::VariableDeclarationKind::Const {
                     decl.id.bound_names(&mut |identifier| {
                         const_bound_names.push(String::from_str(
                             agent,

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -30,19 +30,18 @@ use ahash::AHashSet;
 use core::{
     any::Any,
     marker::PhantomData,
-    mem::ManuallyDrop,
     ops::{Index, IndexMut},
 };
-use oxc_ast::ast::{BindingIdentifier, Program, VariableDeclarationKind};
+use oxc_ast::ast::{self, BindingIdentifier, VariableDeclarationKind};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::BoundNames;
-use std::rc::Rc;
+use std::{ptr::NonNull, rc::Rc};
 
 use super::{
     module::module_semantics::{
         LoadedModules, ModuleRequest, abstract_module_records::AbstractModule,
     },
-    source_code::{SourceCode, SourceCodeType},
+    source_code::{ParseResult, SourceCode, SourceCodeType},
 };
 
 pub type HostDefined = Rc<dyn Any>;
@@ -62,6 +61,23 @@ impl core::fmt::Debug for Script<'_> {
 }
 
 impl Script<'_> {
+    /// Get the script statements as a slice.
+    pub(crate) fn get_statements<'a>(
+        self,
+        agent: &Agent,
+        _: NoGcScope<'a, '_>,
+    ) -> &'a [ast::Statement<'a>] {
+        // SAFETY: Caller promises that SourceTextModule is rooted while the
+        // statements slice is held: the SourceTextModuleRecord may move during
+        // GC but the statements it points to do not move. Hence the reference
+        // is valid while the self SourceTextModule is held (the parent call).
+        unsafe {
+            core::mem::transmute::<&[ast::Statement], &'a [ast::Statement<'a>]>(
+                agent[self].ecmascript_code.as_ref(),
+            )
+        }
+    }
+
     /// Creates a script identififer from a usize.
     ///
     /// ## Panics
@@ -171,12 +187,12 @@ pub struct ScriptRecord<'a> {
     ///
     /// The result of parsing the source text of this script.
     ///
-    /// Note: The Program's drop code is never run. The referred structures
-    /// live in the SourceCode heap data in its contained Allocator. The bump
-    /// allocator drops all of the data in a single go. All that needs to be
-    /// dropped here is the local Program itself, not any of its referred
-    /// parts.
-    pub(crate) ecmascript_code: ManuallyDrop<Program<'static>>,
+    /// Note: The slice and its contents live in the SourceCode heap data in
+    /// its contained Allocator. The SourceCode is thus in charge of dropping
+    /// the ECMAScriptCode, and we ensure it doesn't drop prematurely by
+    /// holding the SourceCode reference.
+    pub(crate) ecmascript_code: NonNull<[ast::Statement<'a>]>,
+    pub(crate) is_strict: bool,
 
     /// ### \[\[LoadedModules]]
     ///
@@ -198,6 +214,9 @@ pub struct ScriptRecord<'a> {
     pub(crate) source_code: SourceCode<'a>,
 }
 
+// SAFETY: [[ECMAScriptCode]] does not permit mutable access, and points to
+// data considered (and used as) immutable. It is safe to send the pointer to
+// other threads.
 unsafe impl Send for ScriptRecord<'_> {}
 
 pub type ScriptOrErrors<'a> = Result<Script<'a>, Vec<OxcDiagnostic>>;
@@ -260,6 +279,7 @@ impl HeapMarkAndSweep for ScriptRecord<'static> {
         let Self {
             realm,
             ecmascript_code: _,
+            is_strict: _,
             loaded_modules,
             host_defined: _,
             source_code,
@@ -273,6 +293,7 @@ impl HeapMarkAndSweep for ScriptRecord<'static> {
         let Self {
             realm,
             ecmascript_code: _,
+            is_strict: _,
             loaded_modules,
             host_defined: _,
             source_code,
@@ -320,7 +341,12 @@ pub fn parse_script<'a>(
         )
     };
 
-    let (program, source_code) = match parse_result {
+    let ParseResult {
+        source_code,
+        body,
+        directives: _,
+        is_strict,
+    } = match parse_result {
         // 2. If script is a List of errors, return script.
         Ok(result) => result,
         Err(errors) => {
@@ -333,13 +359,12 @@ pub fn parse_script<'a>(
         // [[Realm]]: realm,
         realm: realm.unbind(),
         // [[ECMAScriptCode]]: script,
-        // SAFETY: We are moving the Program onto the heap together with the
-        // SourceCode reference: the latter will keep alive the allocation that
-        // Program points to. Hence, we can unbind the Program from the garbage
-        // collector lifetime here.
-        ecmascript_code: ManuallyDrop::new(unsafe {
-            core::mem::transmute::<Program, Program<'static>>(program)
-        }),
+        // SAFETY: We are moving the statements slice onto the heap together
+        // with the SourceCode reference: the latter will keep alive the
+        // allocation that Statements point to. Hence, we can unbind the
+        // Statements from the garbage collector lifetime here.
+        ecmascript_code: NonNull::from(body),
+        is_strict,
         // [[LoadedModules]]: « »,
         loaded_modules: Default::default(),
         // [[HostDefined]]: hostDefined,
@@ -364,8 +389,7 @@ pub fn script_evaluation<'a>(
     let script = script.bind(gc.nogc());
     let script_record = &agent[script];
     let realm_id = script_record.realm;
-    let is_strict_mode = script_record.ecmascript_code.source_type.is_strict()
-        || script_record.ecmascript_code.has_use_strict_directive();
+    let is_strict_mode = script_record.is_strict;
     let source_code = script_record.source_code;
     let realm = agent.get_realm_record_by_id(realm_id);
 
@@ -408,14 +432,13 @@ pub fn script_evaluation<'a>(
     // NOTE: We cannot define the script here due to reference safety.
 
     // 12. Let result be Completion(GlobalDeclarationInstantiation(script, globalEnv)).
-    let result = global_declaration_instantiation(
-        agent,
-        script.unbind(),
-        global_env.unbind(),
-        gc.reborrow(),
-    )
-    .unbind()
-    .bind(gc.nogc());
+    // SAFETY: script is currently on the execution stack and is thus
+    // indirectly rooted.
+    let result = unsafe {
+        global_declaration_instantiation(agent, script.unbind(), global_env.unbind(), gc.reborrow())
+            .unbind()
+            .bind(gc.nogc())
+    };
 
     let Some(ScriptOrModule::Script(script)) = agent.running_execution_context().script_or_module
     else {
@@ -465,7 +488,11 @@ pub fn script_evaluation<'a>(
 /// returns either a normal completion containing UNUSED or a throw completion.
 /// script is the Script for which the execution context is being established.
 /// env is the global environment in which bindings are to be created.
-pub(crate) fn global_declaration_instantiation<'a>(
+///
+/// ## Safety
+///
+/// Script must be rooted for the duration of this call.
+unsafe fn global_declaration_instantiation<'a>(
     agent: &mut Agent,
     script: Script,
     env: GlobalEnvironment,
@@ -477,24 +504,21 @@ pub(crate) fn global_declaration_instantiation<'a>(
     // 11. Let script be scriptRecord.[[ECMAScriptCode]].
     // SAFETY: Analysing the script cannot cause the environment to move even though we change other parts of the Heap.
     let (lex_names, var_names, var_declarations, lex_declarations) = {
-        let ScriptRecord {
-            ecmascript_code: script,
-            ..
-        } = &agent[script];
-        // SAFETY: The borrow of Program is valid for the duration of this
-        // block; the contents of Program are guaranteed to be valid for as
-        // long as the Script is alive in the heap as they are not reallocated.
-        // Thus in effect VarScopedDeclaration<'_> is valid for the duration
-        // of the global_declaration_instantiation call.
-        let script = unsafe { core::mem::transmute::<&Program, &'static Program<'static>>(script) };
+        let body = agent[script].ecmascript_code;
+        // SAFETY: The caller promises that Script is rooted, meaning that its
+        // backing SourceCode cannot be dropped during this call. Hence, we can
+        // take the body slice reference and keep it alive for the duration of
+        // this call.
+        let body = unsafe { body.as_ref() };
+
         // 1. Let lexNames be the LexicallyDeclaredNames of script.
-        let lex_names = script_lexically_declared_names(script);
+        let lex_names = script_lexically_declared_names(body);
         // 2. Let varNames be the VarDeclaredNames of script.
-        let var_names = script_var_declared_names(script);
+        let var_names = script_var_declared_names(body);
         // 5. Let varDeclarations be the VarScopedDeclarations of script.
-        let var_declarations = script_var_scoped_declarations(script);
+        let var_declarations = script_var_scoped_declarations(body);
         // 13. Let lexDeclarations be the LexicallyScopedDeclarations of script.
-        let lex_declarations = script_lexically_scoped_declarations(script);
+        let lex_declarations = script_lexically_scoped_declarations(body);
         (lex_names, var_names, var_declarations, lex_declarations)
     };
 

--- a/nova_vm/src/ecmascript/syntax_directed_operations/contains.rs
+++ b/nova_vm/src/ecmascript/syntax_directed_operations/contains.rs
@@ -24,6 +24,12 @@ pub(crate) trait Contains {
     fn contains(&self, symbol: ContainsSymbol) -> bool;
 }
 
+impl Contains for [ast::Statement<'_>] {
+    fn contains(&self, symbol: ContainsSymbol) -> bool {
+        self.iter().any(|st| st.contains(symbol))
+    }
+}
+
 impl Contains for ast::Program<'_> {
     fn contains(&self, symbol: ContainsSymbol) -> bool {
         self.body.iter().any(|st| st.contains(symbol))

--- a/nova_vm/src/ecmascript/syntax_directed_operations/scope_analysis.rs
+++ b/nova_vm/src/ecmascript/syntax_directed_operations/scope_analysis.rs
@@ -5,7 +5,7 @@
 use core::ops::Deref;
 
 use oxc_ast::ast::{
-    self, BindingIdentifier, BlockStatement, Class, Declaration, ExportDefaultDeclarationKind,
+    BindingIdentifier, BlockStatement, Class, Declaration, ExportDefaultDeclarationKind,
     ForStatementInit, ForStatementLeft, Function, FunctionBody, LabeledStatement, Program,
     Statement, StaticBlock, SwitchCase, SwitchStatement, VariableDeclaration,
     VariableDeclarationKind, VariableDeclarator,
@@ -22,19 +22,15 @@ pub(crate) trait LexicallyDeclaredNames<'a> {
     fn lexically_declared_names<F: FnMut(&BindingIdentifier<'a>)>(&'a self, f: &mut F);
 }
 
-pub(crate) fn script_lexically_declared_names<'a, 'b: 'a>(
-    script: &'b Program<'a>,
-) -> Vec<Atom<'a>> {
+pub(crate) fn script_lexically_declared_names<'a>(body: &'a [Statement<'a>]) -> Vec<Atom<'a>> {
     let mut lexically_declared_names: Vec<Atom<'a>> = vec![];
     // Script : [empty]
     // 1. Return a new empty List.
     // ScriptBody : StatementList
     // 1. Return TopLevelLexicallyDeclaredNames of StatementList.
-    script
-        .body
-        .top_level_lexically_declared_names(&mut |identifier| {
-            lexically_declared_names.push(identifier.name);
-        });
+    body.top_level_lexically_declared_names(&mut |identifier| {
+        lexically_declared_names.push(identifier.name);
+    });
     // NOTE 1
     // At the top level of a Script, function declarations are treated like var declarations rather than like lexical declarations.
     lexically_declared_names
@@ -284,22 +280,20 @@ pub(crate) fn class_static_block_lexically_scoped_declarations<'body>(
     lexically_scoped_declarations
 }
 
-pub(crate) fn script_lexically_scoped_declarations<'body>(
-    script: &'body Program<'body>,
-) -> Vec<LexicallyScopedDeclaration<'body>> {
+pub(crate) fn script_lexically_scoped_declarations<'a>(
+    body: &'a [Statement<'a>],
+) -> Vec<LexicallyScopedDeclaration<'a>> {
     let mut lexically_scoped_declarations = vec![];
     // 1. Return TopLevelLexicallyScopedDeclarations of StatementList.
-    script
-        .body
-        .top_level_lexically_scoped_declarations(&mut |decl| {
-            lexically_scoped_declarations.push(decl);
-        });
+    body.top_level_lexically_scoped_declarations(&mut |decl| {
+        lexically_scoped_declarations.push(decl);
+    });
 
     lexically_scoped_declarations
 }
 
 pub(crate) fn module_lexically_scoped_declarations<'a>(
-    module: &'a [ast::Statement<'a>],
+    module: &'a [Statement<'a>],
 ) -> Vec<LexicallyScopedDeclaration<'a>> {
     let mut lexically_scoped_declarations = vec![];
 
@@ -499,13 +493,13 @@ pub(crate) trait VarDeclaredNames<'a> {
     fn var_declared_names<F: FnMut(&BindingIdentifier<'a>)>(&self, f: &mut F);
 }
 
-pub(crate) fn script_var_declared_names<'a>(script: &'a Program<'a>) -> Vec<Atom<'a>> {
+pub(crate) fn script_var_declared_names<'a>(body: &'a [Statement<'a>]) -> Vec<Atom<'a>> {
     let mut var_declared_names = vec![];
     // Script : [empty]
     // 1. Return a new empty List.
     // ScriptBody : StatementList
     // 1. Return TopLevelVarDeclaredNames of StatementList.
-    script.body.top_level_var_declared_names(&mut |identifier| {
+    body.top_level_var_declared_names(&mut |identifier| {
         var_declared_names.push(identifier.name);
     });
     // NOTE 1
@@ -771,23 +765,21 @@ pub(crate) trait VarScopedDeclarations<'a> {
 }
 
 pub(crate) fn script_var_scoped_declarations<'a>(
-    script: &'a Program<'a>,
+    body: &'a [Statement<'a>],
 ) -> Vec<VarScopedDeclaration<'a>> {
     let mut var_scoped_declarations = vec![];
     // Script : [empty]
     // 1. Return a new empty List.
     // ScriptBody : StatementList
     // 1. Return TopLevelVarScopedDeclarations of StatementList.
-    script
-        .body
-        .top_level_var_scoped_declarations(&mut |declarator| {
-            var_scoped_declarations.push(declarator);
-        });
+    body.top_level_var_scoped_declarations(&mut |declarator| {
+        var_scoped_declarations.push(declarator);
+    });
     var_scoped_declarations
 }
 
 pub(crate) fn module_var_scoped_declarations<'a>(
-    body: &'a [ast::Statement<'a>],
+    body: &'a [Statement<'a>],
 ) -> Vec<VarScopedDeclaration<'a>> {
     let mut var_scoped_declarations = vec![];
     // Module : [empty]
@@ -1074,6 +1066,18 @@ impl<'a> TopLevelLexicallyDeclaredNames<'a> for oxc_allocator::Vec<'a, Statement
     }
 }
 
+impl<'a> TopLevelLexicallyDeclaredNames<'a> for [Statement<'a>] {
+    fn top_level_lexically_declared_names<F: FnMut(&BindingIdentifier<'a>)>(&'a self, f: &mut F) {
+        // StatementList : StatementList StatementListItem
+        // 1. Let names1 be TopLevelLexicallyDeclaredNames of StatementList.
+        // 2. Let names2 be TopLevelLexicallyDeclaredNames of StatementListItem.
+        // 3. Return the list-concatenation of names1 and names2.
+        for ele in self {
+            ele.top_level_lexically_declared_names(f);
+        }
+    }
+}
+
 impl<'a> TopLevelLexicallyDeclaredNames<'a> for Statement<'a> {
     fn top_level_lexically_declared_names<F: FnMut(&BindingIdentifier<'a>)>(&'a self, f: &mut F) {
         // NOTE
@@ -1139,6 +1143,21 @@ trait TopLevelLexicallyScopedDeclarations<'a> {
 }
 
 impl<'a> TopLevelLexicallyScopedDeclarations<'a> for oxc_allocator::Vec<'a, Statement<'a>> {
+    fn top_level_lexically_scoped_declarations<F: FnMut(LexicallyScopedDeclaration<'a>)>(
+        &'a self,
+        f: &mut F,
+    ) {
+        // StatementList : StatementList StatementListItem
+        // 1. Let declarations1 be TopLevelLexicallyScopedDeclarations of StatementList.
+        // 2. Let declarations2 be TopLevelLexicallyScopedDeclarations of StatementListItem.
+        // 3. Return the list-concatenation of declarations1 and declarations2.
+        for ele in self {
+            ele.top_level_lexically_scoped_declarations(f);
+        }
+    }
+}
+
+impl<'a> TopLevelLexicallyScopedDeclarations<'a> for [Statement<'a>] {
     fn top_level_lexically_scoped_declarations<F: FnMut(LexicallyScopedDeclaration<'a>)>(
         &'a self,
         f: &mut F,
@@ -1223,6 +1242,18 @@ trait TopLevelVarDeclaredNames<'a> {
 }
 
 impl<'a> TopLevelVarDeclaredNames<'a> for oxc_allocator::Vec<'a, Statement<'a>> {
+    fn top_level_var_declared_names<F: FnMut(&BindingIdentifier<'a>)>(&'a self, f: &mut F) {
+        // StatementList : StatementList StatementListItem
+        // 1. Let names1 be TopLevelVarDeclaredNames of StatementList.
+        // 2. Let names2 be TopLevelVarDeclaredNames of StatementListItem.
+        // 3. Return the list-concatenation of names1 and names2.
+        for ele in self {
+            ele.top_level_var_declared_names(f);
+        }
+    }
+}
+
+impl<'a> TopLevelVarDeclaredNames<'a> for [Statement<'a>] {
     fn top_level_var_declared_names<F: FnMut(&BindingIdentifier<'a>)>(&'a self, f: &mut F) {
         // StatementList : StatementList StatementListItem
         // 1. Let names1 be TopLevelVarDeclaredNames of StatementList.
@@ -1355,6 +1386,18 @@ trait TopLevelVarScopedDeclarations<'a> {
 }
 
 impl<'a> TopLevelVarScopedDeclarations<'a> for oxc_allocator::Vec<'a, Statement<'a>> {
+    fn top_level_var_scoped_declarations<F: FnMut(VarScopedDeclaration<'a>)>(&'a self, f: &mut F) {
+        // StatementList : StatementList StatementListItem
+        // 1. Let declarations1 be TopLevelVarScopedDeclarations of StatementList.
+        // 2. Let declarations2 be TopLevelVarScopedDeclarations of StatementListItem.
+        // 3. Return the list-concatenation of declarations1 and declarations2.
+        for ele in self {
+            ele.top_level_var_scoped_declarations(f);
+        }
+    }
+}
+
+impl<'a> TopLevelVarScopedDeclarations<'a> for [Statement<'a>] {
     fn top_level_var_scoped_declarations<F: FnMut(VarScopedDeclaration<'a>)>(&'a self, f: &mut F) {
         // StatementList : StatementList StatementListItem
         // 1. Let declarations1 be TopLevelVarScopedDeclarations of StatementList.

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -6,23 +6,31 @@ mod data;
 pub mod into_function;
 
 use super::{
+    InternalMethods, InternalSlots, Object, OrdinaryObject, PropertyKey, String, Value,
     value::{
         BOUND_FUNCTION_DISCRIMINANT, BUILTIN_CONSTRUCTOR_FUNCTION_DISCRIMINANT,
         BUILTIN_FUNCTION_DISCRIMINANT, BUILTIN_GENERATOR_FUNCTION_DISCRIMINANT,
         BUILTIN_PROMISE_COLLECTOR_FUNCTION_DISCRIMINANT,
         BUILTIN_PROMISE_RESOLVING_FUNCTION_DISCRIMINANT, BUILTIN_PROXY_REVOKER_FUNCTION,
         ECMASCRIPT_FUNCTION_DISCRIMINANT,
-    }, InternalMethods, Object, OrdinaryObject, InternalSlots, PropertyKey, Value, String
+    },
 };
-use crate::engine::{context::{ Bindable, GcScope, NoGcScope}, TryResult};
 use crate::{
     ecmascript::{
         builtins::{
-            bound_function::BoundFunction, control_abstraction_objects::promise_objects::promise_abstract_operations::promise_resolving_functions::BuiltinPromiseResolvingFunction, ArgumentsList, BuiltinConstructorFunction, BuiltinFunction, ECMAScriptFunction
+            ArgumentsList, BuiltinConstructorFunction, BuiltinFunction, ECMAScriptFunction,
+            bound_function::BoundFunction,
+            promise_objects::promise_abstract_operations::promise_resolving_functions::BuiltinPromiseResolvingFunction,
         },
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::PropertyDescriptor,
-    }, engine::rootable::{HeapRootData, HeapRootRef, Rootable}, heap::{CompactionLists, HeapMarkAndSweep, WorkQueues}
+    },
+    engine::{
+        TryResult,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::{HeapRootData, HeapRootRef, Rootable},
+    },
+    heap::{CompactionLists, HeapMarkAndSweep, WorkQueues},
 };
 
 pub(crate) use data::*;

--- a/nova_vm/src/ecmascript/types/language/numeric.rs
+++ b/nova_vm/src/ecmascript/types/language/numeric.rs
@@ -2,13 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::engine::context::{Bindable, NoGcScope};
-use crate::engine::small_bigint::SmallBigInt;
 use crate::{
     SmallInteger,
     ecmascript::execution::Agent,
     engine::{
+        context::{Bindable, NoGcScope},
         rootable::{HeapRootData, HeapRootRef, Rootable},
+        small_bigint::SmallBigInt,
         small_f64::SmallF64,
     },
 };

--- a/nova_vm/src/ecmascript/types/spec/property_descriptor.rs
+++ b/nova_vm/src/ecmascript/types/spec/property_descriptor.rs
@@ -2,14 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::ecmascript::abstract_operations::operations_on_objects::{try_get, try_has_property};
-use crate::engine::context::{Bindable, GcScope, NoGcScope};
-use crate::engine::rootable::Scopable;
-use crate::engine::{Scoped, TryResult};
 use crate::{
     ecmascript::{
         abstract_operations::{
-            operations_on_objects::{get, has_property},
+            operations_on_objects::{get, has_property, try_get, try_has_property},
             testing_and_comparison::is_callable,
             type_conversion::to_boolean,
         },
@@ -17,6 +13,11 @@ use crate::{
         types::{
             BUILTIN_STRING_MEMORY, Function, IntoObject, IntoValue, Object, OrdinaryObject, Value,
         },
+    },
+    engine::{
+        Scoped, TryResult,
+        context::{Bindable, GcScope, NoGcScope},
+        rootable::Scopable,
     },
     heap::ObjectEntry,
 };

--- a/nova_vm/src/engine/bytecode.rs
+++ b/nova_vm/src/engine/bytecode.rs
@@ -8,7 +8,9 @@ mod instructions;
 pub(super) mod iterator;
 mod vm;
 
-pub(crate) use bytecode_compiler::{CompileContext, CompileEvaluation, NamedEvaluationParameter};
+pub(crate) use bytecode_compiler::{
+    CompileContext, CompileEvaluation, NamedEvaluationParameter, string_literal_to_wtf8,
+};
 pub(crate) use executable::{
     Executable, ExecutableHeapData, FunctionExpression, IndexType, SendableRef,
 };


### PR DESCRIPTION
The SourceCode's internal Allocator was Box'd because the Program kept references to it. Moving the Allocator would then invalidate those references and cause UB.

But it turns out that we don't really need the Program; we only really care about the body statements (and the directives sometimes). This lets us unbox the Allocator.