### PR TITLE
feat(ecmascript): Non-Ordinary Object caches

### DIFF
--- a/nova_vm/src/ecmascript/abstract_operations/type_conversion.rs
+++ b/nova_vm/src/ecmascript/abstract_operations/type_conversion.rs
@@ -40,7 +40,7 @@ use crate::{
 
 use super::{
     operations_on_objects::{call_function, get, get_method},
-    testing_and_comparison::is_callable,
+    testing_and_comparison::{is_callable, require_object_coercible},
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -1149,12 +1149,9 @@ pub(crate) fn to_object<'a>(
     gc: NoGcScope<'a, '_>,
 ) -> JsResult<'a, Object<'a>> {
     let argument = argument.bind(gc);
+    require_object_coercible(agent, argument, gc)?;
     match argument {
-        Value::Undefined | Value::Null => Err(agent.throw_exception_with_static_message(
-            ExceptionType::TypeError,
-            "Argument cannot be converted into an object",
-            gc,
-        )),
+        Value::Undefined | Value::Null => unreachable!(),
         // Return a new Boolean object whose [[BooleanData]] internal slot is set to argument.
         Value::Boolean(bool) => Ok(agent
             .heap

--- a/nova_vm/src/ecmascript/builtins/array.rs
+++ b/nova_vm/src/ecmascript/builtins/array.rs
@@ -999,7 +999,7 @@ impl<'a> InternalMethods<'a> for Array<'a> {
         // If this was a non-Array index or a named property on the Array then
         // we want to perform a normal cached set with the Array's shape.
         let shape = self.object_shape(agent);
-        shape.set_cached(agent, p, value, receiver, cache, gc)
+        shape.set_cached(agent, self.into_object(), p, value, receiver, cache, gc)
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/array.rs
+++ b/nova_vm/src/ecmascript/builtins/array.rs
@@ -24,8 +24,8 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            BUILTIN_STRING_MEMORY, Function, GetCachedBreak, GetCachedNoCache, InternalMethods,
-            InternalSlots, IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject,
+            BUILTIN_STRING_MEMORY, Function, GetCachedBreak, InternalMethods, InternalSlots,
+            IntoFunction, IntoObject, IntoValue, NoCache, Object, OrdinaryObject,
             PropertyDescriptor, PropertyKey, SetCachedResult, Value,
         },
     },
@@ -879,7 +879,7 @@ impl<'a> InternalMethods<'a> for Array<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         // Cached lookup of an Array should return directly from the Array's
         // internal memory if it can.
         if p == BUILTIN_STRING_MEMORY.length.to_property_key() {

--- a/nova_vm/src/ecmascript/builtins/array/abstract_operations.rs
+++ b/nova_vm/src/ecmascript/builtins/array/abstract_operations.rs
@@ -306,7 +306,7 @@ fn array_set_length_no_value_field(agent: &mut Agent, a: Array, desc: PropertyDe
     true
 }
 
-fn array_set_length_handling(
+pub(crate) fn array_set_length_handling(
     agent: &mut Agent,
     a: Array,
     new_len: u32,

--- a/nova_vm/src/ecmascript/builtins/bound_function.rs
+++ b/nova_vm/src/ecmascript/builtins/bound_function.rs
@@ -12,7 +12,7 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics, agent::ExceptionType},
         types::{
-            BoundFunctionHeapData, Function, FunctionInternalProperties, GetCachedResult,
+            BoundFunctionHeapData, Function, FunctionInternalProperties, GetCachedError,
             InternalMethods, InternalSlots, IntoFunction, IntoValue, Object, OrdinaryObject,
             PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
             function_create_backing_object, function_get_cached,
@@ -299,7 +299,7 @@ impl<'a> InternalMethods<'a> for BoundFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/bound_function.rs
+++ b/nova_vm/src/ecmascript/builtins/bound_function.rs
@@ -14,7 +14,7 @@ use crate::{
         execution::{Agent, JsResult, ProtoIntrinsics, agent::ExceptionType},
         types::{
             BoundFunctionHeapData, Function, FunctionInternalProperties, GetCachedBreak,
-            GetCachedNoCache, InternalMethods, InternalSlots, IntoFunction, IntoValue, Object,
+            NoCache, InternalMethods, InternalSlots, IntoFunction, IntoValue, Object,
             OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
             function_create_backing_object, function_get_cached,
             function_internal_define_own_property, function_internal_delete, function_internal_get,
@@ -300,7 +300,7 @@ impl<'a> InternalMethods<'a> for BoundFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/bound_function.rs
+++ b/nova_vm/src/ecmascript/builtins/bound_function.rs
@@ -12,13 +12,13 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics, agent::ExceptionType},
         types::{
-            BoundFunctionHeapData, Function, FunctionInternalProperties, InternalMethods,
-            InternalSlots, IntoFunction, IntoValue, Object, OrdinaryObject, PropertyDescriptor,
-            PropertyKey, String, Value, function_create_backing_object,
-            function_internal_define_own_property, function_internal_delete, function_internal_get,
-            function_internal_get_own_property, function_internal_has_property,
-            function_internal_own_property_keys, function_internal_set, function_try_get,
-            function_try_has_property, function_try_set,
+            BoundFunctionHeapData, CachedLookupResult, Function, FunctionInternalProperties,
+            InternalMethods, InternalSlots, IntoFunction, IntoValue, Object, OrdinaryObject,
+            PropertyDescriptor, PropertyKey, String, Value, function_cached_lookup,
+            function_create_backing_object, function_internal_define_own_property,
+            function_internal_delete, function_internal_get, function_internal_get_own_property,
+            function_internal_has_property, function_internal_own_property_keys,
+            function_internal_set, function_try_get, function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -33,7 +33,7 @@ use crate::{
     },
 };
 
-use super::ArgumentsList;
+use super::{ArgumentsList, ordinary::caches::PropertyLookupCache};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
@@ -178,6 +178,16 @@ impl<'a> InternalSlots<'a> for BoundFunction<'a> {
 
     fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject<'static> {
         function_create_backing_object(self, agent)
+    }
+
+    fn cached_lookup<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> CachedLookupResult<'gc> {
+        function_cached_lookup(self, agent, p, cache, gc)
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/bound_function.rs
+++ b/nova_vm/src/ecmascript/builtins/bound_function.rs
@@ -12,13 +12,14 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics, agent::ExceptionType},
         types::{
-            BoundFunctionHeapData, CachedLookupResult, Function, FunctionInternalProperties,
+            BoundFunctionHeapData, Function, FunctionInternalProperties, GetCachedResult,
             InternalMethods, InternalSlots, IntoFunction, IntoValue, Object, OrdinaryObject,
-            PropertyDescriptor, PropertyKey, String, Value, function_cached_lookup,
-            function_create_backing_object, function_internal_define_own_property,
-            function_internal_delete, function_internal_get, function_internal_get_own_property,
-            function_internal_has_property, function_internal_own_property_keys,
-            function_internal_set, function_try_get, function_try_has_property, function_try_set,
+            PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
+            function_create_backing_object, function_get_cached,
+            function_internal_define_own_property, function_internal_delete, function_internal_get,
+            function_internal_get_own_property, function_internal_has_property,
+            function_internal_own_property_keys, function_internal_set, function_set_cached,
+            function_try_get, function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -179,16 +180,6 @@ impl<'a> InternalSlots<'a> for BoundFunction<'a> {
     fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject<'static> {
         function_create_backing_object(self, agent)
     }
-
-    fn cached_lookup<'gc>(
-        self,
-        agent: &mut Agent,
-        p: PropertyKey,
-        cache: PropertyLookupCache,
-        gc: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
-        function_cached_lookup(self, agent, p, cache, gc)
-    }
 }
 
 impl<'a> InternalMethods<'a> for BoundFunction<'a> {
@@ -300,6 +291,27 @@ impl<'a> InternalMethods<'a> for BoundFunction<'a> {
         gc: NoGcScope<'gc, '_>,
     ) -> TryResult<Vec<PropertyKey<'gc>>> {
         TryResult::Continue(function_internal_own_property_keys(self, agent, gc))
+    }
+
+    fn get_cached<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> GetCachedResult<'gc> {
+        function_get_cached(self, agent, p, cache, gc)
+    }
+
+    fn set_cached<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        value: Value,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> SetCachedResult<'gc> {
+        function_set_cached(self, agent, p, value, cache, gc)
     }
 
     /// ### [10.4.1.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist)

--- a/nova_vm/src/ecmascript/builtins/bound_function.rs
+++ b/nova_vm/src/ecmascript/builtins/bound_function.rs
@@ -13,8 +13,8 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics, agent::ExceptionType},
         types::{
-            BoundFunctionHeapData, Function, FunctionInternalProperties, GetCachedBreak,
-            NoCache, InternalMethods, InternalSlots, IntoFunction, IntoValue, Object,
+            BoundFunctionHeapData, Function, FunctionInternalProperties, GetCachedResult,
+            InternalMethods, InternalSlots, IntoFunction, IntoValue, NoCache, Object,
             OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
             function_create_backing_object, function_get_cached,
             function_internal_define_own_property, function_internal_delete, function_internal_get,
@@ -300,7 +300,7 @@ impl<'a> InternalMethods<'a> for BoundFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 
@@ -312,7 +312,7 @@ impl<'a> InternalMethods<'a> for BoundFunction<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         function_set_cached(self, agent, p, value, receiver, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/bound_function.rs
+++ b/nova_vm/src/ecmascript/builtins/bound_function.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use core::ops::{Index, IndexMut};
+use std::ops::ControlFlow;
 
 use crate::{
     ecmascript::{
@@ -12,9 +13,9 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics, agent::ExceptionType},
         types::{
-            BoundFunctionHeapData, Function, FunctionInternalProperties, GetCachedError,
-            InternalMethods, InternalSlots, IntoFunction, IntoValue, Object, OrdinaryObject,
-            PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
+            BoundFunctionHeapData, Function, FunctionInternalProperties, GetCachedBreak,
+            GetCachedNoCache, InternalMethods, InternalSlots, IntoFunction, IntoValue, Object,
+            OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
             function_create_backing_object, function_get_cached,
             function_internal_define_own_property, function_internal_delete, function_internal_get,
             function_internal_get_own_property, function_internal_has_property,
@@ -299,7 +300,7 @@ impl<'a> InternalMethods<'a> for BoundFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/bound_function.rs
+++ b/nova_vm/src/ecmascript/builtins/bound_function.rs
@@ -308,10 +308,11 @@ impl<'a> InternalMethods<'a> for BoundFunction<'a> {
         agent: &mut Agent,
         p: PropertyKey,
         value: Value,
+        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
-        function_set_cached(self, agent, p, value, cache, gc)
+        function_set_cached(self, agent, p, value, receiver, cache, gc)
     }
 
     /// ### [10.4.1.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist)

--- a/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
@@ -18,7 +18,7 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, BuiltinConstructorHeapData, Function,
-            FunctionInternalProperties, GetCachedResult, InternalMethods, InternalSlots,
+            FunctionInternalProperties, GetCachedError, InternalMethods, InternalSlots,
             IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor,
             PropertyKey, SetCachedResult, String, Value, function_create_backing_object,
             function_get_cached, function_internal_define_own_property, function_internal_delete,
@@ -308,7 +308,7 @@ impl<'a> InternalMethods<'a> for BuiltinConstructorFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
@@ -17,13 +17,14 @@ use crate::{
             base_class_default_constructor, derived_class_default_constructor,
         },
         types::{
-            BUILTIN_STRING_MEMORY, BuiltinConstructorHeapData, CachedLookupResult, Function,
-            FunctionInternalProperties, InternalMethods, InternalSlots, IntoFunction, IntoObject,
-            IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
-            function_cached_lookup, function_create_backing_object,
-            function_internal_define_own_property, function_internal_delete, function_internal_get,
-            function_internal_get_own_property, function_internal_has_property,
-            function_internal_own_property_keys, function_internal_set, function_try_get,
+            BUILTIN_STRING_MEMORY, BuiltinConstructorHeapData, Function,
+            FunctionInternalProperties, GetCachedResult, InternalMethods, InternalSlots,
+            IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor,
+            PropertyKey, SetCachedResult, String, Value, function_create_backing_object,
+            function_get_cached, function_internal_define_own_property, function_internal_delete,
+            function_internal_get, function_internal_get_own_property,
+            function_internal_has_property, function_internal_own_property_keys,
+            function_internal_set, function_set_cached, function_try_get,
             function_try_has_property, function_try_set,
         },
     },
@@ -188,16 +189,6 @@ impl<'a> InternalSlots<'a> for BuiltinConstructorFunction<'a> {
     fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject<'static> {
         function_create_backing_object(self, agent)
     }
-
-    fn cached_lookup<'gc>(
-        self,
-        agent: &mut Agent,
-        p: PropertyKey,
-        cache: PropertyLookupCache,
-        gc: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
-        function_cached_lookup(self, agent, p, cache, gc)
-    }
 }
 
 impl<'a> InternalMethods<'a> for BuiltinConstructorFunction<'a> {
@@ -309,6 +300,27 @@ impl<'a> InternalMethods<'a> for BuiltinConstructorFunction<'a> {
         gc: NoGcScope<'gc, '_>,
     ) -> TryResult<Vec<PropertyKey<'gc>>> {
         TryResult::Continue(function_internal_own_property_keys(self, agent, gc))
+    }
+
+    fn get_cached<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> GetCachedResult<'gc> {
+        function_get_cached(self, agent, p, cache, gc)
+    }
+
+    fn set_cached<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        value: Value,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> SetCachedResult<'gc> {
+        function_set_cached(self, agent, p, value, cache, gc)
     }
 
     /// ### [10.3.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist)

--- a/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
@@ -317,10 +317,11 @@ impl<'a> InternalMethods<'a> for BuiltinConstructorFunction<'a> {
         agent: &mut Agent,
         p: PropertyKey,
         value: Value,
+        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
-        function_set_cached(self, agent, p, value, cache, gc)
+        function_set_cached(self, agent, p, value, receiver, cache, gc)
     }
 
     /// ### [10.3.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist)

--- a/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use core::ops::{Index, IndexMut};
+use std::ops::ControlFlow;
 
 use oxc_span::Span;
 
@@ -18,14 +19,14 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, BuiltinConstructorHeapData, Function,
-            FunctionInternalProperties, GetCachedError, InternalMethods, InternalSlots,
-            IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor,
-            PropertyKey, SetCachedResult, String, Value, function_create_backing_object,
-            function_get_cached, function_internal_define_own_property, function_internal_delete,
-            function_internal_get, function_internal_get_own_property,
-            function_internal_has_property, function_internal_own_property_keys,
-            function_internal_set, function_set_cached, function_try_get,
-            function_try_has_property, function_try_set,
+            FunctionInternalProperties, GetCachedBreak, GetCachedNoCache, InternalMethods,
+            InternalSlots, IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject,
+            PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
+            function_create_backing_object, function_get_cached,
+            function_internal_define_own_property, function_internal_delete, function_internal_get,
+            function_internal_get_own_property, function_internal_has_property,
+            function_internal_own_property_keys, function_internal_set, function_set_cached,
+            function_try_get, function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -308,7 +309,7 @@ impl<'a> InternalMethods<'a> for BuiltinConstructorFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
@@ -19,7 +19,7 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, BuiltinConstructorHeapData, Function,
-            FunctionInternalProperties, GetCachedBreak, GetCachedNoCache, InternalMethods,
+            FunctionInternalProperties, GetCachedBreak, NoCache, InternalMethods,
             InternalSlots, IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject,
             PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
             function_create_backing_object, function_get_cached,
@@ -309,7 +309,7 @@ impl<'a> InternalMethods<'a> for BuiltinConstructorFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
@@ -17,13 +17,14 @@ use crate::{
             base_class_default_constructor, derived_class_default_constructor,
         },
         types::{
-            BUILTIN_STRING_MEMORY, BuiltinConstructorHeapData, Function,
+            BUILTIN_STRING_MEMORY, BuiltinConstructorHeapData, CachedLookupResult, Function,
             FunctionInternalProperties, InternalMethods, InternalSlots, IntoFunction, IntoObject,
             IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
-            function_create_backing_object, function_internal_define_own_property,
-            function_internal_delete, function_internal_get, function_internal_get_own_property,
-            function_internal_has_property, function_internal_own_property_keys,
-            function_internal_set, function_try_get, function_try_has_property, function_try_set,
+            function_cached_lookup, function_create_backing_object,
+            function_internal_define_own_property, function_internal_delete, function_internal_get,
+            function_internal_get_own_property, function_internal_has_property,
+            function_internal_own_property_keys, function_internal_set, function_try_get,
+            function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -37,7 +38,7 @@ use crate::{
     },
 };
 
-use super::ArgumentsList;
+use super::{ArgumentsList, ordinary::caches::PropertyLookupCache};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BuiltinConstructorFunction<'a>(pub(crate) BuiltinConstructorIndex<'a>);
@@ -186,6 +187,16 @@ impl<'a> InternalSlots<'a> for BuiltinConstructorFunction<'a> {
 
     fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject<'static> {
         function_create_backing_object(self, agent)
+    }
+
+    fn cached_lookup<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> CachedLookupResult<'gc> {
+        function_cached_lookup(self, agent, p, cache, gc)
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
@@ -19,8 +19,8 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, BuiltinConstructorHeapData, Function,
-            FunctionInternalProperties, GetCachedBreak, NoCache, InternalMethods,
-            InternalSlots, IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject,
+            FunctionInternalProperties, GetCachedResult, InternalMethods, InternalSlots,
+            IntoFunction, IntoObject, IntoValue, NoCache, Object, OrdinaryObject,
             PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
             function_create_backing_object, function_get_cached,
             function_internal_define_own_property, function_internal_delete, function_internal_get,
@@ -309,7 +309,7 @@ impl<'a> InternalMethods<'a> for BuiltinConstructorFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 
@@ -321,7 +321,7 @@ impl<'a> InternalMethods<'a> for BuiltinConstructorFunction<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         function_set_cached(self, agent, p, value, receiver, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -15,14 +15,13 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, BuiltinFunctionHeapData, Function, FunctionInternalProperties,
-            GetCachedBreak, NoCache, InternalMethods, InternalSlots, IntoFunction,
-            IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
-            ScopedValuesIterator, SetCachedResult, String, Value, function_create_backing_object,
-            function_get_cached, function_internal_define_own_property, function_internal_delete,
-            function_internal_get, function_internal_get_own_property,
-            function_internal_has_property, function_internal_own_property_keys,
-            function_internal_set, function_set_cached, function_try_get,
-            function_try_has_property, function_try_set,
+            GetCachedResult, InternalMethods, InternalSlots, IntoFunction, IntoObject, IntoValue,
+            NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, ScopedValuesIterator,
+            SetCachedResult, String, Value, function_create_backing_object, function_get_cached,
+            function_internal_define_own_property, function_internal_delete, function_internal_get,
+            function_internal_get_own_property, function_internal_has_property,
+            function_internal_own_property_keys, function_internal_set, function_set_cached,
+            function_try_get, function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -678,7 +677,7 @@ impl<'a> InternalMethods<'a> for BuiltinFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 
@@ -690,7 +689,7 @@ impl<'a> InternalMethods<'a> for BuiltinFunction<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         function_set_cached(self, agent, p, value, receiver, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, BuiltinFunctionHeapData, Function, FunctionInternalProperties,
-            GetCachedResult, InternalMethods, InternalSlots, IntoFunction, IntoObject, IntoValue,
+            GetCachedError, InternalMethods, InternalSlots, IntoFunction, IntoObject, IntoValue,
             Object, OrdinaryObject, PropertyDescriptor, PropertyKey, ScopedValuesIterator,
             SetCachedResult, String, Value, function_create_backing_object, function_get_cached,
             function_internal_define_own_property, function_internal_delete, function_internal_get,
@@ -677,7 +677,7 @@ impl<'a> InternalMethods<'a> for BuiltinFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, BuiltinFunctionHeapData, Function, FunctionInternalProperties,
-            GetCachedBreak, GetCachedNoCache, InternalMethods, InternalSlots, IntoFunction,
+            GetCachedBreak, NoCache, InternalMethods, InternalSlots, IntoFunction,
             IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
             ScopedValuesIterator, SetCachedResult, String, Value, function_create_backing_object,
             function_get_cached, function_internal_define_own_property, function_internal_delete,
@@ -678,7 +678,7 @@ impl<'a> InternalMethods<'a> for BuiltinFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -14,9 +14,10 @@ use crate::{
             Agent, ExecutionContext, JsResult, ProtoIntrinsics, Realm, agent::ExceptionType,
         },
         types::{
-            BUILTIN_STRING_MEMORY, BuiltinFunctionHeapData, Function, FunctionInternalProperties,
-            InternalMethods, InternalSlots, IntoFunction, IntoObject, IntoValue, Object,
-            OrdinaryObject, PropertyDescriptor, PropertyKey, ScopedValuesIterator, String, Value,
+            BUILTIN_STRING_MEMORY, BuiltinFunctionHeapData, CachedLookupResult, Function,
+            FunctionInternalProperties, InternalMethods, InternalSlots, IntoFunction, IntoObject,
+            IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
+            ScopedValuesIterator, String, Value, function_cached_lookup,
             function_create_backing_object, function_internal_define_own_property,
             function_internal_delete, function_internal_get, function_internal_get_own_property,
             function_internal_has_property, function_internal_own_property_keys,
@@ -34,6 +35,8 @@ use crate::{
         ObjectEntryPropertyDescriptor, WorkQueues, indexes::BuiltinFunctionIndex,
     },
 };
+
+use super::ordinary::caches::PropertyLookupCache;
 
 #[derive(Default)]
 #[repr(transparent)]
@@ -554,6 +557,16 @@ impl<'a> InternalSlots<'a> for BuiltinFunction<'a> {
 
     fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject<'static> {
         function_create_backing_object(self, agent)
+    }
+
+    fn cached_lookup<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> CachedLookupResult<'gc> {
+        function_cached_lookup(self, agent, p, cache, gc)
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -6,7 +6,7 @@ use core::{
     marker::PhantomData,
     ops::{Deref, Index, IndexMut},
 };
-use std::{hint::unreachable_unchecked, ptr::NonNull};
+use std::{hint::unreachable_unchecked, ops::ControlFlow, ptr::NonNull};
 
 use crate::{
     ecmascript::{
@@ -15,13 +15,14 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, BuiltinFunctionHeapData, Function, FunctionInternalProperties,
-            GetCachedError, InternalMethods, InternalSlots, IntoFunction, IntoObject, IntoValue,
-            Object, OrdinaryObject, PropertyDescriptor, PropertyKey, ScopedValuesIterator,
-            SetCachedResult, String, Value, function_create_backing_object, function_get_cached,
-            function_internal_define_own_property, function_internal_delete, function_internal_get,
-            function_internal_get_own_property, function_internal_has_property,
-            function_internal_own_property_keys, function_internal_set, function_set_cached,
-            function_try_get, function_try_has_property, function_try_set,
+            GetCachedBreak, GetCachedNoCache, InternalMethods, InternalSlots, IntoFunction,
+            IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
+            ScopedValuesIterator, SetCachedResult, String, Value, function_create_backing_object,
+            function_get_cached, function_internal_define_own_property, function_internal_delete,
+            function_internal_get, function_internal_get_own_property,
+            function_internal_has_property, function_internal_own_property_keys,
+            function_internal_set, function_set_cached, function_try_get,
+            function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -677,7 +678,7 @@ impl<'a> InternalMethods<'a> for BuiltinFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -14,14 +14,14 @@ use crate::{
             Agent, ExecutionContext, JsResult, ProtoIntrinsics, Realm, agent::ExceptionType,
         },
         types::{
-            BUILTIN_STRING_MEMORY, BuiltinFunctionHeapData, CachedLookupResult, Function,
-            FunctionInternalProperties, InternalMethods, InternalSlots, IntoFunction, IntoObject,
-            IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
-            ScopedValuesIterator, String, Value, function_cached_lookup,
-            function_create_backing_object, function_internal_define_own_property,
-            function_internal_delete, function_internal_get, function_internal_get_own_property,
-            function_internal_has_property, function_internal_own_property_keys,
-            function_internal_set, function_try_get, function_try_has_property, function_try_set,
+            BUILTIN_STRING_MEMORY, BuiltinFunctionHeapData, Function, FunctionInternalProperties,
+            GetCachedResult, InternalMethods, InternalSlots, IntoFunction, IntoObject, IntoValue,
+            Object, OrdinaryObject, PropertyDescriptor, PropertyKey, ScopedValuesIterator,
+            SetCachedResult, String, Value, function_create_backing_object, function_get_cached,
+            function_internal_define_own_property, function_internal_delete, function_internal_get,
+            function_internal_get_own_property, function_internal_has_property,
+            function_internal_own_property_keys, function_internal_set, function_set_cached,
+            function_try_get, function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -558,16 +558,6 @@ impl<'a> InternalSlots<'a> for BuiltinFunction<'a> {
     fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject<'static> {
         function_create_backing_object(self, agent)
     }
-
-    fn cached_lookup<'gc>(
-        self,
-        agent: &mut Agent,
-        p: PropertyKey,
-        cache: PropertyLookupCache,
-        gc: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
-        function_cached_lookup(self, agent, p, cache, gc)
-    }
 }
 
 impl<'a> InternalMethods<'a> for BuiltinFunction<'a> {
@@ -679,6 +669,27 @@ impl<'a> InternalMethods<'a> for BuiltinFunction<'a> {
         gc: NoGcScope<'gc, '_>,
     ) -> TryResult<Vec<PropertyKey<'gc>>> {
         TryResult::Continue(function_internal_own_property_keys(self, agent, gc))
+    }
+
+    fn get_cached<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> GetCachedResult<'gc> {
+        function_get_cached(self, agent, p, cache, gc)
+    }
+
+    fn set_cached<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        value: Value,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> SetCachedResult<'gc> {
+        function_set_cached(self, agent, p, value, cache, gc)
     }
 
     /// ### [10.3.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist)

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -686,10 +686,11 @@ impl<'a> InternalMethods<'a> for BuiltinFunction<'a> {
         agent: &mut Agent,
         p: PropertyKey,
         value: Value,
+        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
-        function_set_cached(self, agent, p, value, cache, gc)
+        function_set_cached(self, agent, p, value, receiver, cache, gc)
     }
 
     /// ### [10.3.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist)

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
@@ -12,7 +12,7 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            Function, FunctionInternalProperties, GetCachedResult, InternalMethods, InternalSlots,
+            Function, FunctionInternalProperties, GetCachedError, InternalMethods, InternalSlots,
             Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String,
             Value, function_create_backing_object, function_get_cached,
             function_internal_define_own_property, function_internal_delete, function_internal_get,
@@ -244,7 +244,7 @@ impl<'a> InternalMethods<'a> for BuiltinPromiseResolvingFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
@@ -12,13 +12,13 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            CachedLookupResult, Function, FunctionInternalProperties, InternalMethods,
-            InternalSlots, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
-            function_cached_lookup, function_create_backing_object,
+            Function, FunctionInternalProperties, GetCachedResult, InternalMethods, InternalSlots,
+            Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String,
+            Value, function_create_backing_object, function_get_cached,
             function_internal_define_own_property, function_internal_delete, function_internal_get,
             function_internal_get_own_property, function_internal_has_property,
-            function_internal_own_property_keys, function_internal_set, function_try_get,
-            function_try_has_property, function_try_set,
+            function_internal_own_property_keys, function_internal_set, function_set_cached,
+            function_try_get, function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -124,16 +124,6 @@ impl<'a> InternalSlots<'a> for BuiltinPromiseResolvingFunction<'a> {
 
     fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject<'static> {
         function_create_backing_object(self, agent)
-    }
-
-    fn cached_lookup<'gc>(
-        self,
-        agent: &mut Agent,
-        p: PropertyKey,
-        cache: PropertyLookupCache,
-        gc: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
-        function_cached_lookup(self, agent, p, cache, gc)
     }
 }
 
@@ -246,6 +236,27 @@ impl<'a> InternalMethods<'a> for BuiltinPromiseResolvingFunction<'a> {
         gc: NoGcScope<'gc, '_>,
     ) -> TryResult<Vec<PropertyKey<'gc>>> {
         TryResult::Continue(function_internal_own_property_keys(self, agent, gc))
+    }
+
+    fn get_cached<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> GetCachedResult<'gc> {
+        function_get_cached(self, agent, p, cache, gc)
+    }
+
+    fn set_cached<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        value: Value,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> SetCachedResult<'gc> {
+        function_set_cached(self, agent, p, value, cache, gc)
     }
 
     fn internal_call<'gc>(

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
@@ -253,10 +253,11 @@ impl<'a> InternalMethods<'a> for BuiltinPromiseResolvingFunction<'a> {
         agent: &mut Agent,
         p: PropertyKey,
         value: Value,
+        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
-        function_set_cached(self, agent, p, value, cache, gc)
+        function_set_cached(self, agent, p, value, receiver, cache, gc)
     }
 
     fn internal_call<'gc>(

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
@@ -13,14 +13,13 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            Function, FunctionInternalProperties, GetCachedBreak, NoCache,
-            InternalMethods, InternalSlots, Object, OrdinaryObject, PropertyDescriptor,
-            PropertyKey, SetCachedResult, String, Value, function_create_backing_object,
-            function_get_cached, function_internal_define_own_property, function_internal_delete,
-            function_internal_get, function_internal_get_own_property,
-            function_internal_has_property, function_internal_own_property_keys,
-            function_internal_set, function_set_cached, function_try_get,
-            function_try_has_property, function_try_set,
+            Function, FunctionInternalProperties, GetCachedResult, InternalMethods, InternalSlots,
+            NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
+            String, Value, function_create_backing_object, function_get_cached,
+            function_internal_define_own_property, function_internal_delete, function_internal_get,
+            function_internal_get_own_property, function_internal_has_property,
+            function_internal_own_property_keys, function_internal_set, function_set_cached,
+            function_try_get, function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -246,7 +245,7 @@ impl<'a> InternalMethods<'a> for BuiltinPromiseResolvingFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 
@@ -258,7 +257,7 @@ impl<'a> InternalMethods<'a> for BuiltinPromiseResolvingFunction<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         function_set_cached(self, agent, p, value, receiver, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
@@ -7,17 +7,18 @@ use core::ops::{Index, IndexMut};
 use crate::{
     ecmascript::{
         builtins::{
-            ArgumentsList,
+            ArgumentsList, ordinary::caches::PropertyLookupCache,
             promise_objects::promise_abstract_operations::promise_capability_records::PromiseCapability,
         },
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            Function, FunctionInternalProperties, InternalMethods, InternalSlots, Object,
-            OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
-            function_create_backing_object, function_internal_define_own_property,
-            function_internal_delete, function_internal_get, function_internal_get_own_property,
-            function_internal_has_property, function_internal_own_property_keys,
-            function_internal_set, function_try_get, function_try_has_property, function_try_set,
+            CachedLookupResult, Function, FunctionInternalProperties, InternalMethods,
+            InternalSlots, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
+            function_cached_lookup, function_create_backing_object,
+            function_internal_define_own_property, function_internal_delete, function_internal_get,
+            function_internal_get_own_property, function_internal_has_property,
+            function_internal_own_property_keys, function_internal_set, function_try_get,
+            function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -123,6 +124,16 @@ impl<'a> InternalSlots<'a> for BuiltinPromiseResolvingFunction<'a> {
 
     fn create_backing_object(self, agent: &mut Agent) -> OrdinaryObject<'static> {
         function_create_backing_object(self, agent)
+    }
+
+    fn cached_lookup<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> CachedLookupResult<'gc> {
+        function_cached_lookup(self, agent, p, cache, gc)
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            Function, FunctionInternalProperties, GetCachedBreak, GetCachedNoCache,
+            Function, FunctionInternalProperties, GetCachedBreak, NoCache,
             InternalMethods, InternalSlots, Object, OrdinaryObject, PropertyDescriptor,
             PropertyKey, SetCachedResult, String, Value, function_create_backing_object,
             function_get_cached, function_internal_define_own_property, function_internal_delete,
@@ -246,7 +246,7 @@ impl<'a> InternalMethods<'a> for BuiltinPromiseResolvingFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use core::ops::{Index, IndexMut};
+use std::ops::ControlFlow;
 
 use crate::{
     ecmascript::{
@@ -12,13 +13,14 @@ use crate::{
         },
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            Function, FunctionInternalProperties, GetCachedError, InternalMethods, InternalSlots,
-            Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String,
-            Value, function_create_backing_object, function_get_cached,
-            function_internal_define_own_property, function_internal_delete, function_internal_get,
-            function_internal_get_own_property, function_internal_has_property,
-            function_internal_own_property_keys, function_internal_set, function_set_cached,
-            function_try_get, function_try_has_property, function_try_set,
+            Function, FunctionInternalProperties, GetCachedBreak, GetCachedNoCache,
+            InternalMethods, InternalSlots, Object, OrdinaryObject, PropertyDescriptor,
+            PropertyKey, SetCachedResult, String, Value, function_create_backing_object,
+            function_get_cached, function_internal_define_own_property, function_internal_delete,
+            function_internal_get, function_internal_get_own_property,
+            function_internal_has_property, function_internal_own_property_keys,
+            function_internal_set, function_set_cached, function_try_get,
+            function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -244,7 +246,7 @@ impl<'a> InternalMethods<'a> for BuiltinPromiseResolvingFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -30,13 +30,14 @@ use crate::{
             evaluate_generator_body,
         },
         types::{
-            BUILTIN_STRING_MEMORY, ECMAScriptFunctionHeapData, Function,
+            BUILTIN_STRING_MEMORY, CachedLookupResult, ECMAScriptFunctionHeapData, Function,
             FunctionInternalProperties, InternalMethods, InternalSlots, IntoFunction, IntoObject,
             IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
-            function_create_backing_object, function_internal_define_own_property,
-            function_internal_delete, function_internal_get, function_internal_get_own_property,
-            function_internal_has_property, function_internal_own_property_keys,
-            function_internal_set, function_try_get, function_try_has_property, function_try_set,
+            function_cached_lookup, function_create_backing_object,
+            function_internal_define_own_property, function_internal_delete, function_internal_get,
+            function_internal_get_own_property, function_internal_has_property,
+            function_internal_own_property_keys, function_internal_set, function_try_get,
+            function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -52,7 +53,10 @@ use crate::{
 
 use super::{
     ArgumentsList,
-    ordinary::{ordinary_create_from_constructor, ordinary_object_create_with_intrinsics},
+    ordinary::{
+        caches::PropertyLookupCache, ordinary_create_from_constructor,
+        ordinary_object_create_with_intrinsics,
+    },
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -339,6 +343,16 @@ impl<'a> InternalSlots<'a> for ECMAScriptFunction<'a> {
             };
             Some(proto)
         }
+    }
+
+    fn cached_lookup<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> CachedLookupResult<'gc> {
+        function_cached_lookup(self, agent, p, cache, gc)
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -31,7 +31,7 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, ECMAScriptFunctionHeapData, Function,
-            FunctionInternalProperties, GetCachedResult, InternalMethods, InternalSlots,
+            FunctionInternalProperties, GetCachedError, InternalMethods, InternalSlots,
             IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor,
             PropertyKey, SetCachedResult, String, Value, function_create_backing_object,
             function_get_cached, function_internal_define_own_property, function_internal_delete,
@@ -474,7 +474,7 @@ impl<'a> InternalMethods<'a> for ECMAScriptFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -6,6 +6,7 @@ use core::{
     ops::{Index, IndexMut},
     ptr::NonNull,
 };
+use std::ops::ControlFlow;
 
 use oxc_ast::ast::{FormalParameters, FunctionBody};
 use oxc_ecmascript::IsSimpleParameterList;
@@ -31,14 +32,14 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, ECMAScriptFunctionHeapData, Function,
-            FunctionInternalProperties, GetCachedError, InternalMethods, InternalSlots,
-            IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor,
-            PropertyKey, SetCachedResult, String, Value, function_create_backing_object,
-            function_get_cached, function_internal_define_own_property, function_internal_delete,
-            function_internal_get, function_internal_get_own_property,
-            function_internal_has_property, function_internal_own_property_keys,
-            function_internal_set, function_set_cached, function_try_get,
-            function_try_has_property, function_try_set,
+            FunctionInternalProperties, GetCachedBreak, GetCachedNoCache, InternalMethods,
+            InternalSlots, IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject,
+            PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
+            function_create_backing_object, function_get_cached,
+            function_internal_define_own_property, function_internal_delete, function_internal_get,
+            function_internal_get_own_property, function_internal_has_property,
+            function_internal_own_property_keys, function_internal_set, function_set_cached,
+            function_try_get, function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -474,7 +475,7 @@ impl<'a> InternalMethods<'a> for ECMAScriptFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -32,7 +32,7 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, ECMAScriptFunctionHeapData, Function,
-            FunctionInternalProperties, GetCachedBreak, GetCachedNoCache, InternalMethods,
+            FunctionInternalProperties, GetCachedBreak, NoCache, InternalMethods,
             InternalSlots, IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject,
             PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
             function_create_backing_object, function_get_cached,
@@ -475,7 +475,7 @@ impl<'a> InternalMethods<'a> for ECMAScriptFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -483,10 +483,11 @@ impl<'a> InternalMethods<'a> for ECMAScriptFunction<'a> {
         agent: &mut Agent,
         p: PropertyKey,
         value: Value,
+        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
-        function_set_cached(self, agent, p, value, cache, gc)
+        function_set_cached(self, agent, p, value, receiver, cache, gc)
     }
 
     /// ### [10.2.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-call)

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -30,13 +30,14 @@ use crate::{
             evaluate_generator_body,
         },
         types::{
-            BUILTIN_STRING_MEMORY, CachedLookupResult, ECMAScriptFunctionHeapData, Function,
-            FunctionInternalProperties, InternalMethods, InternalSlots, IntoFunction, IntoObject,
-            IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
-            function_cached_lookup, function_create_backing_object,
-            function_internal_define_own_property, function_internal_delete, function_internal_get,
-            function_internal_get_own_property, function_internal_has_property,
-            function_internal_own_property_keys, function_internal_set, function_try_get,
+            BUILTIN_STRING_MEMORY, ECMAScriptFunctionHeapData, Function,
+            FunctionInternalProperties, GetCachedResult, InternalMethods, InternalSlots,
+            IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor,
+            PropertyKey, SetCachedResult, String, Value, function_create_backing_object,
+            function_get_cached, function_internal_define_own_property, function_internal_delete,
+            function_internal_get, function_internal_get_own_property,
+            function_internal_has_property, function_internal_own_property_keys,
+            function_internal_set, function_set_cached, function_try_get,
             function_try_has_property, function_try_set,
         },
     },
@@ -344,16 +345,6 @@ impl<'a> InternalSlots<'a> for ECMAScriptFunction<'a> {
             Some(proto)
         }
     }
-
-    fn cached_lookup<'gc>(
-        self,
-        agent: &mut Agent,
-        p: PropertyKey,
-        cache: PropertyLookupCache,
-        gc: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
-        function_cached_lookup(self, agent, p, cache, gc)
-    }
 }
 
 impl<'a> FunctionInternalProperties<'a> for ECMAScriptFunction<'a> {
@@ -475,6 +466,27 @@ impl<'a> InternalMethods<'a> for ECMAScriptFunction<'a> {
         gc: NoGcScope<'gc, '_>,
     ) -> TryResult<Vec<PropertyKey<'gc>>> {
         TryResult::Continue(function_internal_own_property_keys(self, agent, gc))
+    }
+
+    fn get_cached<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> GetCachedResult<'gc> {
+        function_get_cached(self, agent, p, cache, gc)
+    }
+
+    fn set_cached<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        value: Value,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> SetCachedResult<'gc> {
+        function_set_cached(self, agent, p, value, cache, gc)
     }
 
     /// ### [10.2.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-call)

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -32,8 +32,8 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, ECMAScriptFunctionHeapData, Function,
-            FunctionInternalProperties, GetCachedBreak, NoCache, InternalMethods,
-            InternalSlots, IntoFunction, IntoObject, IntoValue, Object, OrdinaryObject,
+            FunctionInternalProperties, GetCachedResult, InternalMethods, InternalSlots,
+            IntoFunction, IntoObject, IntoValue, NoCache, Object, OrdinaryObject,
             PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
             function_create_backing_object, function_get_cached,
             function_internal_define_own_property, function_internal_delete, function_internal_get,
@@ -475,7 +475,7 @@ impl<'a> InternalMethods<'a> for ECMAScriptFunction<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         function_get_cached(self, agent, p, cache, gc)
     }
 
@@ -487,7 +487,7 @@ impl<'a> InternalMethods<'a> for ECMAScriptFunction<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         function_set_cached(self, agent, p, value, receiver, cache, gc)
     }
 

--- a/nova_vm/src/ecmascript/builtins/error.rs
+++ b/nova_vm/src/ecmascript/builtins/error.rs
@@ -13,7 +13,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, JsResult, ProtoIntrinsics, agent::ExceptionType},
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedBreak, GetCachedNoCache, InternalMethods,
+            BUILTIN_STRING_MEMORY, GetCachedBreak, NoCache, InternalMethods,
             InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor,
             PropertyKey, SetCachedResult, String, Value,
         },
@@ -464,7 +464,7 @@ impl<'a> InternalMethods<'a> for Error<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         let bo = self.get_backing_object(agent);
         if bo.is_none()
             && p == PropertyKey::from(BUILTIN_STRING_MEMORY.message)

--- a/nova_vm/src/ecmascript/builtins/error.rs
+++ b/nova_vm/src/ecmascript/builtins/error.rs
@@ -13,9 +13,9 @@ use crate::{
     ecmascript::{
         execution::{Agent, JsResult, ProtoIntrinsics, agent::ExceptionType},
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedBreak, NoCache, InternalMethods,
-            InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor,
-            PropertyKey, SetCachedResult, String, Value,
+            BUILTIN_STRING_MEMORY, GetCachedResult, InternalMethods, InternalSlots, IntoObject,
+            IntoValue, NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
+            SetCachedResult, String, Value,
         },
     },
     engine::{
@@ -464,7 +464,7 @@ impl<'a> InternalMethods<'a> for Error<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         let bo = self.get_backing_object(agent);
         if bo.is_none()
             && p == PropertyKey::from(BUILTIN_STRING_MEMORY.message)
@@ -494,7 +494,7 @@ impl<'a> InternalMethods<'a> for Error<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         if let Some(bo) = self.get_backing_object(agent) {
             bo.set_cached(agent, p, value, receiver, cache, gc)
         } else {
@@ -502,12 +502,12 @@ impl<'a> InternalMethods<'a> for Error<'a> {
                 && let Ok(value) = String::try_from(value)
             {
                 agent[self].message = Some(value.unbind());
-                SetCachedResult::Done
+                SetCachedResult::Done.into()
             } else if p == PropertyKey::from(BUILTIN_STRING_MEMORY.cause) {
                 agent[self].cause = Some(value.unbind());
-                SetCachedResult::Done
+                SetCachedResult::Done.into()
             } else {
-                SetCachedResult::NoCache
+                NoCache.into()
             }
         }
     }

--- a/nova_vm/src/ecmascript/builtins/error.rs
+++ b/nova_vm/src/ecmascript/builtins/error.rs
@@ -12,7 +12,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, JsResult, ProtoIntrinsics, agent::ExceptionType},
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedResult, InternalMethods, InternalSlots, IntoObject,
+            BUILTIN_STRING_MEMORY, GetCachedError, InternalMethods, InternalSlots, IntoObject,
             IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
             String, Value,
         },
@@ -463,18 +463,18 @@ impl<'a> InternalMethods<'a> for Error<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         let bo = self.get_backing_object(agent);
         if bo.is_none()
             && p == PropertyKey::from(BUILTIN_STRING_MEMORY.message)
             && let Some(message) = agent[self].message
         {
-            GetCachedResult::Value(message.into_value().bind(gc))
+            Ok(message.into_value().bind(gc))
         } else if bo.is_none()
             && p == PropertyKey::from(BUILTIN_STRING_MEMORY.cause)
             && let Some(message) = agent[self].cause
         {
-            GetCachedResult::Value(message.into_value().bind(gc))
+            Ok(message.into_value().bind(gc))
         } else {
             let shape = if let Some(bo) = bo {
                 bo.object_shape(agent)

--- a/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/native_error_constructors.rs
+++ b/nova_vm/src/ecmascript/builtins/fundamental_objects/error_objects/native_error_constructors.rs
@@ -118,7 +118,7 @@ impl NativeErrorConstructors {
             ExceptionType::ReferenceError => ProtoIntrinsics::ReferenceError,
             ExceptionType::SyntaxError => ProtoIntrinsics::SyntaxError,
             ExceptionType::TypeError => ProtoIntrinsics::TypeError,
-            ExceptionType::UriError => ProtoIntrinsics::UriError,
+            ExceptionType::UriError => ProtoIntrinsics::URIError,
         };
 
         let new_target = new_target.unwrap_or_else(|| {

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -16,7 +16,7 @@ use crate::{
             get_module_namespace,
         },
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedBreak, InternalMethods, InternalSlots, IntoValue,
+            BUILTIN_STRING_MEMORY, GetCachedResult, InternalMethods, InternalSlots, IntoValue,
             NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
             String, Value,
         },
@@ -763,7 +763,7 @@ impl<'a> InternalMethods<'a> for Module<'a> {
         _: PropertyKey,
         _: PropertyLookupCache,
         _: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         ControlFlow::Continue(NoCache)
     }
 
@@ -776,8 +776,8 @@ impl<'a> InternalMethods<'a> for Module<'a> {
         _: Value,
         _: PropertyLookupCache,
         _: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
-        SetCachedResult::Unwritable
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
+        SetCachedResult::Unwritable.into()
     }
 
     #[inline(always)]
@@ -786,7 +786,7 @@ impl<'a> InternalMethods<'a> for Module<'a> {
         _: &Agent,
         _: PropertyOffset,
         _: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         unreachable!()
     }
 }

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -16,8 +16,8 @@ use crate::{
             get_module_namespace,
         },
         types::{
-            BUILTIN_STRING_MEMORY, InternalMethods, InternalSlots, IntoValue, Object,
-            OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
+            BUILTIN_STRING_MEMORY, CachedLookupResult, InternalMethods, InternalSlots, IntoValue,
+            Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
         },
     },
     engine::{
@@ -33,6 +33,11 @@ use crate::{
 };
 
 use self::data::ModuleHeapData;
+
+use super::ordinary::{
+    caches::{PropertyLookupCache, PropertyOffset},
+    shape::ObjectShape,
+};
 
 pub mod data;
 
@@ -163,6 +168,33 @@ impl<'a> InternalSlots<'a> for Module<'a> {
 
     #[inline(always)]
     fn internal_set_prototype(self, _agent: &mut Agent, _prototype: Option<Object>) {
+        unreachable!()
+    }
+
+    #[inline(always)]
+    fn object_shape(self, _: &mut Agent) -> ObjectShape<'static> {
+        unreachable!()
+    }
+
+    #[inline(always)]
+    fn cached_lookup<'gc>(
+        self,
+        _: &mut Agent,
+        _: PropertyKey,
+        _: PropertyLookupCache,
+        _: NoGcScope<'gc, '_>,
+    ) -> CachedLookupResult<'gc> {
+        CachedLookupResult::NoCache
+    }
+
+    #[inline(always)]
+    fn get_property_by_offset<'gc>(
+        self,
+        _: &Agent,
+        _: PropertyLookupCache,
+        _: PropertyOffset,
+        _: NoGcScope<'gc, '_>,
+    ) -> CachedLookupResult<'gc> {
         unreachable!()
     }
 }

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -16,8 +16,9 @@ use crate::{
             get_module_namespace,
         },
         types::{
-            BUILTIN_STRING_MEMORY, CachedLookupResult, InternalMethods, InternalSlots, IntoValue,
-            Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
+            BUILTIN_STRING_MEMORY, GetCachedResult, InternalMethods, InternalSlots, IntoValue,
+            Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String,
+            Value,
         },
     },
     engine::{
@@ -173,28 +174,6 @@ impl<'a> InternalSlots<'a> for Module<'a> {
 
     #[inline(always)]
     fn object_shape(self, _: &mut Agent) -> ObjectShape<'static> {
-        unreachable!()
-    }
-
-    #[inline(always)]
-    fn cached_lookup<'gc>(
-        self,
-        _: &mut Agent,
-        _: PropertyKey,
-        _: PropertyLookupCache,
-        _: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
-        CachedLookupResult::NoCache
-    }
-
-    #[inline(always)]
-    fn get_property_by_offset<'gc>(
-        self,
-        _: &Agent,
-        _: PropertyLookupCache,
-        _: PropertyOffset,
-        _: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
         unreachable!()
     }
 }
@@ -775,6 +754,39 @@ impl<'a> InternalMethods<'a> for Module<'a> {
         exports.for_each(|export_key| own_property_keys.push(export_key));
         own_property_keys.push(WellKnownSymbolIndexes::ToStringTag.into());
         TryResult::Continue(own_property_keys)
+    }
+
+    #[inline(always)]
+    fn get_cached<'gc>(
+        self,
+        _: &mut Agent,
+        _: PropertyKey,
+        _: PropertyLookupCache,
+        _: NoGcScope<'gc, '_>,
+    ) -> GetCachedResult<'gc> {
+        GetCachedResult::NoCache
+    }
+
+    #[inline(always)]
+    fn set_cached<'gc>(
+        self,
+        _: &mut Agent,
+        _: PropertyKey,
+        _: Value,
+        _: PropertyLookupCache,
+        _: NoGcScope<'gc, '_>,
+    ) -> SetCachedResult<'gc> {
+        SetCachedResult::Unwritable
+    }
+
+    #[inline(always)]
+    fn get_own_property_at_offset<'gc>(
+        self,
+        _: &Agent,
+        _: PropertyOffset,
+        _: NoGcScope<'gc, '_>,
+    ) -> GetCachedResult<'gc> {
+        unreachable!()
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -16,9 +16,9 @@ use crate::{
             get_module_namespace,
         },
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedBreak, GetCachedNoCache, InternalMethods,
-            InternalSlots, IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
-            SetCachedResult, String, Value,
+            BUILTIN_STRING_MEMORY, GetCachedBreak, InternalMethods, InternalSlots, IntoValue,
+            NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
+            String, Value,
         },
     },
     engine::{
@@ -763,8 +763,8 @@ impl<'a> InternalMethods<'a> for Module<'a> {
         _: PropertyKey,
         _: PropertyLookupCache,
         _: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
-        ControlFlow::Continue(GetCachedNoCache)
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+        ControlFlow::Continue(NoCache)
     }
 
     #[inline(always)]
@@ -786,7 +786,7 @@ impl<'a> InternalMethods<'a> for Module<'a> {
         _: &Agent,
         _: PropertyOffset,
         _: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         unreachable!()
     }
 }

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use core::ops::{Index, IndexMut};
-use std::marker::PhantomData;
+use std::{marker::PhantomData, ops::ControlFlow};
 
 use crate::{
     ecmascript::{
@@ -16,9 +16,9 @@ use crate::{
             get_module_namespace,
         },
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedError, InternalMethods, InternalSlots, IntoValue,
-            Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String,
-            Value,
+            BUILTIN_STRING_MEMORY, GetCachedBreak, GetCachedNoCache, InternalMethods,
+            InternalSlots, IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
+            SetCachedResult, String, Value,
         },
     },
     engine::{
@@ -763,8 +763,8 @@ impl<'a> InternalMethods<'a> for Module<'a> {
         _: PropertyKey,
         _: PropertyLookupCache,
         _: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
-        Err(GetCachedError::NoCache)
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+        ControlFlow::Continue(GetCachedNoCache)
     }
 
     #[inline(always)]
@@ -786,7 +786,7 @@ impl<'a> InternalMethods<'a> for Module<'a> {
         _: &Agent,
         _: PropertyOffset,
         _: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         unreachable!()
     }
 }

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -16,7 +16,7 @@ use crate::{
             get_module_namespace,
         },
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedResult, InternalMethods, InternalSlots, IntoValue,
+            BUILTIN_STRING_MEMORY, GetCachedError, InternalMethods, InternalSlots, IntoValue,
             Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String,
             Value,
         },
@@ -763,8 +763,8 @@ impl<'a> InternalMethods<'a> for Module<'a> {
         _: PropertyKey,
         _: PropertyLookupCache,
         _: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
-        GetCachedResult::NoCache
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+        Err(GetCachedError::NoCache)
     }
 
     #[inline(always)]
@@ -786,7 +786,7 @@ impl<'a> InternalMethods<'a> for Module<'a> {
         _: &Agent,
         _: PropertyOffset,
         _: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         unreachable!()
     }
 }

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -773,6 +773,7 @@ impl<'a> InternalMethods<'a> for Module<'a> {
         _: &mut Agent,
         _: PropertyKey,
         _: Value,
+        _: Value,
         _: PropertyLookupCache,
         _: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {

--- a/nova_vm/src/ecmascript/builtins/ordinary.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary.rs
@@ -1219,13 +1219,15 @@ pub(crate) fn ordinary_set_at_offset<'a>(
     let receiver = receiver.bind(gc);
 
     if offset.is_unset() {
-        return SetCachedResult::NoCache;
         // 1.c.i. Set ownDesc to PropertyDescriptor {
         //   [[Value]]: undefined,
         //   [[Writable]]: true,
         //   [[Enumerable]]: true,
         //   [[Configurable]]: true
         // }.
+        if !ordinary_is_extensible(agent, bo) {
+            return SetCachedResult::Unwritable;
+        }
         if o.into_value() == receiver {
             // ## 2.e.
             // Fast path for growing an object when we know property does not

--- a/nova_vm/src/ecmascript/builtins/ordinary.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary.rs
@@ -19,7 +19,7 @@ use crate::{
         abstract_operations::operations_on_objects::{
             try_create_data_property, try_get, try_get_function_realm,
         },
-        types::{GetCachedBreak, GetCachedNoCache, IntoValue, SetCachedResult},
+        types::{GetCachedBreak, IntoValue, NoCache, SetCachedResult},
     },
     engine::{
         Scoped, TryResult,
@@ -121,7 +121,7 @@ impl<'a> InternalMethods<'a> for OrdinaryObject<'a> {
         agent: &Agent,
         offset: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         let offset = offset.get_property_offset();
         let obj = self.bind(gc);
         let data = obj.get_elements_storage(agent);

--- a/nova_vm/src/ecmascript/builtins/ordinary/caches.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary/caches.rs
@@ -756,7 +756,7 @@ impl PropertyOffset {
     const OFFSET_BIT_MASK: u16 = 0x1FFF;
     /// Property lookup index indicating that the property was not set in the
     /// Object Shape or in its prototype chain.
-    const UNSET: Self = Self(0xFFFF);
+    const UNSET: Self = Self(Self::UNSET_BIT_MASK);
 
     /// Create a new property lookup offset.
     ///

--- a/nova_vm/src/ecmascript/builtins/ordinary/shape.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary/shape.rs
@@ -11,9 +11,9 @@ use crate::{
     ecmascript::{
         execution::{Agent, PrivateField, Realm},
         types::{
-            BigInt, GetCachedBreak, GetCachedNoCache, InternalMethods, InternalSlots, IntoObject,
-            Number, Numeric, Object, OrdinaryObject, Primitive, PropertyKey, SetCachedResult,
-            String, Symbol, Value,
+            BigInt, GetCachedBreak, InternalMethods, InternalSlots, IntoObject, NoCache, Number,
+            Numeric, Object, OrdinaryObject, Primitive, PropertyKey, SetCachedResult, String,
+            Symbol, Value,
         },
     },
     engine::context::{Bindable, GcToken, NoGcScope},
@@ -179,7 +179,7 @@ impl<'a> ObjectShape<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         let shape = self;
         if let Some((offset, prototype)) = cache.find(agent, shape) {
             // A cached lookup result was found.
@@ -196,7 +196,7 @@ impl<'a> ObjectShape<'a> {
                 .heap
                 .caches
                 .set_current_cache(receiver, cache, p, shape);
-            ControlFlow::Continue(GetCachedNoCache)
+            ControlFlow::Continue(NoCache)
         }
     }
 

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -584,7 +584,7 @@ impl<'a> InternalMethods<'a> for PrimitiveObject<'a> {
             SetCachedResult::Unwritable.into()
         } else {
             let shape = self.object_shape(agent);
-            shape.set_cached(agent, p, value, receiver, cache, gc)
+            shape.set_cached(agent, self.into_object(), p, value, receiver, cache, gc)
         }
     }
 }

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -15,9 +15,9 @@ use crate::{
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
             BIGINT_DISCRIMINANT, BOOLEAN_DISCRIMINANT, BUILTIN_STRING_MEMORY, BigInt,
-            FLOAT_DISCRIMINANT, GetCachedBreak, NoCache, HeapNumber, HeapString,
-            INTEGER_DISCRIMINANT, InternalMethods, InternalSlots, IntoObject, IntoPrimitive,
-            IntoValue, NUMBER_DISCRIMINANT, Number, Object, OrdinaryObject, Primitive,
+            FLOAT_DISCRIMINANT, GetCachedResult, HeapNumber, HeapString, INTEGER_DISCRIMINANT,
+            InternalMethods, InternalSlots, IntoObject, IntoPrimitive, IntoValue,
+            NUMBER_DISCRIMINANT, NoCache, Number, Object, OrdinaryObject, Primitive,
             PropertyDescriptor, PropertyKey, SMALL_BIGINT_DISCRIMINANT, SMALL_STRING_DISCRIMINANT,
             STRING_DISCRIMINANT, SYMBOL_DISCRIMINANT, SetCachedResult, String, Symbol, Value,
             bigint::HeapBigInt,
@@ -558,7 +558,7 @@ impl<'a> InternalMethods<'a> for PrimitiveObject<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         if let Ok(string) = String::try_from(agent[self].data)
             && let Some(value) = string.get_property_value(agent, p)
         {
@@ -577,11 +577,11 @@ impl<'a> InternalMethods<'a> for PrimitiveObject<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         if String::try_from(agent[self].data)
             .is_ok_and(|s| s.get_property_value(agent, p).is_some())
         {
-            SetCachedResult::Unwritable
+            SetCachedResult::Unwritable.into()
         } else {
             let shape = self.object_shape(agent);
             shape.set_cached(agent, p, value, receiver, cache, gc)

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -15,7 +15,7 @@ use crate::{
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
             BIGINT_DISCRIMINANT, BOOLEAN_DISCRIMINANT, BUILTIN_STRING_MEMORY, BigInt,
-            FLOAT_DISCRIMINANT, GetCachedBreak, GetCachedNoCache, HeapNumber, HeapString,
+            FLOAT_DISCRIMINANT, GetCachedBreak, NoCache, HeapNumber, HeapString,
             INTEGER_DISCRIMINANT, InternalMethods, InternalSlots, IntoObject, IntoPrimitive,
             IntoValue, NUMBER_DISCRIMINANT, Number, Object, OrdinaryObject, Primitive,
             PropertyDescriptor, PropertyKey, SMALL_BIGINT_DISCRIMINANT, SMALL_STRING_DISCRIMINANT,
@@ -558,7 +558,7 @@ impl<'a> InternalMethods<'a> for PrimitiveObject<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         if let Ok(string) = String::try_from(agent[self].data)
             && let Some(value) = string.get_property_value(agent, p)
         {

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -14,7 +14,7 @@ use crate::{
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
             BIGINT_DISCRIMINANT, BOOLEAN_DISCRIMINANT, BUILTIN_STRING_MEMORY, BigInt,
-            FLOAT_DISCRIMINANT, GetCachedResult, HeapNumber, HeapString, INTEGER_DISCRIMINANT,
+            FLOAT_DISCRIMINANT, GetCachedError, HeapNumber, HeapString, INTEGER_DISCRIMINANT,
             InternalMethods, InternalSlots, IntoObject, IntoPrimitive, IntoValue,
             NUMBER_DISCRIMINANT, Number, Object, OrdinaryObject, Primitive, PropertyDescriptor,
             PropertyKey, SMALL_BIGINT_DISCRIMINANT, SMALL_STRING_DISCRIMINANT, STRING_DISCRIMINANT,
@@ -556,11 +556,11 @@ impl<'a> InternalMethods<'a> for PrimitiveObject<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         if let Ok(string) = String::try_from(agent[self].data)
             && let Some(value) = string.get_property_value(agent, p)
         {
-            GetCachedResult::Value(value.bind(gc))
+            Ok(value.bind(gc))
         } else {
             let shape = self.object_shape(agent);
             shape.get_cached(agent, p, self.into_value(), cache, gc)

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -563,13 +563,7 @@ impl<'a> InternalMethods<'a> for PrimitiveObject<'a> {
             GetCachedResult::Value(value.bind(gc))
         } else {
             let shape = self.object_shape(agent);
-            shape.get_cached(
-                agent,
-                p.bind(gc),
-                cache.bind(gc),
-                self.into_value().bind(gc),
-                gc,
-            )
+            shape.get_cached(agent, p, self.into_value(), cache, gc)
         }
     }
 
@@ -578,6 +572,7 @@ impl<'a> InternalMethods<'a> for PrimitiveObject<'a> {
         agent: &mut Agent,
         p: PropertyKey,
         value: Value,
+        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
@@ -587,14 +582,7 @@ impl<'a> InternalMethods<'a> for PrimitiveObject<'a> {
             SetCachedResult::Unwritable
         } else {
             let shape = self.object_shape(agent);
-            shape.set_cached(
-                agent,
-                p.bind(gc),
-                cache.bind(gc),
-                value,
-                self.into_value().bind(gc),
-                gc,
-            )
+            shape.set_cached(agent, p, value, receiver, cache, gc)
         }
     }
 }

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use core::ops::{Index, IndexMut};
+use std::ops::ControlFlow;
 
 use crate::{
     SmallInteger,
@@ -14,11 +15,12 @@ use crate::{
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
             BIGINT_DISCRIMINANT, BOOLEAN_DISCRIMINANT, BUILTIN_STRING_MEMORY, BigInt,
-            FLOAT_DISCRIMINANT, GetCachedError, HeapNumber, HeapString, INTEGER_DISCRIMINANT,
-            InternalMethods, InternalSlots, IntoObject, IntoPrimitive, IntoValue,
-            NUMBER_DISCRIMINANT, Number, Object, OrdinaryObject, Primitive, PropertyDescriptor,
-            PropertyKey, SMALL_BIGINT_DISCRIMINANT, SMALL_STRING_DISCRIMINANT, STRING_DISCRIMINANT,
-            SYMBOL_DISCRIMINANT, SetCachedResult, String, Symbol, Value, bigint::HeapBigInt,
+            FLOAT_DISCRIMINANT, GetCachedBreak, GetCachedNoCache, HeapNumber, HeapString,
+            INTEGER_DISCRIMINANT, InternalMethods, InternalSlots, IntoObject, IntoPrimitive,
+            IntoValue, NUMBER_DISCRIMINANT, Number, Object, OrdinaryObject, Primitive,
+            PropertyDescriptor, PropertyKey, SMALL_BIGINT_DISCRIMINANT, SMALL_STRING_DISCRIMINANT,
+            STRING_DISCRIMINANT, SYMBOL_DISCRIMINANT, SetCachedResult, String, Symbol, Value,
+            bigint::HeapBigInt,
         },
     },
     engine::{
@@ -556,11 +558,11 @@ impl<'a> InternalMethods<'a> for PrimitiveObject<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         if let Ok(string) = String::try_from(agent[self].data)
             && let Some(value) = string.get_property_value(agent, p)
         {
-            Ok(value.bind(gc))
+            value.into()
         } else {
             let shape = self.object_shape(agent);
             shape.get_cached(agent, p, self.into_value(), cache, gc)

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -22,8 +22,9 @@ use crate::{
         builtins::ArgumentsList,
         execution::{Agent, JsResult, agent::ExceptionType},
         types::{
-            BUILTIN_STRING_MEMORY, CachedLookupResult, Function, InternalMethods, InternalSlots,
-            IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, String, Value,
+            BUILTIN_STRING_MEMORY, Function, GetCachedResult, InternalMethods, InternalSlots,
+            IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
+            String, Value,
         },
     },
     engine::{
@@ -142,28 +143,6 @@ impl<'a> InternalSlots<'a> for Proxy<'a> {
 
     #[inline(always)]
     fn object_shape(self, _: &mut Agent) -> ObjectShape<'static> {
-        unreachable!()
-    }
-
-    #[inline(always)]
-    fn cached_lookup<'gc>(
-        self,
-        _: &mut Agent,
-        _: PropertyKey,
-        _: PropertyLookupCache,
-        gc: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
-        CachedLookupResult::FoundProxy(self.bind(gc))
-    }
-
-    #[inline(always)]
-    fn get_property_by_offset<'gc>(
-        self,
-        _: &Agent,
-        _: PropertyLookupCache,
-        _: PropertyOffset,
-        _: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
         unreachable!()
     }
 }
@@ -1643,6 +1622,58 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         }
         // 23. Return trapResult.
         Ok(trap_result)
+    }
+
+    #[inline(always)]
+    fn get_cached<'gc>(
+        self,
+        _: &mut Agent,
+        _: PropertyKey,
+        _: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> GetCachedResult<'gc> {
+        // TODO: Check if self is non-revoked, try to go through the Proxy
+        // without trigger the trap.
+        GetCachedResult::Proxy(self.bind(gc))
+    }
+
+    fn set_cached<'gc>(
+        self,
+        _: &mut Agent,
+        _: PropertyKey,
+        _: Value,
+        _: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> SetCachedResult<'gc> {
+        // TODO: Check if self is non-revoked, try to go through the Proxy
+        // without trigger the trap.
+        SetCachedResult::Proxy(self.bind(gc))
+    }
+
+    #[inline(always)]
+    fn get_own_property_at_offset<'gc>(
+        self,
+        _: &Agent,
+        _: PropertyOffset,
+        gc: NoGcScope<'gc, '_>,
+    ) -> GetCachedResult<'gc> {
+        // TODO: Check if self is non-revoked, try to go through the Proxy
+        // without trigger the trap.
+        GetCachedResult::Proxy(self.bind(gc))
+    }
+
+    #[inline(always)]
+    fn define_own_property_at_offset<'gc>(
+        self,
+        _: &mut Agent,
+        _: PropertyOffset,
+        _: Value,
+        _: Value,
+        gc: NoGcScope<'gc, '_>,
+    ) -> SetCachedResult<'gc> {
+        // TODO: Check if self is non-revoked, try to go through the Proxy
+        // without trigger the trap.
+        SetCachedResult::Proxy(self.bind(gc))
     }
 
     /// ### [10.5.12 [[Call]] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist)

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -1642,6 +1642,7 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         _: &mut Agent,
         _: PropertyKey,
         _: Value,
+        _: Value,
         _: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
@@ -1663,9 +1664,10 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
     }
 
     #[inline(always)]
-    fn define_own_property_at_offset<'gc>(
+    fn set_at_offset<'gc>(
         self,
         _: &mut Agent,
+        _: PropertyKey,
         _: PropertyOffset,
         _: Value,
         _: Value,

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -22,8 +22,8 @@ use crate::{
         builtins::ArgumentsList,
         execution::{Agent, JsResult, agent::ExceptionType},
         types::{
-            BUILTIN_STRING_MEMORY, Function, GetCachedBreak, NoCache, InternalMethods,
-            InternalSlots, IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
+            BUILTIN_STRING_MEMORY, Function, GetCachedResult, InternalMethods, InternalSlots,
+            IntoValue, NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
             SetCachedResult, String, Value,
         },
     },
@@ -1631,10 +1631,10 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         _: PropertyKey,
         _: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         // TODO: Check if self is non-revoked, try to go through the Proxy
         // without trigger the trap.
-        GetCachedBreak::Proxy(self.bind(gc)).into()
+        GetCachedResult::Proxy(self.bind(gc)).into()
     }
 
     fn set_cached<'gc>(
@@ -1645,10 +1645,10 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         _: Value,
         _: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         // TODO: Check if self is non-revoked, try to go through the Proxy
         // without trigger the trap.
-        SetCachedResult::Proxy(self.bind(gc))
+        SetCachedResult::Proxy(self.bind(gc)).into()
     }
 
     #[inline(always)]
@@ -1657,10 +1657,10 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         _: &Agent,
         _: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         // TODO: Check if self is non-revoked, try to go through the Proxy
         // without trigger the trap.
-        GetCachedBreak::Proxy(self.bind(gc)).into()
+        GetCachedResult::Proxy(self.bind(gc)).into()
     }
 
     #[inline(always)]
@@ -1672,10 +1672,10 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         _: Value,
         _: Value,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         // TODO: Check if self is non-revoked, try to go through the Proxy
         // without trigger the trap.
-        SetCachedResult::Proxy(self.bind(gc))
+        SetCachedResult::Proxy(self.bind(gc)).into()
     }
 
     /// ### [10.5.12 [[Call]] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist)

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -22,7 +22,7 @@ use crate::{
         builtins::ArgumentsList,
         execution::{Agent, JsResult, agent::ExceptionType},
         types::{
-            BUILTIN_STRING_MEMORY, Function, GetCachedBreak, GetCachedNoCache, InternalMethods,
+            BUILTIN_STRING_MEMORY, Function, GetCachedBreak, NoCache, InternalMethods,
             InternalSlots, IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
             SetCachedResult, String, Value,
         },
@@ -1631,7 +1631,7 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         _: PropertyKey,
         _: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         // TODO: Check if self is non-revoked, try to go through the Proxy
         // without trigger the trap.
         GetCachedBreak::Proxy(self.bind(gc)).into()
@@ -1657,7 +1657,7 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         _: &Agent,
         _: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         // TODO: Check if self is non-revoked, try to go through the Proxy
         // without trigger the trap.
         GetCachedBreak::Proxy(self.bind(gc)).into()

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -22,7 +22,7 @@ use crate::{
         builtins::ArgumentsList,
         execution::{Agent, JsResult, agent::ExceptionType},
         types::{
-            BUILTIN_STRING_MEMORY, Function, GetCachedResult, InternalMethods, InternalSlots,
+            BUILTIN_STRING_MEMORY, Function, GetCachedError, InternalMethods, InternalSlots,
             IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
             String, Value,
         },
@@ -1631,10 +1631,10 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         _: PropertyKey,
         _: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         // TODO: Check if self is non-revoked, try to go through the Proxy
         // without trigger the trap.
-        GetCachedResult::Proxy(self.bind(gc))
+        Err(GetCachedError::Proxy(self.bind(gc)))
     }
 
     fn set_cached<'gc>(
@@ -1657,10 +1657,10 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         _: &Agent,
         _: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         // TODO: Check if self is non-revoked, try to go through the Proxy
         // without trigger the trap.
-        GetCachedResult::Proxy(self.bind(gc))
+        Err(GetCachedError::Proxy(self.bind(gc)))
     }
 
     #[inline(always)]

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use core::ops::{Index, IndexMut};
-use std::collections::VecDeque;
+use std::{collections::VecDeque, ops::ControlFlow};
 
 use abstract_operations::{NonRevokedProxy, validate_non_revoked_proxy};
 use ahash::AHashSet;
@@ -22,9 +22,9 @@ use crate::{
         builtins::ArgumentsList,
         execution::{Agent, JsResult, agent::ExceptionType},
         types::{
-            BUILTIN_STRING_MEMORY, Function, GetCachedError, InternalMethods, InternalSlots,
-            IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
-            String, Value,
+            BUILTIN_STRING_MEMORY, Function, GetCachedBreak, GetCachedNoCache, InternalMethods,
+            InternalSlots, IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
+            SetCachedResult, String, Value,
         },
     },
     engine::{
@@ -1631,10 +1631,10 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         _: PropertyKey,
         _: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         // TODO: Check if self is non-revoked, try to go through the Proxy
         // without trigger the trap.
-        Err(GetCachedError::Proxy(self.bind(gc)))
+        GetCachedBreak::Proxy(self.bind(gc)).into()
     }
 
     fn set_cached<'gc>(
@@ -1657,10 +1657,10 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
         _: &Agent,
         _: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         // TODO: Check if self is non-revoked, try to go through the Proxy
         // without trigger the trap.
-        Err(GetCachedError::Proxy(self.bind(gc)))
+        GetCachedBreak::Proxy(self.bind(gc)).into()
     }
 
     #[inline(always)]

--- a/nova_vm/src/ecmascript/builtins/regexp.rs
+++ b/nova_vm/src/ecmascript/builtins/regexp.rs
@@ -430,8 +430,8 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
             shape.get_cached(
                 agent,
                 p.bind(gc),
-                cache.bind(gc),
                 self.into_value().bind(gc),
+                cache.bind(gc),
                 gc,
             )
         }
@@ -442,6 +442,7 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
         agent: &mut Agent,
         p: PropertyKey,
         value: Value,
+        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
@@ -489,14 +490,7 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
             }
         } else {
             let shape = self.object_shape(agent);
-            shape.set_cached(
-                agent,
-                p.bind(gc),
-                cache.bind(gc),
-                value,
-                self.into_value().bind(gc),
-                gc,
-            )
+            shape.set_cached(agent, p.bind(gc), value, receiver, cache.bind(gc), gc)
         }
     }
 }

--- a/nova_vm/src/ecmascript/builtins/regexp.rs
+++ b/nova_vm/src/ecmascript/builtins/regexp.rs
@@ -491,7 +491,15 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
             }
         } else {
             let shape = self.object_shape(agent);
-            shape.set_cached(agent, p.bind(gc), value, receiver, cache.bind(gc), gc)
+            shape.set_cached(
+                agent,
+                self.into_object(),
+                p.bind(gc),
+                value,
+                receiver,
+                cache.bind(gc),
+                gc,
+            )
         }
     }
 }

--- a/nova_vm/src/ecmascript/builtins/regexp.rs
+++ b/nova_vm/src/ecmascript/builtins/regexp.rs
@@ -12,9 +12,9 @@ use crate::{
     ecmascript::{
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedBreak, NoCache, InternalMethods,
-            InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor,
-            PropertyKey, SetCachedResult, String, Value,
+            BUILTIN_STRING_MEMORY, GetCachedResult, InternalMethods, InternalSlots, IntoObject,
+            IntoValue, NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
+            SetCachedResult, String, Value,
         },
     },
     engine::{
@@ -419,7 +419,7 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         // Regardless of the backing object, we might have a valid value
         // for lastIndex.
         if p == BUILTIN_STRING_MEMORY.lastIndex.into()
@@ -446,7 +446,7 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         if p == BUILTIN_STRING_MEMORY.lastIndex.into() {
             // If we're setting the last index and we have a backing object,
             // then we set the value there first and observe the result.
@@ -467,9 +467,9 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
                     // We successfully set the value, so set it in our direct
                     // data as well.
                     agent[self].last_index = new_last_index;
-                    SetCachedResult::Done
+                    SetCachedResult::Done.into()
                 } else {
-                    SetCachedResult::Unwritable
+                    SetCachedResult::Unwritable.into()
                 }
             } else {
                 // Note: lastIndex property is writable, so setting its value
@@ -487,7 +487,7 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
                         gc,
                     ));
                 }
-                SetCachedResult::Done
+                SetCachedResult::Done.into()
             }
         } else {
             let shape = self.object_shape(agent);

--- a/nova_vm/src/ecmascript/builtins/regexp.rs
+++ b/nova_vm/src/ecmascript/builtins/regexp.rs
@@ -11,7 +11,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedResult, InternalMethods, InternalSlots, IntoObject,
+            BUILTIN_STRING_MEMORY, GetCachedError, InternalMethods, InternalSlots, IntoObject,
             IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
             String, Value,
         },
@@ -418,13 +418,13 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         // Regardless of the backing object, we might have a valid value
         // for lastIndex.
         if p == BUILTIN_STRING_MEMORY.lastIndex.into()
             && let Some(last_index) = agent[self].last_index.get_value()
         {
-            GetCachedResult::Value(last_index.into())
+            Ok(last_index.into())
         } else {
             let shape = self.object_shape(agent);
             shape.get_cached(

--- a/nova_vm/src/ecmascript/builtins/regexp.rs
+++ b/nova_vm/src/ecmascript/builtins/regexp.rs
@@ -12,7 +12,7 @@ use crate::{
     ecmascript::{
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedBreak, GetCachedNoCache, InternalMethods,
+            BUILTIN_STRING_MEMORY, GetCachedBreak, NoCache, InternalMethods,
             InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor,
             PropertyKey, SetCachedResult, String, Value,
         },
@@ -419,7 +419,7 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         // Regardless of the backing object, we might have a valid value
         // for lastIndex.
         if p == BUILTIN_STRING_MEMORY.lastIndex.into()

--- a/nova_vm/src/ecmascript/builtins/regexp.rs
+++ b/nova_vm/src/ecmascript/builtins/regexp.rs
@@ -6,14 +6,15 @@ pub(crate) mod abstract_operations;
 pub(crate) mod data;
 
 use core::ops::{Index, IndexMut};
+use std::ops::ControlFlow;
 
 use crate::{
     ecmascript::{
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedError, InternalMethods, InternalSlots, IntoObject,
-            IntoValue, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
-            String, Value,
+            BUILTIN_STRING_MEMORY, GetCachedBreak, GetCachedNoCache, InternalMethods,
+            InternalSlots, IntoObject, IntoValue, Object, OrdinaryObject, PropertyDescriptor,
+            PropertyKey, SetCachedResult, String, Value,
         },
     },
     engine::{
@@ -418,13 +419,13 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         // Regardless of the backing object, we might have a valid value
         // for lastIndex.
         if p == BUILTIN_STRING_MEMORY.lastIndex.into()
             && let Some(last_index) = agent[self].last_index.get_value()
         {
-            Ok(last_index.into())
+            last_index.into_value().into()
         } else {
             let shape = self.object_shape(agent);
             shape.get_cached(

--- a/nova_vm/src/ecmascript/builtins/typed_array.rs
+++ b/nova_vm/src/ecmascript/builtins/typed_array.rs
@@ -13,11 +13,11 @@ use crate::{
         execution::{Agent, JsResult, agent::ExceptionType},
         types::{
             BIGINT_64_ARRAY_DISCRIMINANT, BIGUINT_64_ARRAY_DISCRIMINANT,
-            FLOAT_32_ARRAY_DISCRIMINANT, FLOAT_64_ARRAY_DISCRIMINANT, GetCachedBreak,
-            NoCache, INT_8_ARRAY_DISCRIMINANT, INT_16_ARRAY_DISCRIMINANT,
-            INT_32_ARRAY_DISCRIMINANT, InternalMethods, InternalSlots, IntoObject, IntoValue,
-            Number, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
-            String, UINT_8_ARRAY_DISCRIMINANT, UINT_8_CLAMPED_ARRAY_DISCRIMINANT,
+            FLOAT_32_ARRAY_DISCRIMINANT, FLOAT_64_ARRAY_DISCRIMINANT, GetCachedResult,
+            INT_8_ARRAY_DISCRIMINANT, INT_16_ARRAY_DISCRIMINANT, INT_32_ARRAY_DISCRIMINANT,
+            InternalMethods, InternalSlots, IntoObject, IntoValue, NoCache, Number, Object,
+            OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String,
+            UINT_8_ARRAY_DISCRIMINANT, UINT_8_CLAMPED_ARRAY_DISCRIMINANT,
             UINT_16_ARRAY_DISCRIMINANT, UINT_32_ARRAY_DISCRIMINANT, Value,
         },
     },
@@ -894,7 +894,7 @@ impl<'a> InternalMethods<'a> for TypedArray<'a> {
         mut p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         // Note: we mutate P but only if it turns into a valid integer, in
         // which case we never enter the get_cached path anyway.
         ta_canonical_numeric_index_string(agent, &mut p, gc);
@@ -917,7 +917,7 @@ impl<'a> InternalMethods<'a> for TypedArray<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         // Note: we mutate P but only if it turns into a valid integer, in
         // which case we never enter the get_cached path anyway.
         ta_canonical_numeric_index_string(agent, &mut p, gc);
@@ -926,8 +926,8 @@ impl<'a> InternalMethods<'a> for TypedArray<'a> {
             let numeric_index = numeric_index.into_i64();
             // 1. Perform ? TypedArraySetElement(O, numericIndex, V).
             match try_typed_array_set_element_generic(agent, self, numeric_index, value, gc) {
-                TryResult::Continue(_) => SetCachedResult::Done,
-                TryResult::Break(_) => SetCachedResult::NoCache,
+                TryResult::Continue(_) => SetCachedResult::Done.into(),
+                TryResult::Break(_) => NoCache.into(),
             }
         } else {
             let shape = self.object_shape(agent);

--- a/nova_vm/src/ecmascript/builtins/typed_array.rs
+++ b/nova_vm/src/ecmascript/builtins/typed_array.rs
@@ -931,7 +931,7 @@ impl<'a> InternalMethods<'a> for TypedArray<'a> {
             }
         } else {
             let shape = self.object_shape(agent);
-            shape.set_cached(agent, p, value, receiver, cache, gc)
+            shape.set_cached(agent, self.into_object(), p, value, receiver, cache, gc)
         }
     }
 }

--- a/nova_vm/src/ecmascript/builtins/typed_array.rs
+++ b/nova_vm/src/ecmascript/builtins/typed_array.rs
@@ -904,13 +904,7 @@ impl<'a> InternalMethods<'a> for TypedArray<'a> {
             GetCachedResult::Value(result.map_or(Value::Undefined, |r| r.into_value()))
         } else {
             let shape = self.object_shape(agent);
-            shape.get_cached(
-                agent,
-                p.bind(gc),
-                cache.bind(gc),
-                self.into_value().bind(gc),
-                gc,
-            )
+            shape.get_cached(agent, p, self.into_value(), cache, gc)
         }
     }
 
@@ -919,6 +913,7 @@ impl<'a> InternalMethods<'a> for TypedArray<'a> {
         agent: &mut Agent,
         mut p: PropertyKey,
         value: Value,
+        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
@@ -935,14 +930,7 @@ impl<'a> InternalMethods<'a> for TypedArray<'a> {
             }
         } else {
             let shape = self.object_shape(agent);
-            shape.set_cached(
-                agent,
-                p.bind(gc),
-                cache.bind(gc),
-                value,
-                self.into_value().bind(gc),
-                gc,
-            )
+            shape.set_cached(agent, p, value, receiver, cache, gc)
         }
     }
 }

--- a/nova_vm/src/ecmascript/builtins/typed_array.rs
+++ b/nova_vm/src/ecmascript/builtins/typed_array.rs
@@ -12,7 +12,7 @@ use crate::{
         execution::{Agent, JsResult, agent::ExceptionType},
         types::{
             BIGINT_64_ARRAY_DISCRIMINANT, BIGUINT_64_ARRAY_DISCRIMINANT,
-            FLOAT_32_ARRAY_DISCRIMINANT, FLOAT_64_ARRAY_DISCRIMINANT, GetCachedResult,
+            FLOAT_32_ARRAY_DISCRIMINANT, FLOAT_64_ARRAY_DISCRIMINANT, GetCachedError,
             INT_8_ARRAY_DISCRIMINANT, INT_16_ARRAY_DISCRIMINANT, INT_32_ARRAY_DISCRIMINANT,
             InternalMethods, InternalSlots, IntoObject, IntoValue, Number, Object, OrdinaryObject,
             PropertyDescriptor, PropertyKey, SetCachedResult, String, UINT_8_ARRAY_DISCRIMINANT,
@@ -893,7 +893,7 @@ impl<'a> InternalMethods<'a> for TypedArray<'a> {
         mut p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         // Note: we mutate P but only if it turns into a valid integer, in
         // which case we never enter the get_cached path anyway.
         ta_canonical_numeric_index_string(agent, &mut p, gc);
@@ -901,7 +901,7 @@ impl<'a> InternalMethods<'a> for TypedArray<'a> {
             // i. Return TypedArrayGetElement(O, numericIndex).
             let numeric_index = numeric_index.into_i64();
             let result = typed_array_get_element_generic(agent, self, numeric_index, gc);
-            GetCachedResult::Value(result.map_or(Value::Undefined, |r| r.into_value()))
+            Ok(result.map_or(Value::Undefined, |r| r.into_value()))
         } else {
             let shape = self.object_shape(agent);
             shape.get_cached(agent, p, self.into_value(), cache, gc)

--- a/nova_vm/src/ecmascript/builtins/typed_array.rs
+++ b/nova_vm/src/ecmascript/builtins/typed_array.rs
@@ -14,7 +14,7 @@ use crate::{
         types::{
             BIGINT_64_ARRAY_DISCRIMINANT, BIGUINT_64_ARRAY_DISCRIMINANT,
             FLOAT_32_ARRAY_DISCRIMINANT, FLOAT_64_ARRAY_DISCRIMINANT, GetCachedBreak,
-            GetCachedNoCache, INT_8_ARRAY_DISCRIMINANT, INT_16_ARRAY_DISCRIMINANT,
+            NoCache, INT_8_ARRAY_DISCRIMINANT, INT_16_ARRAY_DISCRIMINANT,
             INT_32_ARRAY_DISCRIMINANT, InternalMethods, InternalSlots, IntoObject, IntoValue,
             Number, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
             String, UINT_8_ARRAY_DISCRIMINANT, UINT_8_CLAMPED_ARRAY_DISCRIMINANT,
@@ -894,7 +894,7 @@ impl<'a> InternalMethods<'a> for TypedArray<'a> {
         mut p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         // Note: we mutate P but only if it turns into a valid integer, in
         // which case we never enter the get_cached path anyway.
         ta_canonical_numeric_index_string(agent, &mut p, gc);

--- a/nova_vm/src/ecmascript/execution/realm.rs
+++ b/nova_vm/src/ecmascript/execution/realm.rs
@@ -845,7 +845,11 @@ mod test {
     fn test_default_realm_sanity() {
         use super::initialize_default_realm;
         use crate::{
-            ecmascript::execution::{Agent, DefaultHostHooks, agent::Options},
+            ecmascript::{
+                builtins::BuiltinFunction,
+                execution::{Agent, DefaultHostHooks, agent::Options},
+                types::OrdinaryObject,
+            },
             heap::indexes::{BuiltinFunctionIndex, ObjectIndex},
         };
 
@@ -854,15 +858,12 @@ mod test {
         let gc = GcScope::new(&mut gc, &mut scope);
         initialize_default_realm(&mut agent, gc);
         assert_eq!(
-            agent.current_realm_record().intrinsics().object_index_base,
-            ObjectIndex::from_index(0)
+            agent.current_realm_record().intrinsics().object_prototype(),
+            OrdinaryObject::new(ObjectIndex::from_index(0))
         );
         assert_eq!(
-            agent
-                .current_realm_record()
-                .intrinsics()
-                .builtin_function_index_base,
-            BuiltinFunctionIndex::from_index(0)
+            agent.current_realm_record().intrinsics().object(),
+            BuiltinFunction(BuiltinFunctionIndex::from_index(0))
         );
         #[cfg(feature = "array-buffer")]
         assert!(agent.heap.array_buffers.is_empty());

--- a/nova_vm/src/ecmascript/types.rs
+++ b/nova_vm/src/ecmascript/types.rs
@@ -7,9 +7,10 @@ mod spec;
 
 pub(crate) use language::*;
 pub use language::{
-    BigInt, Function, GetCachedError, HeapNumber, HeapString, InternalMethods, InternalSlots,
-    IntoFunction, IntoNumeric, IntoObject, IntoPrimitive, IntoValue, Number, Numeric, Object,
-    OrdinaryObject, Primitive, PropertyKey, PropertyKeySet, String, Symbol, Value, bigint,
+    BigInt, Function, GetCachedBreak, GetCachedNoCache, HeapNumber, HeapString, InternalMethods,
+    InternalSlots, IntoFunction, IntoNumeric, IntoObject, IntoPrimitive, IntoValue, Number,
+    Numeric, Object, OrdinaryObject, Primitive, PropertyKey, PropertyKeySet, String, Symbol, Value,
+    bigint,
 };
 pub use spec::PrivateName;
 pub use spec::PropertyDescriptor;

--- a/nova_vm/src/ecmascript/types.rs
+++ b/nova_vm/src/ecmascript/types.rs
@@ -7,7 +7,7 @@ mod spec;
 
 pub(crate) use language::*;
 pub use language::{
-    BigInt, Function, GetCachedResult, HeapNumber, HeapString, InternalMethods, InternalSlots,
+    BigInt, Function, GetCachedError, HeapNumber, HeapString, InternalMethods, InternalSlots,
     IntoFunction, IntoNumeric, IntoObject, IntoPrimitive, IntoValue, Number, Numeric, Object,
     OrdinaryObject, Primitive, PropertyKey, PropertyKeySet, String, Symbol, Value, bigint,
 };

--- a/nova_vm/src/ecmascript/types.rs
+++ b/nova_vm/src/ecmascript/types.rs
@@ -7,10 +7,9 @@ mod spec;
 
 pub(crate) use language::*;
 pub use language::{
-    BigInt, Function, GetCachedBreak, NoCache, HeapNumber, HeapString, InternalMethods,
-    InternalSlots, IntoFunction, IntoNumeric, IntoObject, IntoPrimitive, IntoValue, Number,
-    Numeric, Object, OrdinaryObject, Primitive, PropertyKey, PropertyKeySet, String, Symbol, Value,
-    bigint,
+    BigInt, Function, GetCachedResult, HeapNumber, HeapString, InternalMethods, InternalSlots,
+    IntoFunction, IntoNumeric, IntoObject, IntoPrimitive, IntoValue, NoCache, Number, Numeric,
+    Object, OrdinaryObject, Primitive, PropertyKey, PropertyKeySet, String, Symbol, Value, bigint,
 };
 pub use spec::PrivateName;
 pub use spec::PropertyDescriptor;

--- a/nova_vm/src/ecmascript/types.rs
+++ b/nova_vm/src/ecmascript/types.rs
@@ -7,9 +7,9 @@ mod spec;
 
 pub(crate) use language::*;
 pub use language::{
-    BigInt, Function, HeapNumber, HeapString, InternalMethods, InternalSlots, IntoFunction,
-    IntoNumeric, IntoObject, IntoPrimitive, IntoValue, Number, Numeric, Object, OrdinaryObject,
-    Primitive, PropertyKey, PropertyKeySet, String, Symbol, Value, bigint,
+    BigInt, Function, GetCachedResult, HeapNumber, HeapString, InternalMethods, InternalSlots,
+    IntoFunction, IntoNumeric, IntoObject, IntoPrimitive, IntoValue, Number, Numeric, Object,
+    OrdinaryObject, Primitive, PropertyKey, PropertyKeySet, String, Symbol, Value, bigint,
 };
 pub use spec::PrivateName;
 pub use spec::PropertyDescriptor;

--- a/nova_vm/src/ecmascript/types.rs
+++ b/nova_vm/src/ecmascript/types.rs
@@ -7,7 +7,7 @@ mod spec;
 
 pub(crate) use language::*;
 pub use language::{
-    BigInt, Function, GetCachedBreak, GetCachedNoCache, HeapNumber, HeapString, InternalMethods,
+    BigInt, Function, GetCachedBreak, NoCache, HeapNumber, HeapString, InternalMethods,
     InternalSlots, IntoFunction, IntoNumeric, IntoObject, IntoPrimitive, IntoValue, Number,
     Numeric, Object, OrdinaryObject, Primitive, PropertyKey, PropertyKeySet, String, Symbol, Value,
     bigint,

--- a/nova_vm/src/ecmascript/types/language.rs
+++ b/nova_vm/src/ecmascript/types/language.rs
@@ -33,7 +33,7 @@ pub use number::{HeapNumber, Number, NumberHeapData};
 pub use numeric::Numeric;
 pub(crate) use object::ScopedPropertyKey;
 pub use object::{
-    GetCachedResult, InternalMethods, InternalSlots, IntoObject, Object, ObjectHeapData,
+    GetCachedError, InternalMethods, InternalSlots, IntoObject, Object, ObjectHeapData,
     OrdinaryObject, PropertyKey, PropertyKeySet, SetCachedResult,
 };
 pub(crate) use primitive::HeapPrimitive;

--- a/nova_vm/src/ecmascript/types/language.rs
+++ b/nova_vm/src/ecmascript/types/language.rs
@@ -33,8 +33,8 @@ pub use number::{HeapNumber, Number, NumberHeapData};
 pub use numeric::Numeric;
 pub(crate) use object::ScopedPropertyKey;
 pub use object::{
-    GetCachedError, InternalMethods, InternalSlots, IntoObject, Object, ObjectHeapData,
-    OrdinaryObject, PropertyKey, PropertyKeySet, SetCachedResult,
+    GetCachedBreak, GetCachedNoCache, InternalMethods, InternalSlots, IntoObject, Object,
+    ObjectHeapData, OrdinaryObject, PropertyKey, PropertyKeySet, SetCachedResult,
 };
 pub(crate) use primitive::HeapPrimitive;
 pub use primitive::Primitive;

--- a/nova_vm/src/ecmascript/types/language.rs
+++ b/nova_vm/src/ecmascript/types/language.rs
@@ -19,11 +19,11 @@ mod value_vec;
 pub use bigint::{BigInt, BigIntHeapData};
 pub(crate) use function::{
     BoundFunctionHeapData, BuiltinConstructorHeapData, BuiltinFunctionHeapData,
-    ECMAScriptFunctionHeapData, FunctionInternalProperties, function_create_backing_object,
-    function_internal_define_own_property, function_internal_delete, function_internal_get,
-    function_internal_get_own_property, function_internal_has_property,
-    function_internal_own_property_keys, function_internal_set, function_try_get,
-    function_try_has_property, function_try_set,
+    ECMAScriptFunctionHeapData, FunctionInternalProperties, function_cached_lookup,
+    function_create_backing_object, function_internal_define_own_property,
+    function_internal_delete, function_internal_get, function_internal_get_own_property,
+    function_internal_has_property, function_internal_own_property_keys, function_internal_set,
+    function_try_get, function_try_has_property, function_try_set,
 };
 pub use function::{Function, IntoFunction};
 pub use into_numeric::IntoNumeric;
@@ -40,6 +40,7 @@ pub(crate) use primitive::HeapPrimitive;
 pub use primitive::Primitive;
 pub use string::{BUILTIN_STRING_MEMORY, BUILTIN_STRINGS_LIST, HeapString, String, StringHeapData};
 pub use symbol::{Symbol, SymbolHeapData};
+pub(crate) use value::CachedLookupResult;
 #[cfg(feature = "date")]
 pub(crate) use value::DATE_DISCRIMINANT;
 #[cfg(feature = "proposal-float16array")]

--- a/nova_vm/src/ecmascript/types/language.rs
+++ b/nova_vm/src/ecmascript/types/language.rs
@@ -33,8 +33,8 @@ pub use number::{HeapNumber, Number, NumberHeapData};
 pub use numeric::Numeric;
 pub(crate) use object::ScopedPropertyKey;
 pub use object::{
-    GetCachedBreak, NoCache, InternalMethods, InternalSlots, IntoObject, Object,
-    ObjectHeapData, OrdinaryObject, PropertyKey, PropertyKeySet, SetCachedResult,
+    GetCachedResult, InternalMethods, InternalSlots, IntoObject, NoCache, Object, ObjectHeapData,
+    OrdinaryObject, PropertyKey, PropertyKeySet, SetCachedResult,
 };
 pub(crate) use primitive::HeapPrimitive;
 pub use primitive::Primitive;

--- a/nova_vm/src/ecmascript/types/language.rs
+++ b/nova_vm/src/ecmascript/types/language.rs
@@ -33,7 +33,7 @@ pub use number::{HeapNumber, Number, NumberHeapData};
 pub use numeric::Numeric;
 pub(crate) use object::ScopedPropertyKey;
 pub use object::{
-    GetCachedBreak, GetCachedNoCache, InternalMethods, InternalSlots, IntoObject, Object,
+    GetCachedBreak, NoCache, InternalMethods, InternalSlots, IntoObject, Object,
     ObjectHeapData, OrdinaryObject, PropertyKey, PropertyKeySet, SetCachedResult,
 };
 pub(crate) use primitive::HeapPrimitive;

--- a/nova_vm/src/ecmascript/types/language.rs
+++ b/nova_vm/src/ecmascript/types/language.rs
@@ -19,10 +19,10 @@ mod value_vec;
 pub use bigint::{BigInt, BigIntHeapData};
 pub(crate) use function::{
     BoundFunctionHeapData, BuiltinConstructorHeapData, BuiltinFunctionHeapData,
-    ECMAScriptFunctionHeapData, FunctionInternalProperties, function_cached_lookup,
-    function_create_backing_object, function_internal_define_own_property,
-    function_internal_delete, function_internal_get, function_internal_get_own_property,
-    function_internal_has_property, function_internal_own_property_keys, function_internal_set,
+    ECMAScriptFunctionHeapData, FunctionInternalProperties, function_create_backing_object,
+    function_get_cached, function_internal_define_own_property, function_internal_delete,
+    function_internal_get, function_internal_get_own_property, function_internal_has_property,
+    function_internal_own_property_keys, function_internal_set, function_set_cached,
     function_try_get, function_try_has_property, function_try_set,
 };
 pub use function::{Function, IntoFunction};
@@ -33,14 +33,13 @@ pub use number::{HeapNumber, Number, NumberHeapData};
 pub use numeric::Numeric;
 pub(crate) use object::ScopedPropertyKey;
 pub use object::{
-    InternalMethods, InternalSlots, IntoObject, Object, ObjectHeapData, OrdinaryObject,
-    PropertyKey, PropertyKeySet,
+    GetCachedResult, InternalMethods, InternalSlots, IntoObject, Object, ObjectHeapData,
+    OrdinaryObject, PropertyKey, PropertyKeySet, SetCachedResult,
 };
 pub(crate) use primitive::HeapPrimitive;
 pub use primitive::Primitive;
 pub use string::{BUILTIN_STRING_MEMORY, BUILTIN_STRINGS_LIST, HeapString, String, StringHeapData};
 pub use symbol::{Symbol, SymbolHeapData};
-pub(crate) use value::CachedLookupResult;
 #[cfg(feature = "date")]
 pub(crate) use value::DATE_DISCRIMINANT;
 #[cfg(feature = "proposal-float16array")]

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -574,17 +574,20 @@ impl<'a> InternalMethods<'a> for Function<'a> {
         agent: &mut Agent,
         p: PropertyKey,
         value: Value,
+        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
         match self {
-            Function::BoundFunction(f) => f.set_cached(agent, p, value, cache, gc),
-            Function::BuiltinFunction(f) => f.set_cached(agent, p, value, cache, gc),
-            Function::ECMAScriptFunction(f) => f.set_cached(agent, p, value, cache, gc),
+            Function::BoundFunction(f) => f.set_cached(agent, p, value, receiver, cache, gc),
+            Function::BuiltinFunction(f) => f.set_cached(agent, p, value, receiver, cache, gc),
+            Function::ECMAScriptFunction(f) => f.set_cached(agent, p, value, receiver, cache, gc),
             Function::BuiltinGeneratorFunction => todo!(),
-            Function::BuiltinConstructorFunction(f) => f.set_cached(agent, p, value, cache, gc),
+            Function::BuiltinConstructorFunction(f) => {
+                f.set_cached(agent, p, value, receiver, cache, gc)
+            }
             Function::BuiltinPromiseResolvingFunction(f) => {
-                f.set_cached(agent, p, value, cache, gc)
+                f.set_cached(agent, p, value, receiver, cache, gc)
             }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
@@ -613,30 +616,27 @@ impl<'a> InternalMethods<'a> for Function<'a> {
         }
     }
 
-    fn define_own_property_at_offset<'gc>(
+    fn set_at_offset<'gc>(
         self,
         agent: &mut Agent,
+        p: PropertyKey,
         offset: PropertyOffset,
         value: Value,
         receiver: Value,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
         match self {
-            Function::BoundFunction(f) => {
-                f.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
-            Function::BuiltinFunction(f) => {
-                f.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Function::BoundFunction(f) => f.set_at_offset(agent, p, offset, value, receiver, gc),
+            Function::BuiltinFunction(f) => f.set_at_offset(agent, p, offset, value, receiver, gc),
             Function::ECMAScriptFunction(f) => {
-                f.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                f.set_at_offset(agent, p, offset, value, receiver, gc)
             }
             Function::BuiltinGeneratorFunction => todo!(),
             Function::BuiltinConstructorFunction(f) => {
-                f.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                f.set_at_offset(agent, p, offset, value, receiver, gc)
             }
             Function::BuiltinPromiseResolvingFunction(f) => {
-                f.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                f.set_at_offset(agent, p, offset, value, receiver, gc)
             }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -6,7 +6,7 @@ mod data;
 pub mod into_function;
 
 use super::{
-    GetCachedResult, InternalMethods, InternalSlots, Object, OrdinaryObject, PropertyKey,
+    GetCachedError, InternalMethods, InternalSlots, Object, OrdinaryObject, PropertyKey,
     SetCachedResult, String, Value,
     value::{
         BOUND_FUNCTION_DISCRIMINANT, BUILTIN_CONSTRUCTOR_FUNCTION_DISCRIMINANT,
@@ -556,7 +556,7 @@ impl<'a> InternalMethods<'a> for Function<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         match self {
             Function::BoundFunction(f) => f.get_cached(agent, p, cache, gc),
             Function::BuiltinFunction(f) => f.get_cached(agent, p, cache, gc),
@@ -599,7 +599,7 @@ impl<'a> InternalMethods<'a> for Function<'a> {
         agent: &Agent,
         offset: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         match self {
             Function::BoundFunction(f) => f.get_own_property_at_offset(agent, offset, gc),
             Function::BuiltinFunction(f) => f.get_own_property_at_offset(agent, offset, gc),

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -5,9 +5,11 @@
 mod data;
 pub mod into_function;
 
+use std::ops::ControlFlow;
+
 use super::{
-    GetCachedError, InternalMethods, InternalSlots, Object, OrdinaryObject, PropertyKey,
-    SetCachedResult, String, Value,
+    GetCachedBreak, GetCachedNoCache, InternalMethods, InternalSlots, Object, OrdinaryObject,
+    PropertyKey, SetCachedResult, String, Value,
     value::{
         BOUND_FUNCTION_DISCRIMINANT, BUILTIN_CONSTRUCTOR_FUNCTION_DISCRIMINANT,
         BUILTIN_FUNCTION_DISCRIMINANT, BUILTIN_GENERATOR_FUNCTION_DISCRIMINANT,
@@ -556,7 +558,7 @@ impl<'a> InternalMethods<'a> for Function<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         match self {
             Function::BoundFunction(f) => f.get_cached(agent, p, cache, gc),
             Function::BuiltinFunction(f) => f.get_cached(agent, p, cache, gc),
@@ -599,7 +601,7 @@ impl<'a> InternalMethods<'a> for Function<'a> {
         agent: &Agent,
         offset: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         match self {
             Function::BoundFunction(f) => f.get_own_property_at_offset(agent, offset, gc),
             Function::BuiltinFunction(f) => f.get_own_property_at_offset(agent, offset, gc),

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -8,7 +8,7 @@ pub mod into_function;
 use std::ops::ControlFlow;
 
 use super::{
-    GetCachedBreak, GetCachedNoCache, InternalMethods, InternalSlots, Object, OrdinaryObject,
+    GetCachedBreak, NoCache, InternalMethods, InternalSlots, Object, OrdinaryObject,
     PropertyKey, SetCachedResult, String, Value,
     value::{
         BOUND_FUNCTION_DISCRIMINANT, BUILTIN_CONSTRUCTOR_FUNCTION_DISCRIMINANT,
@@ -558,7 +558,7 @@ impl<'a> InternalMethods<'a> for Function<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         match self {
             Function::BoundFunction(f) => f.get_cached(agent, p, cache, gc),
             Function::BuiltinFunction(f) => f.get_cached(agent, p, cache, gc),
@@ -601,7 +601,7 @@ impl<'a> InternalMethods<'a> for Function<'a> {
         agent: &Agent,
         offset: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         match self {
             Function::BoundFunction(f) => f.get_own_property_at_offset(agent, offset, gc),
             Function::BuiltinFunction(f) => f.get_own_property_at_offset(agent, offset, gc),

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -8,8 +8,8 @@ pub mod into_function;
 use std::ops::ControlFlow;
 
 use super::{
-    GetCachedBreak, NoCache, InternalMethods, InternalSlots, Object, OrdinaryObject,
-    PropertyKey, SetCachedResult, String, Value,
+    GetCachedResult, InternalMethods, InternalSlots, NoCache, Object, OrdinaryObject, PropertyKey,
+    SetCachedResult, String, Value,
     value::{
         BOUND_FUNCTION_DISCRIMINANT, BUILTIN_CONSTRUCTOR_FUNCTION_DISCRIMINANT,
         BUILTIN_FUNCTION_DISCRIMINANT, BUILTIN_GENERATOR_FUNCTION_DISCRIMINANT,
@@ -558,7 +558,7 @@ impl<'a> InternalMethods<'a> for Function<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         match self {
             Function::BoundFunction(f) => f.get_cached(agent, p, cache, gc),
             Function::BuiltinFunction(f) => f.get_cached(agent, p, cache, gc),
@@ -579,7 +579,7 @@ impl<'a> InternalMethods<'a> for Function<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         match self {
             Function::BoundFunction(f) => f.set_cached(agent, p, value, receiver, cache, gc),
             Function::BuiltinFunction(f) => f.set_cached(agent, p, value, receiver, cache, gc),
@@ -601,7 +601,7 @@ impl<'a> InternalMethods<'a> for Function<'a> {
         agent: &Agent,
         offset: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         match self {
             Function::BoundFunction(f) => f.get_own_property_at_offset(agent, offset, gc),
             Function::BuiltinFunction(f) => f.get_own_property_at_offset(agent, offset, gc),
@@ -626,7 +626,7 @@ impl<'a> InternalMethods<'a> for Function<'a> {
         value: Value,
         receiver: Value,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         match self {
             Function::BoundFunction(f) => f.set_at_offset(agent, p, offset, value, receiver, gc),
             Function::BuiltinFunction(f) => f.set_at_offset(agent, p, offset, value, receiver, gc),

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -6,8 +6,8 @@ mod data;
 pub mod into_function;
 
 use super::{
-    CachedLookupResult, InternalMethods, InternalSlots, Object, OrdinaryObject, PropertyKey,
-    String, Value,
+    GetCachedResult, InternalMethods, InternalSlots, Object, OrdinaryObject, PropertyKey,
+    SetCachedResult, String, Value,
     value::{
         BOUND_FUNCTION_DISCRIMINANT, BUILTIN_CONSTRUCTOR_FUNCTION_DISCRIMINANT,
         BUILTIN_FUNCTION_DISCRIMINANT, BUILTIN_GENERATOR_FUNCTION_DISCRIMINANT,
@@ -38,11 +38,11 @@ use crate::{
 pub(crate) use data::*;
 pub use into_function::IntoFunction;
 pub(crate) use into_function::{
-    FunctionInternalProperties, function_cached_lookup, function_create_backing_object,
+    FunctionInternalProperties, function_create_backing_object, function_get_cached,
     function_internal_define_own_property, function_internal_delete, function_internal_get,
     function_internal_get_own_property, function_internal_has_property,
-    function_internal_own_property_keys, function_internal_set, function_try_get,
-    function_try_has_property, function_try_set,
+    function_internal_own_property_keys, function_internal_set, function_set_cached,
+    function_try_get, function_try_has_property, function_try_set,
 };
 
 /// https://tc39.es/ecma262/#function-object
@@ -258,48 +258,6 @@ impl<'a> InternalSlots<'a> for Function<'a> {
         {
             // Create function base object with custom prototype
             todo!()
-        }
-    }
-
-    fn cached_lookup<'gc>(
-        self,
-        agent: &mut Agent,
-        p: PropertyKey,
-        cache: PropertyLookupCache,
-        gc: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
-        match self {
-            Function::BoundFunction(f) => f.cached_lookup(agent, p, cache, gc),
-            Function::BuiltinFunction(f) => f.cached_lookup(agent, p, cache, gc),
-            Function::ECMAScriptFunction(f) => f.cached_lookup(agent, p, cache, gc),
-            Function::BuiltinGeneratorFunction => todo!(),
-            Function::BuiltinConstructorFunction(f) => f.cached_lookup(agent, p, cache, gc),
-            Function::BuiltinPromiseResolvingFunction(f) => f.cached_lookup(agent, p, cache, gc),
-            Function::BuiltinPromiseCollectorFunction => todo!(),
-            Function::BuiltinProxyRevokerFunction => todo!(),
-        }
-    }
-
-    fn get_property_by_offset<'gc>(
-        self,
-        agent: &Agent,
-        cache: PropertyLookupCache,
-        offset: PropertyOffset,
-        gc: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
-        match self {
-            Function::BoundFunction(f) => f.get_property_by_offset(agent, cache, offset, gc),
-            Function::BuiltinFunction(f) => f.get_property_by_offset(agent, cache, offset, gc),
-            Function::ECMAScriptFunction(f) => f.get_property_by_offset(agent, cache, offset, gc),
-            Function::BuiltinGeneratorFunction => todo!(),
-            Function::BuiltinConstructorFunction(f) => {
-                f.get_property_by_offset(agent, cache, offset, gc)
-            }
-            Function::BuiltinPromiseResolvingFunction(f) => {
-                f.get_property_by_offset(agent, cache, offset, gc)
-            }
-            Function::BuiltinPromiseCollectorFunction => todo!(),
-            Function::BuiltinProxyRevokerFunction => todo!(),
         }
     }
 }
@@ -587,6 +545,99 @@ impl<'a> InternalMethods<'a> for Function<'a> {
             Function::BuiltinGeneratorFunction => todo!(),
             Function::BuiltinConstructorFunction(x) => x.try_own_property_keys(agent, gc),
             Function::BuiltinPromiseResolvingFunction(x) => x.try_own_property_keys(agent, gc),
+            Function::BuiltinPromiseCollectorFunction => todo!(),
+            Function::BuiltinProxyRevokerFunction => todo!(),
+        }
+    }
+
+    fn get_cached<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> GetCachedResult<'gc> {
+        match self {
+            Function::BoundFunction(f) => f.get_cached(agent, p, cache, gc),
+            Function::BuiltinFunction(f) => f.get_cached(agent, p, cache, gc),
+            Function::ECMAScriptFunction(f) => f.get_cached(agent, p, cache, gc),
+            Function::BuiltinGeneratorFunction => todo!(),
+            Function::BuiltinConstructorFunction(f) => f.get_cached(agent, p, cache, gc),
+            Function::BuiltinPromiseResolvingFunction(f) => f.get_cached(agent, p, cache, gc),
+            Function::BuiltinPromiseCollectorFunction => todo!(),
+            Function::BuiltinProxyRevokerFunction => todo!(),
+        }
+    }
+
+    fn set_cached<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        value: Value,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> SetCachedResult<'gc> {
+        match self {
+            Function::BoundFunction(f) => f.set_cached(agent, p, value, cache, gc),
+            Function::BuiltinFunction(f) => f.set_cached(agent, p, value, cache, gc),
+            Function::ECMAScriptFunction(f) => f.set_cached(agent, p, value, cache, gc),
+            Function::BuiltinGeneratorFunction => todo!(),
+            Function::BuiltinConstructorFunction(f) => f.set_cached(agent, p, value, cache, gc),
+            Function::BuiltinPromiseResolvingFunction(f) => {
+                f.set_cached(agent, p, value, cache, gc)
+            }
+            Function::BuiltinPromiseCollectorFunction => todo!(),
+            Function::BuiltinProxyRevokerFunction => todo!(),
+        }
+    }
+
+    fn get_own_property_at_offset<'gc>(
+        self,
+        agent: &Agent,
+        offset: PropertyOffset,
+        gc: NoGcScope<'gc, '_>,
+    ) -> GetCachedResult<'gc> {
+        match self {
+            Function::BoundFunction(f) => f.get_own_property_at_offset(agent, offset, gc),
+            Function::BuiltinFunction(f) => f.get_own_property_at_offset(agent, offset, gc),
+            Function::ECMAScriptFunction(f) => f.get_own_property_at_offset(agent, offset, gc),
+            Function::BuiltinGeneratorFunction => todo!(),
+            Function::BuiltinConstructorFunction(f) => {
+                f.get_own_property_at_offset(agent, offset, gc)
+            }
+            Function::BuiltinPromiseResolvingFunction(f) => {
+                f.get_own_property_at_offset(agent, offset, gc)
+            }
+            Function::BuiltinPromiseCollectorFunction => todo!(),
+            Function::BuiltinProxyRevokerFunction => todo!(),
+        }
+    }
+
+    fn define_own_property_at_offset<'gc>(
+        self,
+        agent: &mut Agent,
+        offset: PropertyOffset,
+        value: Value,
+        receiver: Value,
+        gc: NoGcScope<'gc, '_>,
+    ) -> SetCachedResult<'gc> {
+        match self {
+            Function::BoundFunction(f) => {
+                f.define_own_property_at_offset(agent, offset, value, receiver, gc)
+            }
+            Function::BuiltinFunction(f) => {
+                f.define_own_property_at_offset(agent, offset, value, receiver, gc)
+            }
+            Function::ECMAScriptFunction(f) => {
+                f.define_own_property_at_offset(agent, offset, value, receiver, gc)
+            }
+            Function::BuiltinGeneratorFunction => todo!(),
+            Function::BuiltinConstructorFunction(f) => {
+                f.define_own_property_at_offset(agent, offset, value, receiver, gc)
+            }
+            Function::BuiltinPromiseResolvingFunction(f) => {
+                f.define_own_property_at_offset(agent, offset, value, receiver, gc)
+            }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
         }

--- a/nova_vm/src/ecmascript/types/language/function/into_function.rs
+++ b/nova_vm/src/ecmascript/types/language/function/into_function.rs
@@ -130,7 +130,7 @@ pub(crate) fn function_set_cached<'a, 'gc>(
         } else {
             func.object_shape(agent)
         };
-        shape.set_cached(agent, p, value, receiver, cache, gc)
+        shape.set_cached(agent, func.into_object(), p, value, receiver, cache, gc)
     }
 }
 

--- a/nova_vm/src/ecmascript/types/language/function/into_function.rs
+++ b/nova_vm/src/ecmascript/types/language/function/into_function.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         execution::{Agent, JsResult},
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedBreak, InternalMethods, InternalSlots, IntoValue,
+            BUILTIN_STRING_MEMORY, GetCachedResult, InternalMethods, InternalSlots, IntoValue,
             NoCache, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String,
             Value, language::IntoObject,
         },
@@ -93,7 +93,7 @@ pub(crate) fn function_get_cached<'a, 'gc>(
     p: PropertyKey,
     cache: PropertyLookupCache,
     gc: NoGcScope<'gc, '_>,
-) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
     let bo = func.get_backing_object(agent);
     if bo.is_none() && p == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
         func.get_length(agent).into_value().bind(gc).into()
@@ -117,13 +117,13 @@ pub(crate) fn function_set_cached<'a, 'gc>(
     receiver: Value,
     cache: PropertyLookupCache,
     gc: NoGcScope<'gc, '_>,
-) -> SetCachedResult<'gc> {
+) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
     let bo = func.get_backing_object(agent);
     if bo.is_none()
         && (p == PropertyKey::from(BUILTIN_STRING_MEMORY.length)
             || p == PropertyKey::from(BUILTIN_STRING_MEMORY.name))
     {
-        SetCachedResult::Unwritable
+        SetCachedResult::Unwritable.into()
     } else {
         let shape = if let Some(bo) = bo {
             bo.object_shape(agent)

--- a/nova_vm/src/ecmascript/types/language/function/into_function.rs
+++ b/nova_vm/src/ecmascript/types/language/function/into_function.rs
@@ -105,7 +105,7 @@ pub(crate) fn function_get_cached<'a, 'gc>(
         } else {
             func.object_shape(agent)
         };
-        shape.get_cached(agent, p, cache, func.into_value(), gc)
+        shape.get_cached(agent, p, func.into_value(), cache, gc)
     }
 }
 
@@ -114,6 +114,7 @@ pub(crate) fn function_set_cached<'a, 'gc>(
     agent: &mut Agent,
     p: PropertyKey,
     value: Value,
+    receiver: Value,
     cache: PropertyLookupCache,
     gc: NoGcScope<'gc, '_>,
 ) -> SetCachedResult<'gc> {
@@ -129,7 +130,7 @@ pub(crate) fn function_set_cached<'a, 'gc>(
         } else {
             func.object_shape(agent)
         };
-        shape.set_cached(agent, p, cache, value, func.into_value(), gc)
+        shape.set_cached(agent, p, value, receiver, cache, gc)
     }
 }
 

--- a/nova_vm/src/ecmascript/types/language/function/into_function.rs
+++ b/nova_vm/src/ecmascript/types/language/function/into_function.rs
@@ -14,9 +14,9 @@ use crate::{
         },
         execution::{Agent, JsResult},
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedBreak, GetCachedNoCache, InternalMethods,
-            InternalSlots, IntoValue, OrdinaryObject, PropertyDescriptor, PropertyKey,
-            SetCachedResult, String, Value, language::IntoObject,
+            BUILTIN_STRING_MEMORY, GetCachedBreak, InternalMethods, InternalSlots, IntoValue,
+            NoCache, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String,
+            Value, language::IntoObject,
         },
     },
     engine::{
@@ -93,7 +93,7 @@ pub(crate) fn function_get_cached<'a, 'gc>(
     p: PropertyKey,
     cache: PropertyLookupCache,
     gc: NoGcScope<'gc, '_>,
-) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
     let bo = func.get_backing_object(agent);
     if bo.is_none() && p == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
         func.get_length(agent).into_value().bind(gc).into()

--- a/nova_vm/src/ecmascript/types/language/function/into_function.rs
+++ b/nova_vm/src/ecmascript/types/language/function/into_function.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         execution::{Agent, JsResult},
         types::{
-            BUILTIN_STRING_MEMORY, GetCachedResult, InternalMethods, InternalSlots, IntoValue,
+            BUILTIN_STRING_MEMORY, GetCachedError, InternalMethods, InternalSlots, IntoValue,
             OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
             language::IntoObject,
         },
@@ -93,12 +93,12 @@ pub(crate) fn function_get_cached<'a, 'gc>(
     p: PropertyKey,
     cache: PropertyLookupCache,
     gc: NoGcScope<'gc, '_>,
-) -> GetCachedResult<'gc> {
+) -> Result<Value<'gc>, GetCachedError<'gc>> {
     let bo = func.get_backing_object(agent);
     if bo.is_none() && p == PropertyKey::from(BUILTIN_STRING_MEMORY.length) {
-        GetCachedResult::Value(func.get_length(agent).into())
+        Ok(func.get_length(agent).into())
     } else if bo.is_none() && p == PropertyKey::from(BUILTIN_STRING_MEMORY.name) {
-        GetCachedResult::Value(func.get_name(agent).into_value().bind(gc))
+        Ok(func.get_name(agent).into_value().bind(gc))
     } else {
         let shape = if let Some(bo) = bo {
             bo.object_shape(agent)

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -121,7 +121,7 @@ use crate::{
 
 use ahash::AHashMap;
 pub use data::ObjectHeapData;
-pub use internal_methods::{GetCachedBreak, GetCachedNoCache, InternalMethods, SetCachedResult};
+pub use internal_methods::{GetCachedBreak, InternalMethods, NoCache, SetCachedResult};
 pub use internal_slots::InternalSlots;
 pub use into_object::IntoObject;
 pub use property_key::PropertyKey;
@@ -4088,7 +4088,7 @@ impl<'a> InternalMethods<'a> for Object<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         match self {
             Object::Object(data) => data.get_cached(agent, p, cache, gc),
             Object::Array(data) => data.get_cached(agent, p, cache, gc),
@@ -4305,7 +4305,7 @@ impl<'a> InternalMethods<'a> for Object<'a> {
         agent: &Agent,
         offset: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         match self {
             Object::Object(data) => data.get_own_property_at_offset(agent, offset, gc),
             Object::Array(data) => data.get_own_property_at_offset(agent, offset, gc),

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -121,7 +121,7 @@ use crate::{
 
 use ahash::AHashMap;
 pub use data::ObjectHeapData;
-pub use internal_methods::{GetCachedError, InternalMethods, SetCachedResult};
+pub use internal_methods::{GetCachedBreak, GetCachedNoCache, InternalMethods, SetCachedResult};
 pub use internal_slots::InternalSlots;
 pub use into_object::IntoObject;
 pub use property_key::PropertyKey;
@@ -4088,7 +4088,7 @@ impl<'a> InternalMethods<'a> for Object<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         match self {
             Object::Object(data) => data.get_cached(agent, p, cache, gc),
             Object::Array(data) => data.get_cached(agent, p, cache, gc),
@@ -4305,7 +4305,7 @@ impl<'a> InternalMethods<'a> for Object<'a> {
         agent: &Agent,
         offset: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         match self {
             Object::Object(data) => data.get_own_property_at_offset(agent, offset, gc),
             Object::Array(data) => data.get_own_property_at_offset(agent, offset, gc),

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -121,7 +121,7 @@ use crate::{
 
 use ahash::AHashMap;
 pub use data::ObjectHeapData;
-pub use internal_methods::{GetCachedResult, InternalMethods, SetCachedResult};
+pub use internal_methods::{GetCachedError, InternalMethods, SetCachedResult};
 pub use internal_slots::InternalSlots;
 pub use into_object::IntoObject;
 pub use property_key::PropertyKey;
@@ -4088,7 +4088,7 @@ impl<'a> InternalMethods<'a> for Object<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         match self {
             Object::Object(data) => data.get_cached(agent, p, cache, gc),
             Object::Array(data) => data.get_cached(agent, p, cache, gc),
@@ -4305,7 +4305,7 @@ impl<'a> InternalMethods<'a> for Object<'a> {
         agent: &Agent,
         offset: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         match self {
             Object::Object(data) => data.get_own_property_at_offset(agent, offset, gc),
             Object::Array(data) => data.get_own_property_at_offset(agent, offset, gc),

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -4189,82 +4189,91 @@ impl<'a> InternalMethods<'a> for Object<'a> {
         agent: &mut Agent,
         p: PropertyKey,
         value: Value,
+        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
         match self {
-            Object::Object(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::Array(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::Object(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::Array(data) => data.set_cached(agent, p, value, receiver, cache, gc),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::ArrayBuffer(data) => data.set_cached(agent, p, value, receiver, cache, gc),
             #[cfg(feature = "date")]
-            Object::Date(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::Error(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::BoundFunction(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::BuiltinFunction(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::ECMAScriptFunction(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::Date(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::Error(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::BoundFunction(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::BuiltinFunction(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::ECMAScriptFunction(data) => {
+                data.set_cached(agent, p, value, receiver, cache, gc)
+            }
             Object::BuiltinGeneratorFunction => todo!(),
-            Object::BuiltinConstructorFunction(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::BuiltinConstructorFunction(data) => {
+                data.set_cached(agent, p, value, receiver, cache, gc)
+            }
             Object::BuiltinPromiseResolvingFunction(data) => {
-                data.set_cached(agent, p, value, cache, gc)
+                data.set_cached(agent, p, value, receiver, cache, gc)
             }
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::Arguments(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::PrimitiveObject(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::Arguments(data) => data.set_cached(agent, p, value, receiver, cache, gc),
             #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::FinalizationRegistry(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::Map(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::Promise(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::Proxy(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::DataView(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::FinalizationRegistry(data) => {
+                data.set_cached(agent, p, value, receiver, cache, gc)
+            }
+            Object::Map(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::Promise(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::Proxy(data) => data.set_cached(agent, p, value, receiver, cache, gc),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::RegExp(data) => data.set_cached(agent, p, value, receiver, cache, gc),
             #[cfg(feature = "set")]
-            Object::Set(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::Set(data) => data.set_cached(agent, p, value, receiver, cache, gc),
             #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::SharedArrayBuffer(data) => {
+                data.set_cached(agent, p, value, receiver, cache, gc)
+            }
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::WeakMap(data) => data.set_cached(agent, p, value, receiver, cache, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::WeakRef(data) => data.set_cached(agent, p, value, receiver, cache, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::WeakSet(data) => data.set_cached(agent, p, value, receiver, cache, gc),
             #[cfg(feature = "array-buffer")]
             Object::Int8Array(data) => {
-                TypedArray::Int8Array(data).set_cached(agent, p, value, cache, gc)
+                TypedArray::Int8Array(data).set_cached(agent, p, value, receiver, cache, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8Array(data) => {
-                TypedArray::Uint8Array(data).set_cached(agent, p, value, cache, gc)
+                TypedArray::Uint8Array(data).set_cached(agent, p, value, receiver, cache, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8ClampedArray(data) => {
-                TypedArray::Uint8ClampedArray(data).set_cached(agent, p, value, cache, gc)
+                TypedArray::Uint8ClampedArray(data).set_cached(agent, p, value, receiver, cache, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int16Array(data) => {
-                TypedArray::Int16Array(data).set_cached(agent, p, value, cache, gc)
+                TypedArray::Int16Array(data).set_cached(agent, p, value, receiver, cache, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).set_cached(agent, p, value, cache, gc)
+                TypedArray::Uint16Array(data).set_cached(agent, p, value, receiver, cache, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int32Array(data) => {
-                TypedArray::Int32Array(data).set_cached(agent, p, value, cache, gc)
+                TypedArray::Int32Array(data).set_cached(agent, p, value, receiver, cache, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).set_cached(agent, p, value, cache, gc)
+                TypedArray::Uint32Array(data).set_cached(agent, p, value, receiver, cache, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).set_cached(agent, p, value, cache, gc)
+                TypedArray::BigInt64Array(data).set_cached(agent, p, value, receiver, cache, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigUint64Array(data) => {
-                TypedArray::BigUint64Array(data).set_cached(agent, p, value, cache, gc)
+                TypedArray::BigUint64Array(data).set_cached(agent, p, value, receiver, cache, gc)
             }
             #[cfg(feature = "proposal-float16array")]
             Object::Float16Array(data) => {
@@ -4272,22 +4281,22 @@ impl<'a> InternalMethods<'a> for Object<'a> {
             }
             #[cfg(feature = "array-buffer")]
             Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).set_cached(agent, p, value, cache, gc)
+                TypedArray::Float32Array(data).set_cached(agent, p, value, receiver, cache, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).set_cached(agent, p, value, cache, gc)
+                TypedArray::Float64Array(data).set_cached(agent, p, value, receiver, cache, gc)
             }
             Object::AsyncFromSyncIterator => todo!(),
-            Object::AsyncGenerator(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::ArrayIterator(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::AsyncGenerator(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::ArrayIterator(data) => data.set_cached(agent, p, value, receiver, cache, gc),
             #[cfg(feature = "set")]
-            Object::SetIterator(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::MapIterator(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::StringIterator(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::Generator(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::Module(data) => data.set_cached(agent, p, value, cache, gc),
-            Object::EmbedderObject(data) => data.set_cached(agent, p, value, cache, gc),
+            Object::SetIterator(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::MapIterator(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::StringIterator(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::Generator(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::Module(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::EmbedderObject(data) => data.set_cached(agent, p, value, receiver, cache, gc),
         }
     }
 
@@ -4400,157 +4409,129 @@ impl<'a> InternalMethods<'a> for Object<'a> {
         }
     }
 
-    fn define_own_property_at_offset<'gc>(
+    fn set_at_offset<'gc>(
         self,
         agent: &mut Agent,
+        p: PropertyKey,
         offset: PropertyOffset,
         value: Value,
         receiver: Value,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
         match self {
-            Object::Object(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
-            Object::Array(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Object::Object(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::Array(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Object::ArrayBuffer(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             #[cfg(feature = "date")]
-            Object::Date(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
-            Object::Error(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Object::Date(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::Error(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             Object::BoundFunction(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                data.set_at_offset(agent, p, offset, value, receiver, gc)
             }
             Object::BuiltinFunction(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                data.set_at_offset(agent, p, offset, value, receiver, gc)
             }
             Object::ECMAScriptFunction(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                data.set_at_offset(agent, p, offset, value, receiver, gc)
             }
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                data.set_at_offset(agent, p, offset, value, receiver, gc)
             }
             Object::BuiltinPromiseResolvingFunction(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                data.set_at_offset(agent, p, offset, value, receiver, gc)
             }
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
             Object::PrimitiveObject(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                data.set_at_offset(agent, p, offset, value, receiver, gc)
             }
-            Object::Arguments(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Object::Arguments(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Object::DataView(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             Object::FinalizationRegistry(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                data.set_at_offset(agent, p, offset, value, receiver, gc)
             }
-            Object::Map(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
-            Object::Promise(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
-            Object::Proxy(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Object::Map(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::Promise(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::Proxy(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Object::RegExp(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             #[cfg(feature = "set")]
-            Object::Set(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Object::Set(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             #[cfg(feature = "shared-array-buffer")]
             Object::SharedArrayBuffer(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                data.set_at_offset(agent, p, offset, value, receiver, gc)
             }
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Object::WeakMap(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Object::WeakRef(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+            Object::WeakSet(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            #[cfg(feature = "array-buffer")]
+            Object::Int8Array(data) => {
+                TypedArray::Int8Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
             }
             #[cfg(feature = "array-buffer")]
-            Object::Int8Array(data) => TypedArray::Int8Array(data)
-                .define_own_property_at_offset(agent, offset, value, receiver, gc),
-            #[cfg(feature = "array-buffer")]
-            Object::Uint8Array(data) => TypedArray::Uint8Array(data)
-                .define_own_property_at_offset(agent, offset, value, receiver, gc),
+            Object::Uint8Array(data) => {
+                TypedArray::Uint8Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+            }
             #[cfg(feature = "array-buffer")]
             Object::Uint8ClampedArray(data) => TypedArray::Uint8ClampedArray(data)
-                .define_own_property_at_offset(agent, offset, value, receiver, gc),
+                .set_at_offset(agent, p, offset, value, receiver, gc),
             #[cfg(feature = "array-buffer")]
-            Object::Int16Array(data) => TypedArray::Int16Array(data)
-                .define_own_property_at_offset(agent, offset, value, receiver, gc),
+            Object::Int16Array(data) => {
+                TypedArray::Int16Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+            }
             #[cfg(feature = "array-buffer")]
-            Object::Uint16Array(data) => TypedArray::Uint16Array(data)
-                .define_own_property_at_offset(agent, offset, value, receiver, gc),
+            Object::Uint16Array(data) => {
+                TypedArray::Uint16Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+            }
             #[cfg(feature = "array-buffer")]
-            Object::Int32Array(data) => TypedArray::Int32Array(data)
-                .define_own_property_at_offset(agent, offset, value, receiver, gc),
+            Object::Int32Array(data) => {
+                TypedArray::Int32Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+            }
             #[cfg(feature = "array-buffer")]
-            Object::Uint32Array(data) => TypedArray::Uint32Array(data)
-                .define_own_property_at_offset(agent, offset, value, receiver, gc),
+            Object::Uint32Array(data) => {
+                TypedArray::Uint32Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+            }
             #[cfg(feature = "array-buffer")]
-            Object::BigInt64Array(data) => TypedArray::BigInt64Array(data)
-                .define_own_property_at_offset(agent, offset, value, receiver, gc),
+            Object::BigInt64Array(data) => {
+                TypedArray::BigInt64Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+            }
             #[cfg(feature = "array-buffer")]
             Object::BigUint64Array(data) => TypedArray::BigUint64Array(data)
-                .define_own_property_at_offset(agent, offset, value, receiver, gc),
+                .set_at_offset(agent, p, offset, value, receiver, gc),
             #[cfg(feature = "proposal-float16array")]
             Object::Float16Array(data) => TypedArray::Float16Array(data)
                 .define_own_property_at_offset(agent, offset, value, receiver, gc),
             #[cfg(feature = "array-buffer")]
-            Object::Float32Array(data) => TypedArray::Float32Array(data)
-                .define_own_property_at_offset(agent, offset, value, receiver, gc),
+            Object::Float32Array(data) => {
+                TypedArray::Float32Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+            }
             #[cfg(feature = "array-buffer")]
-            Object::Float64Array(data) => TypedArray::Float64Array(data)
-                .define_own_property_at_offset(agent, offset, value, receiver, gc),
+            Object::Float64Array(data) => {
+                TypedArray::Float64Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+            }
             Object::AsyncFromSyncIterator => todo!(),
             Object::AsyncGenerator(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                data.set_at_offset(agent, p, offset, value, receiver, gc)
             }
             Object::ArrayIterator(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                data.set_at_offset(agent, p, offset, value, receiver, gc)
             }
             #[cfg(feature = "set")]
-            Object::SetIterator(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
-            Object::MapIterator(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Object::SetIterator(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::MapIterator(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             Object::StringIterator(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                data.set_at_offset(agent, p, offset, value, receiver, gc)
             }
-            Object::Generator(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
-            Object::Module(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
-            }
+            Object::Generator(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::Module(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             Object::EmbedderObject(data) => {
-                data.define_own_property_at_offset(agent, offset, value, receiver, gc)
+                data.set_at_offset(agent, p, offset, value, receiver, gc)
             }
         }
     }

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -121,7 +121,7 @@ use crate::{
 
 use ahash::AHashMap;
 pub use data::ObjectHeapData;
-pub use internal_methods::{GetCachedBreak, InternalMethods, NoCache, SetCachedResult};
+pub use internal_methods::{GetCachedResult, InternalMethods, NoCache, SetCachedResult};
 pub use internal_slots::InternalSlots;
 pub use into_object::IntoObject;
 pub use property_key::PropertyKey;
@@ -4088,7 +4088,7 @@ impl<'a> InternalMethods<'a> for Object<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         match self {
             Object::Object(data) => data.get_cached(agent, p, cache, gc),
             Object::Array(data) => data.get_cached(agent, p, cache, gc),
@@ -4192,7 +4192,7 @@ impl<'a> InternalMethods<'a> for Object<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         match self {
             Object::Object(data) => data.set_cached(agent, p, value, receiver, cache, gc),
             Object::Array(data) => data.set_cached(agent, p, value, receiver, cache, gc),
@@ -4305,7 +4305,7 @@ impl<'a> InternalMethods<'a> for Object<'a> {
         agent: &Agent,
         offset: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         match self {
             Object::Object(data) => data.get_own_property_at_offset(agent, offset, gc),
             Object::Array(data) => data.get_own_property_at_offset(agent, offset, gc),
@@ -4417,7 +4417,7 @@ impl<'a> InternalMethods<'a> for Object<'a> {
         value: Value,
         receiver: Value,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         match self {
             Object::Object(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
             Object::Array(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),

--- a/nova_vm/src/ecmascript/types/language/object/internal_methods.rs
+++ b/nova_vm/src/ecmascript/types/language/object/internal_methods.rs
@@ -535,7 +535,7 @@ where
         // A cache-based lookup on an ordinary object can fully rely on the
         // Object Shape and caches.
         let shape = self.object_shape(agent);
-        shape.set_cached(agent, p, value, receiver, cache, gc)
+        shape.set_cached(agent, self.into_object(), p, value, receiver, cache, gc)
     }
 
     /// ## \[\[GetOwnProperty]] method with offset.

--- a/nova_vm/src/ecmascript/types/language/object/internal_methods.rs
+++ b/nova_vm/src/ecmascript/types/language/object/internal_methods.rs
@@ -509,7 +509,7 @@ where
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         // A cache-based lookup on an ordinary object can fully rely on the
         // Object Shape and caches.
         let shape = self.object_shape(agent);
@@ -549,7 +549,7 @@ where
         agent: &Agent,
         offset: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         if offset.is_custom_property() {
             // We don't yet cache any of these accesses.
             todo!(
@@ -652,11 +652,11 @@ impl<'a, T> From<Value<'a>> for ControlFlow<GetCachedBreak<'a>, T> {
 
 /// No property cache was found.
 ///
-/// The normal \[\[Get]] method variant should be entered.
-pub struct GetCachedNoCache;
+/// The normal \[\[Get]] or \[\[Set]] method variant should be entered.
+pub struct NoCache;
 
-impl<T> From<GetCachedNoCache> for ControlFlow<T, GetCachedNoCache> {
-    fn from(value: GetCachedNoCache) -> Self {
+impl<T> From<NoCache> for ControlFlow<T, NoCache> {
+    fn from(value: NoCache) -> Self {
         ControlFlow::Continue(value)
     }
 }

--- a/nova_vm/src/ecmascript/types/language/object/internal_methods.rs
+++ b/nova_vm/src/ecmascript/types/language/object/internal_methods.rs
@@ -507,7 +507,7 @@ where
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         // A cache-based lookup on an ordinary object can fully rely on the
         // Object Shape and caches.
         let shape = self.object_shape(agent);
@@ -547,7 +547,7 @@ where
         agent: &Agent,
         offset: PropertyOffset,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         if offset.is_custom_property() {
             // We don't yet cache any of these accesses.
             todo!(
@@ -623,10 +623,8 @@ where
 }
 
 #[derive(Debug)]
-pub enum GetCachedResult<'a> {
-    /// A data property was found.
-    Value(Value<'a>),
-    /// An accessor property with a getter was found.
+pub enum GetCachedError<'a> {
+    /// A getter call is needed.
     Get(Function<'a>),
     /// A Proxy trap call is needed.
     Proxy(Proxy<'a>),
@@ -635,8 +633,8 @@ pub enum GetCachedResult<'a> {
 }
 
 // SAFETY: Property implemented as a lifetime transmute.
-unsafe impl Bindable for GetCachedResult<'_> {
-    type Of<'a> = GetCachedResult<'a>;
+unsafe impl Bindable for GetCachedError<'_> {
+    type Of<'a> = GetCachedError<'a>;
 
     #[inline(always)]
     fn unbind(self) -> Self::Of<'static> {

--- a/nova_vm/src/ecmascript/types/language/object/internal_slots.rs
+++ b/nova_vm/src/ecmascript/types/language/object/internal_slots.rs
@@ -2,17 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::{IntoObject, Object, OrdinaryObject, PropertyKey};
-use crate::{
-    ecmascript::{
-        builtins::ordinary::{
-            caches::{PropertyLookupCache, PropertyOffset},
-            shape::ObjectShape,
-        },
-        execution::{Agent, ProtoIntrinsics},
-        types::CachedLookupResult,
-    },
-    engine::context::NoGcScope,
+use super::{IntoObject, Object, OrdinaryObject};
+use crate::ecmascript::{
+    builtins::ordinary::shape::ObjectShape,
+    execution::{Agent, ProtoIntrinsics},
 };
 
 /// ### [10.1 Ordinary Object Internal Methods and Internal Slots](https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots)
@@ -132,40 +125,5 @@ where
     fn get_or_create_backing_object(self, agent: &mut Agent) -> OrdinaryObject<'static> {
         self.get_backing_object(agent)
             .unwrap_or_else(|| self.create_backing_object(agent))
-    }
-
-    fn cached_lookup<'gc>(
-        self,
-        agent: &mut Agent,
-        p: PropertyKey,
-        cache: PropertyLookupCache,
-        gc: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
-        // A cache-based lookup on an ordinary object can fully rely on the
-        // Object Shape and caches.
-        let shape = self.object_shape(agent);
-        shape.cached_lookup(agent, p, cache, self, gc)
-    }
-
-    /// Get a property value by offset from an object.
-    fn get_property_by_offset<'gc>(
-        self,
-        agent: &Agent,
-        cache: PropertyLookupCache,
-        offset: PropertyOffset,
-        gc: NoGcScope<'gc, '_>,
-    ) -> CachedLookupResult<'gc> {
-        if offset.is_custom_property() {
-            // We don't yet cache any of these accesses.
-            todo!(
-                "{} needs to implement custom property caching manually",
-                core::any::type_name::<Self>()
-            )
-        } else {
-            // It should be impossible for us to not have a backing store.
-            self.get_backing_object(agent)
-                .unwrap()
-                .get_property_by_offset(agent, cache, offset, gc)
-        }
     }
 }

--- a/nova_vm/src/ecmascript/types/language/object/property_storage.rs
+++ b/nova_vm/src/ecmascript/types/language/object/property_storage.rs
@@ -306,7 +306,15 @@ impl<'a> PropertyStorage<'a> {
         Some((value, descriptor))
     }
 
-    pub fn get(self, agent: &Agent, key: PropertyKey) -> Option<(PropertyDescriptor<'a>, u32)> {
+    pub fn get<'b>(
+        self,
+        agent: &'b Agent,
+        key: PropertyKey,
+    ) -> Option<(
+        &'b Option<Value<'a>>,
+        Option<&'b ElementDescriptor<'a>>,
+        u32,
+    )> {
         let object = self.0;
         let PropertyStorageRef {
             keys,
@@ -319,11 +327,10 @@ impl<'a> PropertyStorage<'a> {
             .find(|(_, k)| **k == key)
             .map(|res| res.0);
         result.map(|index| {
-            let value = values[index].unbind();
+            let value = &values[index];
             let index = index as u32;
             let descriptor = descriptors.and_then(|d| d.get(&index));
-            let result = ElementDescriptor::to_property_descriptor(descriptor, value);
-            (result, index)
+            (value, descriptor, index)
         })
     }
 

--- a/nova_vm/src/ecmascript/types/language/object/property_storage.rs
+++ b/nova_vm/src/ecmascript/types/language/object/property_storage.rs
@@ -27,7 +27,7 @@ use crate::{
     },
 };
 
-use super::{IntoObject, Object, OrdinaryObject, PropertyKey};
+use super::{InternalSlots, IntoObject, Object, OrdinaryObject, PropertyKey};
 
 #[derive(Debug, Clone, Copy)]
 pub struct PropertyStorage<'a>(OrdinaryObject<'a>);
@@ -129,7 +129,7 @@ impl<'a> PropertyStorage<'a> {
         private_fields: NonNull<[PrivateField]>,
     ) -> Result<(), TryReserveError> {
         let original_len = object.len(agent);
-        let original_shape = object.get_shape(agent);
+        let original_shape = object.object_shape(agent);
         // SAFETY: User says so.
         let (new_shape, insertion_index) =
             unsafe { original_shape.add_private_fields(agent, private_fields) };
@@ -376,7 +376,7 @@ impl<'a> PropertyStorage<'a> {
             0
         };
         let new_len = cur_len.checked_add(1).unwrap();
-        let old_shape = object.get_shape(agent);
+        let old_shape = object.object_shape(agent);
         let new_shape = old_shape.get_child_shape(agent, key);
         agent.heap.alloc_counter += core::mem::size_of::<Option<Value>>()
             + if element_descriptor.is_some() {
@@ -467,7 +467,7 @@ impl<'a> PropertyStorage<'a> {
                 }
             }
         }
-        let old_shape = object.get_shape(agent);
+        let old_shape = object.object_shape(agent);
         let new_shape = old_shape.get_shape_with_removal(agent, index);
         agent[object].set_len(new_len);
         if old_shape == new_shape {

--- a/nova_vm/src/ecmascript/types/language/primitive.rs
+++ b/nova_vm/src/ecmascript/types/language/primitive.rs
@@ -182,7 +182,7 @@ impl Primitive<'_> {
             | Primitive::SmallBigInt(_) => {
                 self.object_shape(agent)
                     .unwrap()
-                    .get_cached(agent, p, cache, self.into_value(), gc)
+                    .get_cached(agent, p, self.into_value(), cache, gc)
             }
             Primitive::String(_) | Primitive::SmallString(_) => String::try_from(self)
                 .unwrap()
@@ -195,6 +195,7 @@ impl Primitive<'_> {
         agent: &mut Agent,
         p: PropertyKey,
         value: Value,
+        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
@@ -206,17 +207,13 @@ impl Primitive<'_> {
             | Primitive::Integer(_)
             | Primitive::SmallF64(_)
             | Primitive::BigInt(_)
-            | Primitive::SmallBigInt(_) => self.object_shape(agent).unwrap().set_cached(
-                agent,
-                p,
-                cache,
-                value,
-                self.into_value(),
-                gc,
-            ),
+            | Primitive::SmallBigInt(_) => self
+                .object_shape(agent)
+                .unwrap()
+                .set_cached(agent, p, value, receiver, cache, gc),
             Primitive::String(_) | Primitive::SmallString(_) => String::try_from(self)
                 .unwrap()
-                .set_cached(agent, p, cache, value, gc),
+                .set_cached(agent, p, value, receiver, cache, gc),
         }
     }
 }

--- a/nova_vm/src/ecmascript/types/language/primitive.rs
+++ b/nova_vm/src/ecmascript/types/language/primitive.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use super::{
-    GetCachedBreak, IntoValue, NoCache, PropertyKey, SetCachedResult, String, Symbol, Value,
+    GetCachedResult, IntoValue, NoCache, PropertyKey, SetCachedResult, String, Symbol, Value,
     bigint::HeapBigInt,
     number::HeapNumber,
     string::HeapString,
@@ -172,7 +172,7 @@ impl Primitive<'_> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         match self {
             Primitive::Undefined | Primitive::Null => ControlFlow::Continue(NoCache),
             Primitive::Boolean(_)
@@ -200,9 +200,9 @@ impl Primitive<'_> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         match self {
-            Primitive::Undefined | Primitive::Null => SetCachedResult::NoCache,
+            Primitive::Undefined | Primitive::Null => NoCache.into(),
             Primitive::Boolean(_)
             | Primitive::Symbol(_)
             | Primitive::Number(_)

--- a/nova_vm/src/ecmascript/types/language/primitive.rs
+++ b/nova_vm/src/ecmascript/types/language/primitive.rs
@@ -201,6 +201,7 @@ impl Primitive<'_> {
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
+        debug_assert_eq!(self.into_value(), receiver);
         match self {
             Primitive::Undefined | Primitive::Null => NoCache.into(),
             Primitive::Boolean(_)
@@ -212,10 +213,10 @@ impl Primitive<'_> {
             | Primitive::SmallBigInt(_) => self
                 .object_shape(agent)
                 .unwrap()
-                .set_cached(agent, p, value, receiver, cache, gc),
+                .set_cached_primitive(agent, p, value, self, cache, gc),
             Primitive::String(_) | Primitive::SmallString(_) => String::try_from(self)
                 .unwrap()
-                .set_cached(agent, p, value, receiver, cache, gc),
+                .set_cached(agent, p, value, cache, gc),
         }
     }
 }

--- a/nova_vm/src/ecmascript/types/language/primitive.rs
+++ b/nova_vm/src/ecmascript/types/language/primitive.rs
@@ -18,8 +18,7 @@ use crate::{
 };
 
 use super::{
-    GetCachedBreak, GetCachedNoCache, IntoValue, PropertyKey, SetCachedResult, String, Symbol,
-    Value,
+    GetCachedBreak, IntoValue, NoCache, PropertyKey, SetCachedResult, String, Symbol, Value,
     bigint::HeapBigInt,
     number::HeapNumber,
     string::HeapString,
@@ -173,9 +172,9 @@ impl Primitive<'_> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         match self {
-            Primitive::Undefined | Primitive::Null => ControlFlow::Continue(GetCachedNoCache),
+            Primitive::Undefined | Primitive::Null => ControlFlow::Continue(NoCache),
             Primitive::Boolean(_)
             | Primitive::Symbol(_)
             | Primitive::Number(_)

--- a/nova_vm/src/ecmascript/types/language/primitive.rs
+++ b/nova_vm/src/ecmascript/types/language/primitive.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::ops::ControlFlow;
+
 use small_string::SmallString;
 
 use crate::{
@@ -16,7 +18,8 @@ use crate::{
 };
 
 use super::{
-    GetCachedError, IntoValue, PropertyKey, SetCachedResult, String, Symbol, Value,
+    GetCachedBreak, GetCachedNoCache, IntoValue, PropertyKey, SetCachedResult, String, Symbol,
+    Value,
     bigint::HeapBigInt,
     number::HeapNumber,
     string::HeapString,
@@ -170,9 +173,9 @@ impl Primitive<'_> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         match self {
-            Primitive::Undefined | Primitive::Null => Err(GetCachedError::NoCache),
+            Primitive::Undefined | Primitive::Null => ControlFlow::Continue(GetCachedNoCache),
             Primitive::Boolean(_)
             | Primitive::Symbol(_)
             | Primitive::Number(_)

--- a/nova_vm/src/ecmascript/types/language/primitive.rs
+++ b/nova_vm/src/ecmascript/types/language/primitive.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use super::{
-    GetCachedResult, IntoValue, PropertyKey, SetCachedResult, String, Symbol, Value,
+    GetCachedError, IntoValue, PropertyKey, SetCachedResult, String, Symbol, Value,
     bigint::HeapBigInt,
     number::HeapNumber,
     string::HeapString,
@@ -170,9 +170,9 @@ impl Primitive<'_> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         match self {
-            Primitive::Undefined | Primitive::Null => GetCachedResult::NoCache,
+            Primitive::Undefined | Primitive::Null => Err(GetCachedError::NoCache),
             Primitive::Boolean(_)
             | Primitive::Symbol(_)
             | Primitive::Number(_)

--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -12,7 +12,7 @@ use core::{
 use std::borrow::Cow;
 
 use super::{
-    GetCachedResult, IntoPrimitive, IntoValue, Primitive, PropertyKey, SMALL_STRING_DISCRIMINANT,
+    GetCachedError, IntoPrimitive, IntoValue, Primitive, PropertyKey, SMALL_STRING_DISCRIMINANT,
     STRING_DISCRIMINANT, SetCachedResult, Value,
 };
 use crate::{
@@ -660,9 +660,9 @@ impl<'a> String<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         if let Some(v) = self.get_property_value(agent, p) {
-            GetCachedResult::Value(v.bind(gc))
+            Ok(v.bind(gc))
         } else {
             self.object_shape(agent)
                 .get_cached(agent, p, self.into_value(), cache, gc)

--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -665,7 +665,7 @@ impl<'a> String<'a> {
             GetCachedResult::Value(v.bind(gc))
         } else {
             self.object_shape(agent)
-                .get_cached(agent, p, cache, self.into_value(), gc)
+                .get_cached(agent, p, self.into_value(), cache, gc)
         }
     }
 
@@ -673,15 +673,16 @@ impl<'a> String<'a> {
         self,
         agent: &mut Agent,
         p: PropertyKey,
-        cache: PropertyLookupCache,
         value: Value,
+        receiver: Value,
+        cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
         if let Some(_) = self.get_property_value(agent, p) {
             SetCachedResult::Unwritable
         } else {
             self.object_shape(agent)
-                .set_cached(agent, p, cache, value, self.into_value(), gc)
+                .set_cached(agent, p, value, receiver, cache, gc)
         }
     }
 }

--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -9,11 +9,11 @@ use core::{
     hash::Hash,
     ops::{Index, IndexMut},
 };
-use std::borrow::Cow;
+use std::{borrow::Cow, ops::ControlFlow};
 
 use super::{
-    GetCachedError, IntoPrimitive, IntoValue, Primitive, PropertyKey, SMALL_STRING_DISCRIMINANT,
-    STRING_DISCRIMINANT, SetCachedResult, Value,
+    GetCachedBreak, GetCachedNoCache, IntoPrimitive, IntoValue, Primitive, PropertyKey,
+    SMALL_STRING_DISCRIMINANT, STRING_DISCRIMINANT, SetCachedResult, Value,
 };
 use crate::{
     SmallInteger, SmallString,
@@ -660,9 +660,9 @@ impl<'a> String<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         if let Some(v) = self.get_property_value(agent, p) {
-            Ok(v.bind(gc))
+            v.bind(gc).into()
         } else {
             self.object_shape(agent)
                 .get_cached(agent, p, self.into_value(), cache, gc)

--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -12,7 +12,7 @@ use core::{
 use std::{borrow::Cow, ops::ControlFlow};
 
 use super::{
-    GetCachedBreak, IntoPrimitive, IntoValue, NoCache, Primitive, PropertyKey,
+    GetCachedResult, IntoPrimitive, IntoValue, NoCache, Primitive, PropertyKey,
     SMALL_STRING_DISCRIMINANT, STRING_DISCRIMINANT, SetCachedResult, Value,
 };
 use crate::{
@@ -660,7 +660,7 @@ impl<'a> String<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         if let Some(v) = self.get_property_value(agent, p) {
             v.bind(gc).into()
         } else {
@@ -677,9 +677,9 @@ impl<'a> String<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         if let Some(_) = self.get_property_value(agent, p) {
-            SetCachedResult::Unwritable
+            SetCachedResult::Unwritable.into()
         } else {
             self.object_shape(agent)
                 .set_cached(agent, p, value, receiver, cache, gc)

--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -674,15 +674,20 @@ impl<'a> String<'a> {
         agent: &mut Agent,
         p: PropertyKey,
         value: Value,
-        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         if let Some(_) = self.get_property_value(agent, p) {
             SetCachedResult::Unwritable.into()
         } else {
-            self.object_shape(agent)
-                .set_cached(agent, p, value, receiver, cache, gc)
+            self.object_shape(agent).set_cached_primitive(
+                agent,
+                p,
+                value,
+                self.into_primitive(),
+                cache,
+                gc,
+            )
         }
     }
 }

--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -12,7 +12,7 @@ use core::{
 use std::{borrow::Cow, ops::ControlFlow};
 
 use super::{
-    GetCachedBreak, GetCachedNoCache, IntoPrimitive, IntoValue, Primitive, PropertyKey,
+    GetCachedBreak, IntoPrimitive, IntoValue, NoCache, Primitive, PropertyKey,
     SMALL_STRING_DISCRIMINANT, STRING_DISCRIMINANT, SetCachedResult, Value,
 };
 use crate::{
@@ -660,7 +660,7 @@ impl<'a> String<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         if let Some(v) = self.get_property_value(agent, p) {
             v.bind(gc).into()
         } else {

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{
-    BigInt, BigIntHeapData, GetCachedBreak, GetCachedNoCache, InternalMethods, IntoValue, Number,
+    BigInt, BigIntHeapData, GetCachedBreak, NoCache, InternalMethods, IntoValue, Number,
     Numeric, OrdinaryObject, Primitive, PropertyKey, SetCachedResult, String, StringHeapData,
     Symbol, bigint::HeapBigInt, number::HeapNumber, string::HeapString,
 };
@@ -1124,7 +1124,7 @@ impl<'a> Value<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         if let Ok(o) = Object::try_from(self) {
             o.get_cached(agent, p, cache, gc)
         } else {
@@ -1158,7 +1158,7 @@ impl<'a> Value<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
         if let Ok(o) = Object::try_from(self) {
             o.get_cached(agent, p, cache, gc)
         } else {

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -3,9 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{
-    BigInt, BigIntHeapData, GetCachedError, InternalMethods, IntoValue, Number, Numeric,
-    OrdinaryObject, Primitive, PropertyKey, SetCachedResult, String, StringHeapData, Symbol,
-    bigint::HeapBigInt, number::HeapNumber, string::HeapString,
+    BigInt, BigIntHeapData, GetCachedBreak, GetCachedNoCache, InternalMethods, IntoValue, Number,
+    Numeric, OrdinaryObject, Primitive, PropertyKey, SetCachedResult, String, StringHeapData,
+    Symbol, bigint::HeapBigInt, number::HeapNumber, string::HeapString,
 };
 #[cfg(feature = "date")]
 use crate::ecmascript::builtins::date::Date;
@@ -70,6 +70,7 @@ use core::{
     mem::size_of,
     ops::Index,
 };
+use std::ops::ControlFlow;
 
 /// ### [6.1 ECMAScript Language Types](https://tc39.es/ecma262/#sec-ecmascript-language-types)
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -1123,7 +1124,7 @@ impl<'a> Value<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         if let Ok(o) = Object::try_from(self) {
             o.get_cached(agent, p, cache, gc)
         } else {
@@ -1157,7 +1158,7 @@ impl<'a> Value<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
+    ) -> ControlFlow<GetCachedBreak<'gc>, GetCachedNoCache> {
         if let Ok(o) = Object::try_from(self) {
             o.get_cached(agent, p, cache, gc)
         } else {

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{
-    BigInt, BigIntHeapData, GetCachedResult, InternalMethods, IntoValue, Number, Numeric,
+    BigInt, BigIntHeapData, GetCachedError, InternalMethods, IntoValue, Number, Numeric,
     OrdinaryObject, Primitive, PropertyKey, SetCachedResult, String, StringHeapData, Symbol,
     bigint::HeapBigInt, number::HeapNumber, string::HeapString,
 };
@@ -1123,7 +1123,7 @@ impl<'a> Value<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         if let Ok(o) = Object::try_from(self) {
             o.get_cached(agent, p, cache, gc)
         } else {
@@ -1157,7 +1157,7 @@ impl<'a> Value<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> GetCachedResult<'gc> {
+    ) -> Result<Value<'gc>, GetCachedError<'gc>> {
         if let Ok(o) = Object::try_from(self) {
             o.get_cached(agent, p, cache, gc)
         } else {

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -3,9 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{
-    BigInt, BigIntHeapData, GetCachedBreak, NoCache, InternalMethods, IntoValue, Number,
-    Numeric, OrdinaryObject, Primitive, PropertyKey, SetCachedResult, String, StringHeapData,
-    Symbol, bigint::HeapBigInt, number::HeapNumber, string::HeapString,
+    BigInt, BigIntHeapData, GetCachedResult, InternalMethods, IntoValue, NoCache, Number, Numeric,
+    OrdinaryObject, Primitive, PropertyKey, SetCachedResult, String, StringHeapData, Symbol,
+    bigint::HeapBigInt, number::HeapNumber, string::HeapString,
 };
 #[cfg(feature = "date")]
 use crate::ecmascript::builtins::date::Date;
@@ -1124,7 +1124,7 @@ impl<'a> Value<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         if let Ok(o) = Object::try_from(self) {
             o.get_cached(agent, p, cache, gc)
         } else {
@@ -1142,7 +1142,7 @@ impl<'a> Value<'a> {
         receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> SetCachedResult<'gc> {
+    ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         if let Ok(o) = Object::try_from(self) {
             o.set_cached(agent, p, value, receiver, cache, gc)
         } else {
@@ -1158,7 +1158,7 @@ impl<'a> Value<'a> {
         p: PropertyKey,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
-    ) -> ControlFlow<GetCachedBreak<'gc>, NoCache> {
+    ) -> ControlFlow<GetCachedResult<'gc>, NoCache> {
         if let Ok(o) = Object::try_from(self) {
             o.get_cached(agent, p, cache, gc)
         } else {

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -1138,15 +1138,16 @@ impl<'a> Value<'a> {
         agent: &mut Agent,
         p: PropertyKey,
         value: Value,
+        receiver: Value,
         cache: PropertyLookupCache,
         gc: NoGcScope<'gc, '_>,
     ) -> SetCachedResult<'gc> {
         if let Ok(o) = Object::try_from(self) {
-            o.set_cached(agent, p, value, cache, gc)
+            o.set_cached(agent, p, value, receiver, cache, gc)
         } else {
             Primitive::try_from(self)
                 .unwrap()
-                .set_cached(agent, p, value, cache, gc)
+                .set_cached(agent, p, value, receiver, cache, gc)
         }
     }
 

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -3,8 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{
-    BigInt, BigIntHeapData, IntoValue, Number, Numeric, OrdinaryObject, Primitive, String,
-    StringHeapData, Symbol, bigint::HeapBigInt, number::HeapNumber, string::HeapString,
+    BigInt, BigIntHeapData, Function, IntoValue, Number, Numeric, OrdinaryObject, Primitive,
+    PropertyKey, String, StringHeapData, Symbol, bigint::HeapBigInt, number::HeapNumber,
+    string::HeapString,
 };
 #[cfg(feature = "date")]
 use crate::ecmascript::builtins::date::Date;
@@ -40,6 +41,7 @@ use crate::{
             keyed_collections::map_objects::map_iterator_objects::map_iterator::MapIterator,
             map::Map,
             module::Module,
+            ordinary::caches::PropertyLookupCache,
             primitive_objects::PrimitiveObject,
             promise::Promise,
             proxy::Proxy,
@@ -1113,6 +1115,51 @@ impl<'a> Value<'a> {
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn cached_lookup<'gc>(
+        self,
+        agent: &mut Agent,
+        p: PropertyKey,
+        cache: PropertyLookupCache,
+        gc: NoGcScope<'gc, '_>,
+    ) -> CachedLookupResult<'gc> {
+        if let Ok(o) = Object::try_from(self) {
+            o.cached_lookup(agent, p, cache, gc)
+        } else {
+            Primitive::try_from(self)
+                .unwrap()
+                .cached_lookup(agent, p, cache, gc)
+        }
+    }
+}
+
+pub enum CachedLookupResult<'a> {
+    /// A data property was found.
+    Found(Value<'a>),
+    /// A getter property was found.
+    FoundGetter(Function<'a>),
+    /// An accessor property with no getter was found.
+    Accessor,
+    /// A Proxy object was found.
+    FoundProxy(Proxy<'a>),
+    /// This property is not present in the object or its prototype chain.
+    Unset,
+    NoCache,
+}
+
+// SAFETY: Property implemented as a lifetime transmute.
+unsafe impl Bindable for CachedLookupResult<'_> {
+    type Of<'a> = CachedLookupResult<'a>;
+
+    #[inline(always)]
+    fn unbind(self) -> Self::Of<'static> {
+        unsafe { core::mem::transmute::<Self, Self::Of<'static>>(self) }
+    }
+
+    #[inline(always)]
+    fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
+        unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
     }
 }
 

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -49,13 +49,13 @@ use crate::{
         },
         scripts_and_modules::{ScriptOrModule, module::evaluate_import_call},
         types::{
-            BUILTIN_STRING_MEMORY, BigInt, Function, InternalMethods, InternalSlots, IntoFunction,
-            IntoObject, IntoValue, Number, Numeric, Object, OrdinaryObject, Primitive,
-            PropertyDescriptor, PropertyKey, PropertyKeySet, Reference, String, Value,
-            get_this_value, get_value, initialize_referenced_binding, is_private_reference,
-            is_property_reference, is_super_reference, is_unresolvable_reference, put_value,
-            throw_read_undefined_or_null_error, try_get_value, try_initialize_referenced_binding,
-            try_put_value,
+            BUILTIN_STRING_MEMORY, BigInt, CachedLookupResult, Function, InternalMethods,
+            InternalSlots, IntoFunction, IntoObject, IntoValue, Number, Numeric, Object,
+            OrdinaryObject, Primitive, PropertyDescriptor, PropertyKey, PropertyKeySet, Reference,
+            String, Value, get_this_value, get_value, initialize_referenced_binding,
+            is_private_reference, is_property_reference, is_super_reference,
+            is_unresolvable_reference, put_value, throw_read_undefined_or_null_error,
+            try_get_value, try_initialize_referenced_binding, try_put_value,
         },
     },
     engine::{
@@ -1031,64 +1031,64 @@ impl Vm {
                 )?;
             }
             Instruction::PutValueWithCache => {
-                let cache = executable.fetch_cache(agent, instr.get_first_index(), gc.nogc());
+                let _cache = executable.fetch_cache(agent, instr.get_first_index(), gc.nogc());
                 let value = vm.result.take().unwrap();
                 let reference = vm.reference.take().unwrap();
                 assert!(reference.is_static_property_reference());
 
-                let set_current_cache = if let Ok(object) = Object::try_from(reference.base_value())
-                    && !object.is_proxy()
-                    && let Some(backing_object) = object.get_backing_object(agent).bind(gc.nogc())
-                {
-                    let shape = backing_object.get_shape(agent);
-                    if let Some((offset, prototype)) = cache.find(agent, shape) {
-                        if let Some(offset) = offset {
-                            if prototype.is_none() {
-                                set_value_by_offset(
-                                    agent,
-                                    vm,
-                                    (object.unbind(), backing_object.unbind()),
-                                    offset,
-                                    value.unbind(),
-                                    reference.strict(),
-                                    gc,
-                                )?;
-                                return Ok(ContinuationKind::Normal);
-                            }
-                        } else {
-                            with_vm_gc(
-                                agent,
-                                vm,
-                                |agent, gc| {
-                                    object.internal_define_own_property(
-                                        agent,
-                                        reference.referenced_name_property_key(),
-                                        PropertyDescriptor::new_data_descriptor(value),
-                                        gc,
-                                    )
-                                },
-                                gc,
-                            )?;
-                            return Ok(ContinuationKind::Normal);
-                        }
-                        false
-                    } else {
-                        agent.heap.caches.set_current_cache(
-                            object,
-                            cache,
-                            reference.referenced_name_property_key(),
-                            shape,
-                        );
-                        true
-                    }
-                } else {
-                    false
-                };
+                // let set_current_cache = if let Ok(object) = Object::try_from(reference.base_value())
+                //     && !object.is_proxy()
+                //     && let Some(backing_object) = object.get_backing_object(agent).bind(gc.nogc())
+                // {
+                //     let shape = backing_object.get_shape(agent);
+                //     if let Some((offset, prototype)) = cache.find(agent, shape) {
+                //         if let Some(offset) = offset {
+                //             if prototype.is_none() {
+                //                 set_value_by_offset(
+                //                     agent,
+                //                     vm,
+                //                     (object.unbind(), backing_object.unbind()),
+                //                     offset,
+                //                     value.unbind(),
+                //                     reference.strict(),
+                //                     gc,
+                //                 )?;
+                //                 return Ok(ContinuationKind::Normal);
+                //             }
+                //         } else {
+                //             with_vm_gc(
+                //                 agent,
+                //                 vm,
+                //                 |agent, gc| {
+                //                     object.internal_define_own_property(
+                //                         agent,
+                //                         reference.referenced_name_property_key(),
+                //                         PropertyDescriptor::new_data_descriptor(value),
+                //                         gc,
+                //                     )
+                //                 },
+                //                 gc,
+                //             )?;
+                //             return Ok(ContinuationKind::Normal);
+                //         }
+                //         false
+                //     } else {
+                //         agent.heap.caches.set_current_cache(
+                //             object,
+                //             cache,
+                //             reference.referenced_name_property_key(),
+                //             shape,
+                //         );
+                //         true
+                //     }
+                // } else {
+                //     false
+                // };
 
                 let result = try_put_value(agent, &reference, value, gc.nogc());
-                if set_current_cache {
-                    agent.heap.caches.clear_current_cache_to_populate();
-                }
+                // if set_current_cache {
+                //     agent.heap.caches.clear_current_cache_to_populate();
+                // }
 
                 if let TryResult::Continue(result) = result {
                     result.unbind()?;
@@ -1102,73 +1102,7 @@ impl Vm {
                 }
             }
             Instruction::GetValueWithCache => {
-                let cache = executable.fetch_cache(agent, instr.get_first_index(), gc.nogc());
-                // 1. If V is not a Reference Record, return V.
-                let reference = vm.reference.take().unwrap().bind(gc.nogc());
-
-                assert!(reference.is_static_property_reference());
-
-                let set_current_cache = if let Ok(object) = Object::try_from(reference.base_value())
-                    && !object.is_proxy()
-                    && let Some(backing_object) = object.get_backing_object(agent).bind(gc.nogc())
-                {
-                    let shape = backing_object.get_shape(agent);
-                    if let Some((offset, prototype)) = cache.find(agent, shape) {
-                        let Some(offset) = offset else {
-                            vm.result = Some(Value::Undefined);
-                            return Ok(ContinuationKind::Normal);
-                        };
-                        if let Some(prototype) = prototype {
-                            let prototype_backing_object =
-                                prototype.get_backing_object(agent).unwrap();
-                            get_value_by_offset(
-                                agent,
-                                vm,
-                                prototype_backing_object,
-                                object.unbind(),
-                                offset,
-                                gc,
-                            )?;
-                        } else {
-                            get_value_by_offset(
-                                agent,
-                                vm,
-                                backing_object.unbind(),
-                                object.unbind(),
-                                offset,
-                                gc,
-                            )?;
-                        }
-                        return Ok(ContinuationKind::Normal);
-                    }
-
-                    agent.heap.caches.set_current_cache(
-                        object,
-                        cache,
-                        reference.referenced_name_property_key(),
-                        shape,
-                    );
-                    true
-                } else {
-                    false
-                };
-
-                let result = if let TryResult::Continue(result) =
-                    try_get_value(agent, &reference, gc.nogc())
-                {
-                    if set_current_cache {
-                        agent.heap.caches.clear_current_cache_to_populate();
-                    }
-                    result.unbind()
-                } else {
-                    if set_current_cache {
-                        agent.heap.caches.clear_current_cache_to_populate();
-                    }
-                    let reference = reference.unbind();
-                    with_vm_gc(agent, vm, |agent, gc| get_value(agent, &reference, gc), gc).unbind()
-                };
-
-                vm.result = Some(result?);
+                get_value_with_cache(agent, vm, executable, instr, false, gc)?;
             }
             Instruction::GetValue => {
                 // 1. If V is not a Reference Record, return V.
@@ -1238,73 +1172,7 @@ impl Vm {
                 vm.result = Some(result.unbind());
             }
             Instruction::GetValueWithCacheKeepReference => {
-                let cache = executable.fetch_cache(agent, instr.get_first_index(), gc.nogc());
-                // 1. If V is not a Reference Record, return V.
-                let reference = vm.reference.as_ref().unwrap();
-
-                assert!(reference.is_static_property_reference());
-
-                let set_current_cache = if let Ok(object) = Object::try_from(reference.base_value())
-                    && !object.is_proxy()
-                    && let Some(backing_object) = object.get_backing_object(agent).bind(gc.nogc())
-                {
-                    let shape = backing_object.get_shape(agent);
-                    if let Some((offset, prototype)) = cache.find(agent, shape) {
-                        let Some(offset) = offset else {
-                            vm.result = Some(Value::Undefined);
-                            return Ok(ContinuationKind::Normal);
-                        };
-                        if let Some(prototype) = prototype {
-                            let prototype_backing_object =
-                                prototype.get_backing_object(agent).unwrap();
-                            get_value_by_offset(
-                                agent,
-                                vm,
-                                prototype_backing_object,
-                                object.unbind(),
-                                offset,
-                                gc,
-                            )?;
-                        } else {
-                            get_value_by_offset(
-                                agent,
-                                vm,
-                                backing_object.unbind(),
-                                object.unbind(),
-                                offset,
-                                gc,
-                            )?;
-                        }
-                        return Ok(ContinuationKind::Normal);
-                    }
-
-                    agent.heap.caches.set_current_cache(
-                        object,
-                        cache,
-                        reference.referenced_name_property_key(),
-                        shape,
-                    );
-                    true
-                } else {
-                    false
-                };
-
-                let result = if let TryResult::Continue(result) =
-                    try_get_value(agent, reference, gc.nogc())
-                {
-                    if set_current_cache {
-                        agent.heap.caches.clear_current_cache_to_populate();
-                    }
-                    result.unbind()?.bind(gc.into_nogc())
-                } else {
-                    if set_current_cache {
-                        agent.heap.caches.clear_current_cache_to_populate();
-                    }
-                    let reference = reference.clone();
-                    with_vm_gc(agent, vm, |agent, gc| get_value(agent, &reference, gc), gc)?
-                };
-
-                vm.result = Some(result.unbind());
+                get_value_with_cache(agent, vm, executable, instr, true, gc)?;
             }
             Instruction::Typeof => {
                 // 2. If val is a Reference Record, then
@@ -4020,38 +3888,6 @@ fn delete_evaluation<'a>(
     // choose to avoid the actual creation of that object.
 }
 
-fn get_value_by_offset<'a>(
-    agent: &mut Agent,
-    vm: &mut Vm,
-    backing_object: OrdinaryObject,
-    object: Object,
-    offset: u16,
-    gc: GcScope<'a, '_>,
-) -> JsResult<'a, ()> {
-    let backing_object = backing_object.bind(gc.nogc());
-    let object = object.bind(gc.nogc());
-
-    // SAFETY: I'm pretty sure this is okay.
-    match unsafe { backing_object.try_get_property_by_offset(agent, offset, gc.nogc()) } {
-        ControlFlow::Continue(result) => {
-            vm.result = Some(result.unbind());
-        }
-        ControlFlow::Break(getter) => {
-            let object = object.unbind();
-            let getter = getter.unbind();
-            let result = with_vm_gc(
-                agent,
-                vm,
-                |agent, gc| call_function(agent, getter.unbind(), object.into_value(), None, gc),
-                gc,
-            )
-            .unbind()?;
-            vm.result = Some(result);
-        }
-    }
-    Ok(())
-}
-
 fn set_value_by_offset<'a>(
     agent: &mut Agent,
     vm: &mut Vm,
@@ -4100,4 +3936,90 @@ fn set_value_by_offset<'a>(
             )
         }
     }
+}
+
+fn get_value_with_cache<'gc>(
+    agent: &mut Agent,
+    vm: &mut Vm,
+    executable: Scoped<Executable>,
+    instr: &Instr,
+    keep_reference: bool,
+    gc: GcScope<'gc, '_>,
+) -> JsResult<'gc, ()> {
+    // 1. If V is not a Reference Record, return V.
+    let reference = if keep_reference {
+        vm.reference.as_ref().unwrap().clone().bind(gc.nogc())
+    } else {
+        vm.reference.take().unwrap().bind(gc.nogc())
+    };
+
+    assert!(reference.is_static_property_reference());
+
+    if is_super_reference(&reference) {
+        // TODO: super references have class prototype as base_value and target
+        // object as this_value; they call [[Get]] method of base_value with
+        // this_value as the Receiver parameter. This can lead to fun hijinks.
+        // Usually it's intended to call the base_value property getter method
+        // with the this_value as `this`.
+    } else {
+        // O[[Get]](P, O)
+        let o = reference.base_value().bind(gc.nogc());
+        let p = reference.referenced_name_property_key().bind(gc.nogc());
+        let cache = executable.fetch_cache(agent, instr.get_first_index(), gc.nogc());
+        match o.cached_lookup(agent, p, cache, gc.nogc()) {
+            CachedLookupResult::Found(value) => {
+                vm.result = Some(value.unbind());
+                return Ok(());
+            }
+            CachedLookupResult::FoundGetter(getter) => {
+                let getter = getter.unbind();
+                let o = o.unbind();
+                let result = with_vm_gc(
+                    agent,
+                    vm,
+                    |agent, gc| call_function(agent, getter, o, None, gc),
+                    gc,
+                )?;
+                vm.result = Some(result.unbind());
+                return Ok(());
+            }
+            CachedLookupResult::FoundProxy(proxy) => {
+                let proxy = proxy.unbind();
+                let o = o.unbind();
+                let p = p.unbind();
+                let result = with_vm_gc(
+                    agent,
+                    vm,
+                    |agent, gc| proxy.internal_get(agent, p, o, gc),
+                    gc,
+                )?;
+                vm.result = Some(result.unbind());
+                return Ok(());
+            }
+            CachedLookupResult::Unset | CachedLookupResult::Accessor => {
+                vm.result = Some(Value::Undefined);
+                return Ok(());
+            }
+            CachedLookupResult::NoCache => {}
+        }
+    }
+
+    // agent.heap.caches.set_current_cache(
+    //     object,
+    //     cache,
+    //     reference.referenced_name_property_key(),
+    //     shape,
+    // );
+
+    let result = try_get_value(agent, &reference, gc.nogc());
+    agent.heap.caches.clear_current_cache_to_populate();
+
+    if let TryResult::Continue(result) = result {
+        vm.result = Some(result.unbind()?)
+    } else {
+        let reference = reference.unbind();
+        vm.result =
+            Some(with_vm_gc(agent, vm, |agent, gc| get_value(agent, &reference, gc), gc).unbind()?);
+    }
+    Ok(())
 }

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -3972,7 +3972,7 @@ fn put_value_with_cache<'gc>(
         let o = reference.base_value().bind(gc.nogc());
         let p = reference.referenced_name_property_key().bind(gc.nogc());
         let cache = executable.fetch_cache(agent, instr.get_first_index(), gc.nogc());
-        match o.set_cached(agent, p, value, cache, gc.nogc()) {
+        match o.set_cached(agent, p, value, o, cache, gc.nogc()) {
             SetCachedResult::Done => {
                 return Ok(());
             }

--- a/nova_vm/src/heap.rs
+++ b/nova_vm/src/heap.rs
@@ -14,8 +14,9 @@ use std::ops::Deref;
 
 pub(crate) use self::heap_constants::{
     IntrinsicConstructorIndexes, IntrinsicFunctionIndexes, IntrinsicObjectIndexes,
-    IntrinsicPrimitiveObjectIndexes, LAST_WELL_KNOWN_SYMBOL_INDEX, WellKnownSymbolIndexes,
-    intrinsic_function_count, intrinsic_object_count, intrinsic_primitive_object_count,
+    IntrinsicObjectShapes, IntrinsicPrimitiveObjectIndexes, LAST_WELL_KNOWN_SYMBOL_INDEX,
+    WellKnownSymbolIndexes, intrinsic_function_count, intrinsic_object_count,
+    intrinsic_primitive_object_count,
 };
 #[cfg(test)]
 pub(crate) use self::heap_constants::{


### PR DESCRIPTION
This enables caching of lookups like `[].map(cb)`; the `.map` lookup will first attempt an uncached Array property lookup (which would hit for `length` and indexed properties between 0 and 2^32-2) but if that fails, it falls through to the normal cached lookup. If this isn't the first time we're looking up `map` on an Array, this will remember `map` existing on the `Array.prototype` at some offset and will perform the lookup there.

This does not (yet) enable caching of eg. `[][0]` if `Array.prototype[0]` has been set. That's not particularly important anyway.