### PR TITLE
refactor(ecmascript): cached_set install lookup on push

### DIFF
--- a/nova_vm/src/ecmascript/builtins/bound_function.rs
+++ b/nova_vm/src/ecmascript/builtins/bound_function.rs
@@ -15,8 +15,8 @@ use crate::{
         types::{
             BoundFunctionHeapData, Function, FunctionInternalProperties, GetCachedResult,
             InternalMethods, InternalSlots, IntoFunction, IntoValue, NoCache, Object,
-            OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
-            function_create_backing_object, function_get_cached,
+            OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedProps, SetCachedResult,
+            String, Value, function_create_backing_object, function_get_cached,
             function_internal_define_own_property, function_internal_delete, function_internal_get,
             function_internal_get_own_property, function_internal_has_property,
             function_internal_own_property_keys, function_internal_set, function_set_cached,
@@ -307,13 +307,10 @@ impl<'a> InternalMethods<'a> for BoundFunction<'a> {
     fn set_cached<'gc>(
         self,
         agent: &mut Agent,
-        p: PropertyKey,
-        value: Value,
-        receiver: Value,
-        cache: PropertyLookupCache,
+        props: &SetCachedProps,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
-        function_set_cached(self, agent, p, value, receiver, cache, gc)
+        function_set_cached(self, agent, props, gc)
     }
 
     /// ### [10.4.1.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist)

--- a/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_constructor.rs
@@ -21,7 +21,7 @@ use crate::{
             BUILTIN_STRING_MEMORY, BuiltinConstructorHeapData, Function,
             FunctionInternalProperties, GetCachedResult, InternalMethods, InternalSlots,
             IntoFunction, IntoObject, IntoValue, NoCache, Object, OrdinaryObject,
-            PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
+            PropertyDescriptor, PropertyKey, SetCachedProps, SetCachedResult, String, Value,
             function_create_backing_object, function_get_cached,
             function_internal_define_own_property, function_internal_delete, function_internal_get,
             function_internal_get_own_property, function_internal_has_property,
@@ -316,13 +316,10 @@ impl<'a> InternalMethods<'a> for BuiltinConstructorFunction<'a> {
     fn set_cached<'gc>(
         self,
         agent: &mut Agent,
-        p: PropertyKey,
-        value: Value,
-        receiver: Value,
-        cache: PropertyLookupCache,
+        props: &SetCachedProps,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
-        function_set_cached(self, agent, p, value, receiver, cache, gc)
+        function_set_cached(self, agent, props, gc)
     }
 
     /// ### [10.3.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist)

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -17,11 +17,12 @@ use crate::{
             BUILTIN_STRING_MEMORY, BuiltinFunctionHeapData, Function, FunctionInternalProperties,
             GetCachedResult, InternalMethods, InternalSlots, IntoFunction, IntoObject, IntoValue,
             NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, ScopedValuesIterator,
-            SetCachedResult, String, Value, function_create_backing_object, function_get_cached,
-            function_internal_define_own_property, function_internal_delete, function_internal_get,
-            function_internal_get_own_property, function_internal_has_property,
-            function_internal_own_property_keys, function_internal_set, function_set_cached,
-            function_try_get, function_try_has_property, function_try_set,
+            SetCachedProps, SetCachedResult, String, Value, function_create_backing_object,
+            function_get_cached, function_internal_define_own_property, function_internal_delete,
+            function_internal_get, function_internal_get_own_property,
+            function_internal_has_property, function_internal_own_property_keys,
+            function_internal_set, function_set_cached, function_try_get,
+            function_try_has_property, function_try_set,
         },
     },
     engine::{
@@ -684,13 +685,10 @@ impl<'a> InternalMethods<'a> for BuiltinFunction<'a> {
     fn set_cached<'gc>(
         self,
         agent: &mut Agent,
-        p: PropertyKey,
-        value: Value,
-        receiver: Value,
-        cache: PropertyLookupCache,
+        props: &SetCachedProps,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
-        function_set_cached(self, agent, p, value, receiver, cache, gc)
+        function_set_cached(self, agent, props, gc)
     }
 
     /// ### [10.3.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist)

--- a/nova_vm/src/ecmascript/builtins/builtin_function.rs
+++ b/nova_vm/src/ecmascript/builtins/builtin_function.rs
@@ -343,6 +343,26 @@ impl<'scope> ScopedArgumentsList<'scope> {
             unreachable!()
         }
     }
+
+    /// Get access to the backing reference slice as a pointer slice.
+    ///
+    /// ## Safety
+    ///
+    /// Garbage collection must not be called while this slice is exposed.
+    ///
+    /// Stack values must not be accessed while this slice is exposed.
+    pub(crate) unsafe fn as_non_null_slice(&self, agent: &Agent) -> NonNull<[Value<'static>]> {
+        if let HeapRootCollectionData::ArgumentsList(args) = agent
+            .stack_ref_collections
+            .borrow()
+            .get(self.index as usize)
+            .unwrap()
+        {
+            *args
+        } else {
+            unreachable!()
+        }
+    }
 }
 
 impl core::fmt::Debug for ScopedArgumentsList<'_> {

--- a/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
+++ b/nova_vm/src/ecmascript/builtins/control_abstraction_objects/promise_objects/promise_abstract_operations/promise_resolving_functions.rs
@@ -14,8 +14,8 @@ use crate::{
         execution::{Agent, JsResult, ProtoIntrinsics},
         types::{
             Function, FunctionInternalProperties, GetCachedResult, InternalMethods, InternalSlots,
-            NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
-            String, Value, function_create_backing_object, function_get_cached,
+            NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedProps,
+            SetCachedResult, String, Value, function_create_backing_object, function_get_cached,
             function_internal_define_own_property, function_internal_delete, function_internal_get,
             function_internal_get_own_property, function_internal_has_property,
             function_internal_own_property_keys, function_internal_set, function_set_cached,
@@ -252,13 +252,10 @@ impl<'a> InternalMethods<'a> for BuiltinPromiseResolvingFunction<'a> {
     fn set_cached<'gc>(
         self,
         agent: &mut Agent,
-        p: PropertyKey,
-        value: Value,
-        receiver: Value,
-        cache: PropertyLookupCache,
+        props: &SetCachedProps,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
-        function_set_cached(self, agent, p, value, receiver, cache, gc)
+        function_set_cached(self, agent, props, gc)
     }
 
     fn internal_call<'gc>(

--- a/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
+++ b/nova_vm/src/ecmascript/builtins/ecmascript_function.rs
@@ -34,7 +34,7 @@ use crate::{
             BUILTIN_STRING_MEMORY, ECMAScriptFunctionHeapData, Function,
             FunctionInternalProperties, GetCachedResult, InternalMethods, InternalSlots,
             IntoFunction, IntoObject, IntoValue, NoCache, Object, OrdinaryObject,
-            PropertyDescriptor, PropertyKey, SetCachedResult, String, Value,
+            PropertyDescriptor, PropertyKey, SetCachedProps, SetCachedResult, String, Value,
             function_create_backing_object, function_get_cached,
             function_internal_define_own_property, function_internal_delete, function_internal_get,
             function_internal_get_own_property, function_internal_has_property,
@@ -482,13 +482,10 @@ impl<'a> InternalMethods<'a> for ECMAScriptFunction<'a> {
     fn set_cached<'gc>(
         self,
         agent: &mut Agent,
-        p: PropertyKey,
-        value: Value,
-        receiver: Value,
-        cache: PropertyLookupCache,
+        props: &SetCachedProps,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
-        function_set_cached(self, agent, p, value, receiver, cache, gc)
+        function_set_cached(self, agent, props, gc)
     }
 
     /// ### [10.2.1 \[\[Call\]\] ( thisArgument, argumentsList )](https://tc39.es/ecma262/#sec-call)

--- a/nova_vm/src/ecmascript/builtins/error.rs
+++ b/nova_vm/src/ecmascript/builtins/error.rs
@@ -15,7 +15,7 @@ use crate::{
         types::{
             BUILTIN_STRING_MEMORY, GetCachedResult, InternalMethods, InternalSlots, IntoObject,
             IntoValue, NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
-            SetCachedResult, String, Value,
+            SetCachedProps, SetCachedResult, String, Value,
         },
     },
     engine::{
@@ -489,21 +489,18 @@ impl<'a> InternalMethods<'a> for Error<'a> {
     fn set_cached<'gc>(
         self,
         agent: &mut Agent,
-        p: PropertyKey,
-        value: Value,
-        receiver: Value,
-        cache: PropertyLookupCache,
+        props: &SetCachedProps,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         if let Some(bo) = self.get_backing_object(agent) {
-            bo.set_cached(agent, p, value, receiver, cache, gc)
-        } else if p == PropertyKey::from(BUILTIN_STRING_MEMORY.message)
-            && let Ok(value) = String::try_from(value)
+            bo.set_cached(agent, props, gc)
+        } else if props.p == PropertyKey::from(BUILTIN_STRING_MEMORY.message)
+            && let Ok(value) = String::try_from(props.value)
         {
             agent[self].message = Some(value.unbind());
             SetCachedResult::Done.into()
-        } else if p == PropertyKey::from(BUILTIN_STRING_MEMORY.cause) {
-            agent[self].cause = Some(value.unbind());
+        } else if props.p == PropertyKey::from(BUILTIN_STRING_MEMORY.cause) {
+            agent[self].cause = Some(props.value.unbind());
             SetCachedResult::Done.into()
         } else {
             NoCache.into()

--- a/nova_vm/src/ecmascript/builtins/module.rs
+++ b/nova_vm/src/ecmascript/builtins/module.rs
@@ -17,8 +17,8 @@ use crate::{
         },
         types::{
             BUILTIN_STRING_MEMORY, GetCachedResult, InternalMethods, InternalSlots, IntoValue,
-            NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedResult,
-            String, Value,
+            NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey, SetCachedProps,
+            SetCachedResult, String, Value,
         },
     },
     engine::{
@@ -771,10 +771,7 @@ impl<'a> InternalMethods<'a> for Module<'a> {
     fn set_cached<'gc>(
         self,
         _: &mut Agent,
-        _: PropertyKey,
-        _: Value,
-        _: Value,
-        _: PropertyLookupCache,
+        _: &SetCachedProps,
         _: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         SetCachedResult::Unwritable.into()

--- a/nova_vm/src/ecmascript/builtins/proxy.rs
+++ b/nova_vm/src/ecmascript/builtins/proxy.rs
@@ -24,7 +24,7 @@ use crate::{
         types::{
             BUILTIN_STRING_MEMORY, Function, GetCachedResult, InternalMethods, InternalSlots,
             IntoValue, NoCache, Object, OrdinaryObject, PropertyDescriptor, PropertyKey,
-            SetCachedResult, String, Value,
+            SetCachedProps, SetCachedResult, String, Value,
         },
     },
     engine::{
@@ -1640,10 +1640,7 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
     fn set_cached<'gc>(
         self,
         _: &mut Agent,
-        _: PropertyKey,
-        _: Value,
-        _: Value,
-        _: PropertyLookupCache,
+        _: &SetCachedProps,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         // TODO: Check if self is non-revoked, try to go through the Proxy
@@ -1667,10 +1664,8 @@ impl<'a> InternalMethods<'a> for Proxy<'a> {
     fn set_at_offset<'gc>(
         self,
         _: &mut Agent,
-        _: PropertyKey,
+        _: &SetCachedProps,
         _: PropertyOffset,
-        _: Value,
-        _: Value,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         // TODO: Check if self is non-revoked, try to go through the Proxy

--- a/nova_vm/src/ecmascript/types/language.rs
+++ b/nova_vm/src/ecmascript/types/language.rs
@@ -34,7 +34,7 @@ pub use numeric::Numeric;
 pub(crate) use object::ScopedPropertyKey;
 pub use object::{
     GetCachedResult, InternalMethods, InternalSlots, IntoObject, NoCache, Object, ObjectHeapData,
-    OrdinaryObject, PropertyKey, PropertyKeySet, SetCachedResult,
+    OrdinaryObject, PropertyKey, PropertyKeySet, SetCachedProps, SetCachedResult,
 };
 pub(crate) use primitive::HeapPrimitive;
 pub use primitive::Primitive;

--- a/nova_vm/src/ecmascript/types/language/function.rs
+++ b/nova_vm/src/ecmascript/types/language/function.rs
@@ -9,7 +9,7 @@ use std::ops::ControlFlow;
 
 use super::{
     GetCachedResult, InternalMethods, InternalSlots, NoCache, Object, OrdinaryObject, PropertyKey,
-    SetCachedResult, String, Value,
+    SetCachedProps, SetCachedResult, String, Value,
     value::{
         BOUND_FUNCTION_DISCRIMINANT, BUILTIN_CONSTRUCTOR_FUNCTION_DISCRIMINANT,
         BUILTIN_FUNCTION_DISCRIMINANT, BUILTIN_GENERATOR_FUNCTION_DISCRIMINANT,
@@ -574,23 +574,16 @@ impl<'a> InternalMethods<'a> for Function<'a> {
     fn set_cached<'gc>(
         self,
         agent: &mut Agent,
-        p: PropertyKey,
-        value: Value,
-        receiver: Value,
-        cache: PropertyLookupCache,
+        props: &SetCachedProps,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         match self {
-            Function::BoundFunction(f) => f.set_cached(agent, p, value, receiver, cache, gc),
-            Function::BuiltinFunction(f) => f.set_cached(agent, p, value, receiver, cache, gc),
-            Function::ECMAScriptFunction(f) => f.set_cached(agent, p, value, receiver, cache, gc),
+            Function::BoundFunction(f) => f.set_cached(agent, props, gc),
+            Function::BuiltinFunction(f) => f.set_cached(agent, props, gc),
+            Function::ECMAScriptFunction(f) => f.set_cached(agent, props, gc),
             Function::BuiltinGeneratorFunction => todo!(),
-            Function::BuiltinConstructorFunction(f) => {
-                f.set_cached(agent, p, value, receiver, cache, gc)
-            }
-            Function::BuiltinPromiseResolvingFunction(f) => {
-                f.set_cached(agent, p, value, receiver, cache, gc)
-            }
+            Function::BuiltinConstructorFunction(f) => f.set_cached(agent, props, gc),
+            Function::BuiltinPromiseResolvingFunction(f) => f.set_cached(agent, props, gc),
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),
         }
@@ -621,24 +614,18 @@ impl<'a> InternalMethods<'a> for Function<'a> {
     fn set_at_offset<'gc>(
         self,
         agent: &mut Agent,
-        p: PropertyKey,
+        props: &SetCachedProps,
         offset: PropertyOffset,
-        value: Value,
-        receiver: Value,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         match self {
-            Function::BoundFunction(f) => f.set_at_offset(agent, p, offset, value, receiver, gc),
-            Function::BuiltinFunction(f) => f.set_at_offset(agent, p, offset, value, receiver, gc),
-            Function::ECMAScriptFunction(f) => {
-                f.set_at_offset(agent, p, offset, value, receiver, gc)
-            }
+            Function::BoundFunction(f) => f.set_at_offset(agent, props, offset, gc),
+            Function::BuiltinFunction(f) => f.set_at_offset(agent, props, offset, gc),
+            Function::ECMAScriptFunction(f) => f.set_at_offset(agent, props, offset, gc),
             Function::BuiltinGeneratorFunction => todo!(),
-            Function::BuiltinConstructorFunction(f) => {
-                f.set_at_offset(agent, p, offset, value, receiver, gc)
-            }
+            Function::BuiltinConstructorFunction(f) => f.set_at_offset(agent, props, offset, gc),
             Function::BuiltinPromiseResolvingFunction(f) => {
-                f.set_at_offset(agent, p, offset, value, receiver, gc)
+                f.set_at_offset(agent, props, offset, gc)
             }
             Function::BuiltinPromiseCollectorFunction => todo!(),
             Function::BuiltinProxyRevokerFunction => todo!(),

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -455,6 +455,25 @@ impl<'a> OrdinaryObject<'a> {
             .create(ObjectHeapData::new(shape, values, cap, len, extensible))
     }
 
+    pub(crate) fn create_object_with_shape(
+        agent: &mut Agent,
+        shape: ObjectShape<'a>,
+    ) -> Result<Self, TryReserveError> {
+        // SAFETY: Option<Value> uses a niche in Value enum at discriminant 0.
+        let ElementsVector {
+            elements_index: values,
+            cap,
+            len,
+            len_writable: extensible,
+        } = agent
+            .heap
+            .elements
+            .allocate_elements_with_capacity(shape.get_length(agent) as usize)?;
+        Ok(agent
+            .heap
+            .create(ObjectHeapData::new(shape, values, cap, len, extensible)))
+    }
+
     /// Creates a new "intrinsic" object. An intrinsic object owns its Object
     /// Shape uniquely and thus any changes to the object properties mutate the
     /// Shape directly.

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -121,7 +121,9 @@ use crate::{
 
 use ahash::AHashMap;
 pub use data::ObjectHeapData;
-pub use internal_methods::{GetCachedResult, InternalMethods, NoCache, SetCachedResult};
+pub use internal_methods::{
+    GetCachedResult, InternalMethods, NoCache, SetCachedProps, SetCachedResult,
+};
 pub use internal_slots::InternalSlots;
 pub use into_object::IntoObject;
 pub use property_key::PropertyKey;
@@ -4187,116 +4189,91 @@ impl<'a> InternalMethods<'a> for Object<'a> {
     fn set_cached<'gc>(
         self,
         agent: &mut Agent,
-        p: PropertyKey,
-        value: Value,
-        receiver: Value,
-        cache: PropertyLookupCache,
+        props: &SetCachedProps,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         match self {
-            Object::Object(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::Array(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::Object(data) => data.set_cached(agent, props, gc),
+            Object::Array(data) => data.set_cached(agent, props, gc),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::ArrayBuffer(data) => data.set_cached(agent, props, gc),
             #[cfg(feature = "date")]
-            Object::Date(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::Error(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::BoundFunction(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::BuiltinFunction(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::ECMAScriptFunction(data) => {
-                data.set_cached(agent, p, value, receiver, cache, gc)
-            }
+            Object::Date(data) => data.set_cached(agent, props, gc),
+            Object::Error(data) => data.set_cached(agent, props, gc),
+            Object::BoundFunction(data) => data.set_cached(agent, props, gc),
+            Object::BuiltinFunction(data) => data.set_cached(agent, props, gc),
+            Object::ECMAScriptFunction(data) => data.set_cached(agent, props, gc),
             Object::BuiltinGeneratorFunction => todo!(),
-            Object::BuiltinConstructorFunction(data) => {
-                data.set_cached(agent, p, value, receiver, cache, gc)
-            }
-            Object::BuiltinPromiseResolvingFunction(data) => {
-                data.set_cached(agent, p, value, receiver, cache, gc)
-            }
+            Object::BuiltinConstructorFunction(data) => data.set_cached(agent, props, gc),
+            Object::BuiltinPromiseResolvingFunction(data) => data.set_cached(agent, props, gc),
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::Arguments(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::PrimitiveObject(data) => data.set_cached(agent, props, gc),
+            Object::Arguments(data) => data.set_cached(agent, props, gc),
             #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::FinalizationRegistry(data) => {
-                data.set_cached(agent, p, value, receiver, cache, gc)
-            }
-            Object::Map(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::Promise(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::Proxy(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::DataView(data) => data.set_cached(agent, props, gc),
+            Object::FinalizationRegistry(data) => data.set_cached(agent, props, gc),
+            Object::Map(data) => data.set_cached(agent, props, gc),
+            Object::Promise(data) => data.set_cached(agent, props, gc),
+            Object::Proxy(data) => data.set_cached(agent, props, gc),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::RegExp(data) => data.set_cached(agent, props, gc),
             #[cfg(feature = "set")]
-            Object::Set(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::Set(data) => data.set_cached(agent, props, gc),
             #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => {
-                data.set_cached(agent, p, value, receiver, cache, gc)
-            }
+            Object::SharedArrayBuffer(data) => data.set_cached(agent, props, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::WeakMap(data) => data.set_cached(agent, props, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::WeakRef(data) => data.set_cached(agent, props, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::WeakSet(data) => data.set_cached(agent, props, gc),
             #[cfg(feature = "array-buffer")]
-            Object::Int8Array(data) => {
-                TypedArray::Int8Array(data).set_cached(agent, p, value, receiver, cache, gc)
-            }
+            Object::Int8Array(data) => TypedArray::Int8Array(data).set_cached(agent, props, gc),
             #[cfg(feature = "array-buffer")]
-            Object::Uint8Array(data) => {
-                TypedArray::Uint8Array(data).set_cached(agent, p, value, receiver, cache, gc)
-            }
+            Object::Uint8Array(data) => TypedArray::Uint8Array(data).set_cached(agent, props, gc),
             #[cfg(feature = "array-buffer")]
             Object::Uint8ClampedArray(data) => {
-                TypedArray::Uint8ClampedArray(data).set_cached(agent, p, value, receiver, cache, gc)
+                TypedArray::Uint8ClampedArray(data).set_cached(agent, props, gc)
             }
             #[cfg(feature = "array-buffer")]
-            Object::Int16Array(data) => {
-                TypedArray::Int16Array(data).set_cached(agent, p, value, receiver, cache, gc)
-            }
+            Object::Int16Array(data) => TypedArray::Int16Array(data).set_cached(agent, props, gc),
             #[cfg(feature = "array-buffer")]
-            Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).set_cached(agent, p, value, receiver, cache, gc)
-            }
+            Object::Uint16Array(data) => TypedArray::Uint16Array(data).set_cached(agent, props, gc),
             #[cfg(feature = "array-buffer")]
-            Object::Int32Array(data) => {
-                TypedArray::Int32Array(data).set_cached(agent, p, value, receiver, cache, gc)
-            }
+            Object::Int32Array(data) => TypedArray::Int32Array(data).set_cached(agent, props, gc),
             #[cfg(feature = "array-buffer")]
-            Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).set_cached(agent, p, value, receiver, cache, gc)
-            }
+            Object::Uint32Array(data) => TypedArray::Uint32Array(data).set_cached(agent, props, gc),
             #[cfg(feature = "array-buffer")]
             Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).set_cached(agent, p, value, receiver, cache, gc)
+                TypedArray::BigInt64Array(data).set_cached(agent, props, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigUint64Array(data) => {
-                TypedArray::BigUint64Array(data).set_cached(agent, p, value, receiver, cache, gc)
+                TypedArray::BigUint64Array(data).set_cached(agent, props, gc)
             }
             #[cfg(feature = "proposal-float16array")]
             Object::Float16Array(data) => {
-                TypedArray::Float16Array(data).set_cached(agent, p, value, receiver, cache, gc)
+                TypedArray::Float16Array(data).set_cached(agent, props, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).set_cached(agent, p, value, receiver, cache, gc)
+                TypedArray::Float32Array(data).set_cached(agent, props, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).set_cached(agent, p, value, receiver, cache, gc)
+                TypedArray::Float64Array(data).set_cached(agent, props, gc)
             }
             Object::AsyncFromSyncIterator => todo!(),
-            Object::AsyncGenerator(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::ArrayIterator(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::AsyncGenerator(data) => data.set_cached(agent, props, gc),
+            Object::ArrayIterator(data) => data.set_cached(agent, props, gc),
             #[cfg(feature = "set")]
-            Object::SetIterator(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::MapIterator(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::StringIterator(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::Generator(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::Module(data) => data.set_cached(agent, p, value, receiver, cache, gc),
-            Object::EmbedderObject(data) => data.set_cached(agent, p, value, receiver, cache, gc),
+            Object::SetIterator(data) => data.set_cached(agent, props, gc),
+            Object::MapIterator(data) => data.set_cached(agent, props, gc),
+            Object::StringIterator(data) => data.set_cached(agent, props, gc),
+            Object::Generator(data) => data.set_cached(agent, props, gc),
+            Object::Module(data) => data.set_cached(agent, props, gc),
+            Object::EmbedderObject(data) => data.set_cached(agent, props, gc),
         }
     }
 
@@ -4412,128 +4389,108 @@ impl<'a> InternalMethods<'a> for Object<'a> {
     fn set_at_offset<'gc>(
         self,
         agent: &mut Agent,
-        p: PropertyKey,
+        props: &SetCachedProps,
         offset: PropertyOffset,
-        value: Value,
-        receiver: Value,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         match self {
-            Object::Object(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
-            Object::Array(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::Object(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::Array(data) => data.set_at_offset(agent, props, offset, gc),
             #[cfg(feature = "array-buffer")]
-            Object::ArrayBuffer(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::ArrayBuffer(data) => data.set_at_offset(agent, props, offset, gc),
             #[cfg(feature = "date")]
-            Object::Date(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
-            Object::Error(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
-            Object::BoundFunction(data) => {
-                data.set_at_offset(agent, p, offset, value, receiver, gc)
-            }
-            Object::BuiltinFunction(data) => {
-                data.set_at_offset(agent, p, offset, value, receiver, gc)
-            }
-            Object::ECMAScriptFunction(data) => {
-                data.set_at_offset(agent, p, offset, value, receiver, gc)
-            }
+            Object::Date(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::Error(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::BoundFunction(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::BuiltinFunction(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::ECMAScriptFunction(data) => data.set_at_offset(agent, props, offset, gc),
             Object::BuiltinGeneratorFunction => todo!(),
             Object::BuiltinConstructorFunction(data) => {
-                data.set_at_offset(agent, p, offset, value, receiver, gc)
+                data.set_at_offset(agent, props, offset, gc)
             }
             Object::BuiltinPromiseResolvingFunction(data) => {
-                data.set_at_offset(agent, p, offset, value, receiver, gc)
+                data.set_at_offset(agent, props, offset, gc)
             }
             Object::BuiltinPromiseCollectorFunction => todo!(),
             Object::BuiltinProxyRevokerFunction => todo!(),
-            Object::PrimitiveObject(data) => {
-                data.set_at_offset(agent, p, offset, value, receiver, gc)
-            }
-            Object::Arguments(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::PrimitiveObject(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::Arguments(data) => data.set_at_offset(agent, props, offset, gc),
             #[cfg(feature = "array-buffer")]
-            Object::DataView(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
-            Object::FinalizationRegistry(data) => {
-                data.set_at_offset(agent, p, offset, value, receiver, gc)
-            }
-            Object::Map(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
-            Object::Promise(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
-            Object::Proxy(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::DataView(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::FinalizationRegistry(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::Map(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::Promise(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::Proxy(data) => data.set_at_offset(agent, props, offset, gc),
             #[cfg(feature = "regexp")]
-            Object::RegExp(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::RegExp(data) => data.set_at_offset(agent, props, offset, gc),
             #[cfg(feature = "set")]
-            Object::Set(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::Set(data) => data.set_at_offset(agent, props, offset, gc),
             #[cfg(feature = "shared-array-buffer")]
-            Object::SharedArrayBuffer(data) => {
-                data.set_at_offset(agent, p, offset, value, receiver, gc)
-            }
+            Object::SharedArrayBuffer(data) => data.set_at_offset(agent, props, offset, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakMap(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::WeakMap(data) => data.set_at_offset(agent, props, offset, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakRef(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::WeakRef(data) => data.set_at_offset(agent, props, offset, gc),
             #[cfg(feature = "weak-refs")]
-            Object::WeakSet(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::WeakSet(data) => data.set_at_offset(agent, props, offset, gc),
             #[cfg(feature = "array-buffer")]
             Object::Int8Array(data) => {
-                TypedArray::Int8Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+                TypedArray::Int8Array(data).set_at_offset(agent, props, offset, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint8Array(data) => {
-                TypedArray::Uint8Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+                TypedArray::Uint8Array(data).set_at_offset(agent, props, offset, gc)
             }
             #[cfg(feature = "array-buffer")]
-            Object::Uint8ClampedArray(data) => TypedArray::Uint8ClampedArray(data)
-                .set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::Uint8ClampedArray(data) => {
+                TypedArray::Uint8ClampedArray(data).set_at_offset(agent, props, offset, gc)
+            }
             #[cfg(feature = "array-buffer")]
             Object::Int16Array(data) => {
-                TypedArray::Int16Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+                TypedArray::Int16Array(data).set_at_offset(agent, props, offset, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint16Array(data) => {
-                TypedArray::Uint16Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+                TypedArray::Uint16Array(data).set_at_offset(agent, props, offset, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Int32Array(data) => {
-                TypedArray::Int32Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+                TypedArray::Int32Array(data).set_at_offset(agent, props, offset, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Uint32Array(data) => {
-                TypedArray::Uint32Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+                TypedArray::Uint32Array(data).set_at_offset(agent, props, offset, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::BigInt64Array(data) => {
-                TypedArray::BigInt64Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+                TypedArray::BigInt64Array(data).set_at_offset(agent, props, offset, gc)
             }
             #[cfg(feature = "array-buffer")]
-            Object::BigUint64Array(data) => TypedArray::BigUint64Array(data)
-                .set_at_offset(agent, p, offset, value, receiver, gc),
+            Object::BigUint64Array(data) => {
+                TypedArray::BigUint64Array(data).set_at_offset(agent, props, offset, gc)
+            }
             #[cfg(feature = "proposal-float16array")]
             Object::Float16Array(data) => {
-                TypedArray::Float16Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+                TypedArray::Float16Array(data).set_at_offset(agent, props, offset, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float32Array(data) => {
-                TypedArray::Float32Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+                TypedArray::Float32Array(data).set_at_offset(agent, props, offset, gc)
             }
             #[cfg(feature = "array-buffer")]
             Object::Float64Array(data) => {
-                TypedArray::Float64Array(data).set_at_offset(agent, p, offset, value, receiver, gc)
+                TypedArray::Float64Array(data).set_at_offset(agent, props, offset, gc)
             }
             Object::AsyncFromSyncIterator => todo!(),
-            Object::AsyncGenerator(data) => {
-                data.set_at_offset(agent, p, offset, value, receiver, gc)
-            }
-            Object::ArrayIterator(data) => {
-                data.set_at_offset(agent, p, offset, value, receiver, gc)
-            }
+            Object::AsyncGenerator(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::ArrayIterator(data) => data.set_at_offset(agent, props, offset, gc),
             #[cfg(feature = "set")]
-            Object::SetIterator(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
-            Object::MapIterator(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
-            Object::StringIterator(data) => {
-                data.set_at_offset(agent, p, offset, value, receiver, gc)
-            }
-            Object::Generator(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
-            Object::Module(data) => data.set_at_offset(agent, p, offset, value, receiver, gc),
-            Object::EmbedderObject(data) => {
-                data.set_at_offset(agent, p, offset, value, receiver, gc)
-            }
+            Object::SetIterator(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::MapIterator(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::StringIterator(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::Generator(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::Module(data) => data.set_at_offset(agent, props, offset, gc),
+            Object::EmbedderObject(data) => data.set_at_offset(agent, props, offset, gc),
         }
     }
 

--- a/nova_vm/src/ecmascript/types/language/object/property_storage.rs
+++ b/nova_vm/src/ecmascript/types/language/object/property_storage.rs
@@ -347,7 +347,7 @@ impl<'a> PropertyStorage<'a> {
         let value = descriptor.value;
         let element_descriptor = ElementDescriptor::from_property_descriptor(descriptor);
 
-        let cur_len = if let Some(PropertyStorageMut {
+        if let Some(PropertyStorageMut {
             keys,
             values,
             descriptors,
@@ -378,49 +378,8 @@ impl<'a> PropertyStorage<'a> {
                 }
                 return Ok(());
             }
-            keys.len() as u32
-        } else {
-            0
-        };
-        let new_len = cur_len.checked_add(1).unwrap();
-        let old_shape = object.object_shape(agent);
-        let new_shape = old_shape.get_child_shape(agent, key);
-        agent.heap.alloc_counter += core::mem::size_of::<Option<Value>>()
-            + if element_descriptor.is_some() {
-                core::mem::size_of::<(u32, ElementDescriptor)>()
-            } else {
-                0
-            };
-        object.reserve(agent, new_len)?;
-        agent[object].set_len(new_len);
-        let ElementStorageMut {
-            values,
-            descriptors,
-        } = object.get_elements_storage_mut(agent);
-        debug_assert!(
-            values[cur_len as usize].is_none()
-                && match &descriptors {
-                    Entry::Occupied(e) => {
-                        !e.get().contains_key(&cur_len)
-                    }
-                    Entry::Vacant(_) => true,
-                }
-        );
-        values[cur_len as usize] = value.unbind();
-        if let Some(element_descriptor) = element_descriptor {
-            let descriptors = descriptors.or_insert_with(|| AHashMap::with_capacity(1));
-            descriptors.insert(cur_len, element_descriptor.unbind());
         }
-        if old_shape == new_shape {
-            // Intrinsic shape! Adding a new property to an intrinsic needs to
-            // invalidate any NOT_FOUND caches for the added key.
-            Caches::invalidate_caches_on_intrinsic_shape_property_addition(
-                agent, o, old_shape, key, cur_len, gc,
-            );
-        } else {
-            agent[object].set_shape(new_shape);
-        }
-        Ok(())
+        self.push(agent, o, key, value, element_descriptor, gc)
     }
 
     pub fn push(

--- a/nova_vm/src/ecmascript/types/language/string.rs
+++ b/nova_vm/src/ecmascript/types/language/string.rs
@@ -13,7 +13,7 @@ use std::{borrow::Cow, ops::ControlFlow};
 
 use super::{
     GetCachedResult, IntoPrimitive, IntoValue, NoCache, Primitive, PropertyKey,
-    SMALL_STRING_DISCRIMINANT, STRING_DISCRIMINANT, SetCachedResult, Value,
+    SMALL_STRING_DISCRIMINANT, STRING_DISCRIMINANT, SetCachedProps, SetCachedResult, Value,
 };
 use crate::{
     SmallInteger, SmallString,
@@ -672,22 +672,14 @@ impl<'a> String<'a> {
     pub(crate) fn set_cached<'gc>(
         self,
         agent: &mut Agent,
-        p: PropertyKey,
-        value: Value,
-        cache: PropertyLookupCache,
+        props: &SetCachedProps,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
-        if self.get_property_value(agent, p).is_some() {
+        if self.get_property_value(agent, props.p).is_some() {
             SetCachedResult::Unwritable.into()
         } else {
-            self.object_shape(agent).set_cached_primitive(
-                agent,
-                p,
-                value,
-                self.into_primitive(),
-                cache,
-                gc,
-            )
+            self.object_shape(agent)
+                .set_cached_primitive(agent, props, gc)
         }
     }
 }

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -4,8 +4,8 @@
 
 use super::{
     BigInt, BigIntHeapData, GetCachedResult, InternalMethods, IntoValue, NoCache, Number, Numeric,
-    OrdinaryObject, Primitive, PropertyKey, SetCachedResult, String, StringHeapData, Symbol,
-    bigint::HeapBigInt, number::HeapNumber, string::HeapString,
+    OrdinaryObject, Primitive, PropertyKey, SetCachedProps, SetCachedResult, String,
+    StringHeapData, Symbol, bigint::HeapBigInt, number::HeapNumber, string::HeapString,
 };
 #[cfg(feature = "date")]
 use crate::ecmascript::builtins::date::Date;
@@ -1137,18 +1137,15 @@ impl<'a> Value<'a> {
     pub(crate) fn set_cached<'gc>(
         self,
         agent: &mut Agent,
-        p: PropertyKey,
-        value: Value,
-        receiver: Value,
-        cache: PropertyLookupCache,
+        props: &SetCachedProps,
         gc: NoGcScope<'gc, '_>,
     ) -> ControlFlow<SetCachedResult<'gc>, NoCache> {
         if let Ok(o) = Object::try_from(self) {
-            o.set_cached(agent, p, value, receiver, cache, gc)
+            o.set_cached(agent, props, gc)
         } else {
             Primitive::try_from(self)
                 .unwrap()
-                .set_cached(agent, p, value, receiver, cache, gc)
+                .set_cached(agent, props, gc)
         }
     }
 

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -3517,6 +3517,7 @@ pub(crate) fn instanceof_operator<'a, 'b>(
     }
 }
 
+#[inline(always)]
 fn with_vm_gc<'a, 'b, R: 'a>(
     agent: &mut Agent,
     vm: &mut Vm,

--- a/nova_vm/src/engine/bytecode/vm.rs
+++ b/nova_vm/src/engine/bytecode/vm.rs
@@ -52,7 +52,7 @@ use crate::{
             BUILTIN_STRING_MEMORY, BigInt, Function, GetCachedResult, InternalMethods,
             InternalSlots, IntoFunction, IntoObject, IntoValue, Number, Numeric, Object,
             OrdinaryObject, Primitive, PropertyDescriptor, PropertyKey, PropertyKeySet, Reference,
-            SetCachedResult, String, Value, get_this_value, get_value,
+            SetCachedProps, SetCachedResult, String, Value, get_this_value, get_value,
             initialize_referenced_binding, is_private_reference, is_property_reference,
             is_super_reference, is_unresolvable_reference, put_value, throw_cannot_set_property,
             throw_read_undefined_or_null_error, try_get_value, try_initialize_referenced_binding,
@@ -3995,7 +3995,16 @@ fn put_value_with_cache<'gc>(
     }
     let receiver = reference.this_value().bind(gc.nogc());
     let cache = executable.fetch_cache(agent, instr.get_first_index(), gc.nogc());
-    if let ControlFlow::Break(b) = o.set_cached(agent, p, value, receiver, cache, gc.nogc()) {
+    if let ControlFlow::Break(b) = o.set_cached(
+        agent,
+        &SetCachedProps {
+            p,
+            receiver,
+            cache,
+            value,
+        },
+        gc.nogc(),
+    ) {
         if matches!(b, SetCachedResult::Done) {
             return Ok(());
         }


### PR DESCRIPTION
Change the API of [[Set]] cached to take parameters in a bag and use that to pass the PropertyCache all the way through the callstack. Then, use that when installing a new property on an object to immediately create a property lookup cache.