### PR TITLE
feat(vm): Global property lookup caches

### DIFF
--- a/nova_vm/src/ecmascript/builtins/array.rs
+++ b/nova_vm/src/ecmascript/builtins/array.rs
@@ -595,7 +595,13 @@ impl<'a> InternalMethods<'a> for Array<'a> {
             if let Some(backing_object) = self.get_backing_object(agent) {
                 // Note: this looks up in the prototype chain as well, so we
                 // don't need to fall-through if this returns false or such.
-                return ordinary_try_has_property(agent, backing_object, property_key, gc);
+                return ordinary_try_has_property(
+                    agent,
+                    self.into_object(),
+                    backing_object,
+                    property_key,
+                    gc,
+                );
             }
         }
         // Data is not found in the array or its backing object (or one does
@@ -654,7 +660,13 @@ impl<'a> InternalMethods<'a> for Array<'a> {
             if let Some(backing_object) = self.get_backing_object(agent) {
                 // Note: this looks up in the prototype chain as well, so we
                 // don't need to fall-through if this returns false or such.
-                return ordinary_has_property(agent, backing_object, property_key, gc);
+                return ordinary_has_property(
+                    agent,
+                    self.into_object(),
+                    backing_object,
+                    property_key,
+                    gc,
+                );
             }
         }
         // Data is not found in the array or its backing object (or one does

--- a/nova_vm/src/ecmascript/builtins/error.rs
+++ b/nova_vm/src/ecmascript/builtins/error.rs
@@ -31,8 +31,8 @@ use crate::{
 };
 
 use super::ordinary::{
-    caches::PropertyLookupCache, ordinary_delete, ordinary_get_own_property, ordinary_set,
-    ordinary_try_get, ordinary_try_set,
+    caches::PropertyLookupCache, ordinary_delete, ordinary_get_own_property, ordinary_has_property,
+    ordinary_set, ordinary_try_get, ordinary_try_has_property, ordinary_try_set,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -219,7 +219,13 @@ impl<'a> InternalMethods<'a> for Error<'a> {
         gc: NoGcScope,
     ) -> TryResult<bool> {
         match self.get_backing_object(agent) {
-            Some(backing_object) => backing_object.try_has_property(agent, property_key, gc),
+            Some(backing_object) => ordinary_try_has_property(
+                agent,
+                self.into_object(),
+                backing_object,
+                property_key,
+                gc,
+            ),
             None => {
                 let found_direct =
                     if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.message) {
@@ -250,9 +256,13 @@ impl<'a> InternalMethods<'a> for Error<'a> {
     ) -> JsResult<'gc, bool> {
         let property_key = property_key.bind(gc.nogc());
         match self.get_backing_object(agent) {
-            Some(backing_object) => {
-                backing_object.internal_has_property(agent, property_key.unbind(), gc)
-            }
+            Some(backing_object) => ordinary_has_property(
+                agent,
+                self.into_object(),
+                backing_object,
+                property_key.unbind(),
+                gc,
+            ),
             None => {
                 let found_direct =
                     if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.message) {

--- a/nova_vm/src/ecmascript/builtins/global_object.rs
+++ b/nova_vm/src/ecmascript/builtins/global_object.rs
@@ -386,8 +386,15 @@ pub fn perform_eval<'gc>(
         // 29. If result is a normal completion, then
         match result {
             Ok(_) => {
-                let exe =
-                    Executable::compile_eval_body(agent, body, gc.nogc()).scope(agent, gc.nogc());
+                let source_code = agent
+                    .running_execution_context()
+                    .ecmascript_code
+                    .as_ref()
+                    .unwrap()
+                    .source_code
+                    .bind(gc.nogc());
+                let exe = Executable::compile_eval_body(agent, body, source_code, gc.nogc())
+                    .scope(agent, gc.nogc());
                 // a. Set result to Completion(Evaluation of body).
                 // 30. If result is a normal completion and result.[[Value]] is empty, then
                 // a. Set result to NormalCompletion(undefined).

--- a/nova_vm/src/ecmascript/builtins/ordinary/caches.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary/caches.rs
@@ -14,6 +14,7 @@ use crate::{
     engine::{
         TryResult,
         context::{Bindable, GcToken, NoGcScope},
+        rootable::{HeapRootData, HeapRootRef, Rootable},
     },
     heap::{
         CompactionLists, HeapMarkAndSweep, HeapSweepWeakReference, PropertyKeyHeap, WeakReference,
@@ -712,6 +713,29 @@ unsafe impl Bindable for PropertyLookupCache<'_> {
 
     fn bind<'a>(self, _: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
+    }
+}
+
+impl<'a> Rootable for PropertyLookupCache<'a> {
+    type RootRepr = HeapRootRef;
+
+    fn to_root_repr(value: Self) -> Result<Self::RootRepr, HeapRootData> {
+        Err(HeapRootData::PropertyLookupCache(value.unbind()))
+    }
+
+    fn from_root_repr(value: &Self::RootRepr) -> Result<Self, HeapRootRef> {
+        Err(*value)
+    }
+
+    fn from_heap_ref(heap_ref: HeapRootRef) -> Self::RootRepr {
+        heap_ref
+    }
+
+    fn from_heap_data(heap_data: HeapRootData) -> Option<Self> {
+        match heap_data {
+            HeapRootData::PropertyLookupCache(object) => Some(object),
+            _ => None,
+        }
     }
 }
 

--- a/nova_vm/src/ecmascript/builtins/ordinary/shape.rs
+++ b/nova_vm/src/ecmascript/builtins/ordinary/shape.rs
@@ -185,7 +185,7 @@ impl<'a> ObjectShape<'a> {
             // A cached lookup result was found.
             if offset.is_unset() {
                 // The property is unset.
-                Value::Undefined.into()
+                GetCachedResult::Unset.into()
             } else {
                 let o = prototype.unwrap_or_else(|| Object::try_from(receiver).unwrap());
                 o.get_own_property_at_offset(agent, offset, gc)

--- a/nova_vm/src/ecmascript/builtins/primitive_objects.rs
+++ b/nova_vm/src/ecmascript/builtins/primitive_objects.rs
@@ -333,9 +333,13 @@ impl<'a> InternalMethods<'a> for PrimitiveObject<'a> {
 
         // 1. Return ? OrdinaryHasProperty(O, P).
         match self.get_backing_object(agent) {
-            Some(backing_object) => {
-                ordinary_has_property(agent, backing_object, property_key.unbind(), gc)
-            }
+            Some(backing_object) => ordinary_has_property(
+                agent,
+                self.into_object(),
+                backing_object,
+                property_key.unbind(),
+                gc,
+            ),
             None => {
                 // 3. Let parent be ? O.[[GetPrototypeOf]]().
                 // Note: Primitive objects never call into JS from GetPrototypeOf.

--- a/nova_vm/src/ecmascript/builtins/regexp.rs
+++ b/nova_vm/src/ecmascript/builtins/regexp.rs
@@ -36,8 +36,8 @@ use oxc_ast::ast::RegExpFlags;
 use wtf8::Wtf8Buf;
 
 use super::ordinary::{
-    caches::PropertyLookupCache, ordinary_get_own_property, ordinary_set, ordinary_try_get,
-    ordinary_try_set,
+    caches::PropertyLookupCache, ordinary_get_own_property, ordinary_has_property, ordinary_set,
+    ordinary_try_get, ordinary_try_has_property, ordinary_try_set,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -212,7 +212,7 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
             // lastIndex always exists
             TryResult::Continue(true)
         } else if let Some(backing_object) = self.get_backing_object(agent) {
-            backing_object.try_has_property(agent, property_key, gc)
+            ordinary_try_has_property(agent, self.into_object(), backing_object, property_key, gc)
         } else {
             // a. Let parent be ? O.[[GetPrototypeOf]]().
             // Note: We know statically what this ends up doing.
@@ -236,7 +236,7 @@ impl<'a> InternalMethods<'a> for RegExp<'a> {
             // lastIndex always exists
             Ok(true)
         } else if let Some(backing_object) = self.get_backing_object(agent) {
-            backing_object.internal_has_property(agent, property_key, gc)
+            ordinary_has_property(agent, self.into_object(), backing_object, property_key, gc)
         } else {
             // a. Let parent be ? O.[[GetPrototypeOf]]().
             // Note: We know statically what this ends up doing.

--- a/nova_vm/src/ecmascript/scripts_and_modules/module/module_semantics/source_text_module_records.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/module/module_semantics/source_text_module_records.rs
@@ -155,6 +155,15 @@ impl core::fmt::Debug for SourceTextModule<'_> {
 }
 
 impl<'m> SourceTextModule<'m> {
+    /// Get the script SourceCode.
+    pub(crate) fn get_source_code<'a>(
+        self,
+        agent: &Agent,
+        gc: NoGcScope<'a, '_>,
+    ) -> SourceCode<'a> {
+        self.get(agent).source_code.bind(gc)
+    }
+
     pub(crate) const fn _def() -> Self {
         Self(0, PhantomData)
     }

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -78,6 +78,15 @@ impl Script<'_> {
         }
     }
 
+    /// Get the script SourceCode.
+    pub(crate) fn get_source_code<'a>(
+        self,
+        agent: &Agent,
+        gc: NoGcScope<'a, '_>,
+    ) -> SourceCode<'a> {
+        agent[self].source_code.bind(gc)
+    }
+
     /// Creates a script identififer from a usize.
     ///
     /// ## Panics

--- a/nova_vm/src/ecmascript/scripts_and_modules/script.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/script.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     ecmascript::{
+        builtins::ordinary::caches::PropertyLookupCache,
         execution::{
             Agent, ECMAScriptCode, Environment, ExecutionContext, GlobalEnvironment, JsResult,
             Realm, agent::ExceptionType,
@@ -749,9 +750,10 @@ unsafe fn global_declaration_instantiation<'a>(
     // 17. For each String vn of declaredVarNames, do
     for vn in declared_var_names {
         // a. Perform ? env.CreateGlobalVarBinding(vn, false).
+        let cache = PropertyLookupCache::new(agent, vn.to_property_key());
         scoped_env
             .get(agent)
-            .create_global_var_binding(agent, vn, false, gc.reborrow())
+            .create_global_var_binding(agent, vn, cache, false, gc.reborrow())
             .unbind()?
             .bind(gc.nogc());
     }
@@ -1095,6 +1097,7 @@ mod test {
         let foo = unwrap_try(agent.current_global_env(gc.nogc()).try_get_binding_value(
             &mut agent,
             foo_key,
+            None,
             true,
             gc.nogc(),
         ))
@@ -1122,6 +1125,7 @@ mod test {
         let foo = unwrap_try(agent.current_global_env(gc.nogc()).try_get_binding_value(
             &mut agent,
             foo_key,
+            None,
             true,
             gc.nogc(),
         ))
@@ -1177,12 +1181,19 @@ mod test {
         assert!(unwrap_try(global_env.try_has_binding(
             &mut agent,
             foo_key,
+            None,
             gc.nogc()
         )));
         assert!(
-            unwrap_try(global_env.try_get_binding_value(&mut agent, foo_key, true, gc.nogc()))
-                .unwrap()
-                .is_function(),
+            unwrap_try(global_env.try_get_binding_value(
+                &mut agent,
+                foo_key,
+                None,
+                true,
+                gc.nogc()
+            ))
+            .unwrap()
+            .is_function(),
         );
     }
 
@@ -1452,20 +1463,22 @@ mod test {
         assert!(unwrap_try(global_env.try_has_binding(
             &mut agent,
             a_key,
+            None,
             gc.nogc()
         )));
         assert!(unwrap_try(global_env.try_has_binding(
             &mut agent,
             i_key,
+            None,
             gc.nogc()
         )));
         assert_eq!(
-            unwrap_try(global_env.try_get_binding_value(&mut agent, a_key, true, gc.nogc()))
+            unwrap_try(global_env.try_get_binding_value(&mut agent, a_key, None, true, gc.nogc()))
                 .unwrap(),
             String::from_small_string("foo").into_value()
         );
         assert_eq!(
-            unwrap_try(global_env.try_get_binding_value(&mut agent, i_key, true, gc.nogc()))
+            unwrap_try(global_env.try_get_binding_value(&mut agent, i_key, None, true, gc.nogc()))
                 .unwrap(),
             Value::from(3)
         );
@@ -1996,17 +2009,17 @@ mod test {
         assert!(global_env.has_lexical_declaration(&agent, b_key));
         assert!(global_env.has_lexical_declaration(&agent, c_key));
         assert_eq!(
-            unwrap_try(global_env.try_get_binding_value(&mut agent, a_key, true, gc.nogc()))
+            unwrap_try(global_env.try_get_binding_value(&mut agent, a_key, None, true, gc.nogc()))
                 .unwrap(),
             1.into()
         );
         assert_eq!(
-            unwrap_try(global_env.try_get_binding_value(&mut agent, b_key, true, gc.nogc()))
+            unwrap_try(global_env.try_get_binding_value(&mut agent, b_key, None, true, gc.nogc()))
                 .unwrap(),
             2.into()
         );
         assert_eq!(
-            unwrap_try(global_env.try_get_binding_value(&mut agent, c_key, true, gc.nogc()))
+            unwrap_try(global_env.try_get_binding_value(&mut agent, c_key, None, true, gc.nogc()))
                 .unwrap(),
             4.into()
         );
@@ -2039,6 +2052,7 @@ mod test {
             unwrap_try(global_env.try_get_binding_value(
                 &mut agent,
                 i_key.unbind(),
+                None,
                 true,
                 gc.nogc()
             ))

--- a/nova_vm/src/ecmascript/scripts_and_modules/source_code.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/source_code.rs
@@ -13,7 +13,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_parser::{Parser, ParserReturn};
-use oxc_semantic::{SemanticBuilder, SemanticBuilderReturn};
+use oxc_semantic::{AstNodes, Scoping, SemanticBuilder, SemanticBuilderReturn};
 use oxc_span::SourceType;
 
 use crate::{
@@ -139,7 +139,7 @@ impl<'a> SourceCode<'a> {
             }
         };
 
-        let allocator = Allocator::new();
+        let mut allocator = Allocator::new();
 
         let parser_result = match source_type {
             SourceCodeType::Script => {
@@ -152,24 +152,10 @@ impl<'a> SourceCode<'a> {
                 Parser::new(&allocator, source_text, source_type).parse()
             }
             SourceCodeType::StrictScript => {
-                #[allow(unused_mut)]
-                let mut source_type = SourceType::mjs();
-                #[cfg(feature = "typescript")]
-                if typescript {
-                    source_type = source_type.with_typescript(true);
-                }
-
-                // Strict script! We first parse this as a module, which makes
-                // the script parsing strict but allows module declarations. If
-                // that works, then we parse it as a normal script and check
-                // that it works as well: this will catch module declarations
-                // and TLA.
-                let parser_result = Parser::new(&allocator, source_text, source_type).parse();
-                if parser_result.panicked {
-                    let errors = parser_result.errors;
-                    return Err(errors);
-                }
-
+                // Strict script! We first parse and syntax check this as a
+                // normal script, which checks that the code contains no module
+                // declarations or TLA. If that passes, then we parse the
+                // script as a module, which sets strict mode on.
                 #[allow(unused_mut)]
                 let mut source_type = SourceType::cjs();
                 #[cfg(feature = "typescript")]
@@ -196,6 +182,32 @@ impl<'a> SourceCode<'a> {
                 if !sloppy_errors.is_empty() {
                     return Err(sloppy_errors);
                 }
+
+                let old_capacity = allocator.capacity();
+                // Reset the allocator; we don't need the sloppy program
+                // anymore.
+                allocator.reset();
+                if (old_capacity / 2) > allocator.capacity() {
+                    // If we more than halved the capacity of the allocator by
+                    // resetting it, we'll reallocate the whole thing to
+                    // old capacity.
+                    let _ =
+                        core::mem::replace(&mut allocator, Allocator::with_capacity(old_capacity));
+                }
+
+                #[allow(unused_mut)]
+                let mut source_type = SourceType::mjs();
+                #[cfg(feature = "typescript")]
+                if typescript {
+                    source_type = source_type.with_typescript(true);
+                }
+
+                let parser_result = Parser::new(&allocator, source_text, source_type).parse();
+                if parser_result.panicked {
+                    let errors = parser_result.errors;
+                    return Err(errors);
+                }
+
                 parser_result
             }
             SourceCodeType::Module => {
@@ -217,13 +229,14 @@ impl<'a> SourceCode<'a> {
             return Err(errors);
         }
 
-        let SemanticBuilderReturn { errors, .. } = SemanticBuilder::new()
+        let SemanticBuilderReturn { errors, semantic } = SemanticBuilder::new()
             .with_check_syntax_error(true)
             .build(&program);
 
         if !errors.is_empty() {
             return Err(errors);
         }
+        let (scoping, nodes) = semantic.into_scoping_and_nodes();
         let is_strict = source_type != SourceCodeType::Script || program.has_use_strict_directive();
         // SAFETY: Caller guarantees that they will drop the Program before
         // SourceCode can be garbage collected.
@@ -237,8 +250,16 @@ impl<'a> SourceCode<'a> {
                 ),
             )
         };
+        // SAFETY: AstNodes refers to the bump heap allocations of allocator.
+        // We move allocator onto the heap together with nodes, making this
+        // self-referential. The bump allocations are never moved or
+        // dellocated until dropping the entire struct, at which point the
+        // "allocator" field is dropped last.
+        let nodes = unsafe { core::mem::transmute::<AstNodes, AstNodes<'static>>(nodes) };
         let source_code = agent.heap.create(SourceCodeHeapData {
             source: source.unbind(),
+            scoping,
+            nodes,
             allocator,
         });
 
@@ -290,6 +311,8 @@ pub struct SourceCodeHeapData<'a> {
     /// string was small-string optimised and on the stack, then those
     /// references would necessarily and definitely be invalid.
     source: HeapString<'a>,
+    scoping: Scoping,
+    nodes: AstNodes<'static>,
     /// The arena that contains the parsed data of the eval source.
     allocator: Allocator,
 }
@@ -392,6 +415,8 @@ impl HeapMarkAndSweep for SourceCodeHeapData<'static> {
         let Self {
             source,
             allocator: _,
+            scoping: _,
+            nodes: _,
         } = self;
         source.mark_values(queues);
     }
@@ -400,6 +425,8 @@ impl HeapMarkAndSweep for SourceCodeHeapData<'static> {
         let Self {
             source,
             allocator: _,
+            scoping: _,
+            nodes: _,
         } = self;
         source.sweep_values(compactions);
     }

--- a/nova_vm/src/ecmascript/scripts_and_modules/source_code.rs
+++ b/nova_vm/src/ecmascript/scripts_and_modules/source_code.rs
@@ -299,6 +299,16 @@ impl<'a> SourceCode<'a> {
         unsafe { agent[agent[self].source].as_str().unwrap_unchecked() }
     }
 
+    /// Access the Scoping information of the SourceCode.
+    pub(crate) fn get_scoping(self, agent: &Agent) -> &Scoping {
+        &agent[self].scoping
+    }
+
+    /// Access the AstNodes information of the SourceCode.
+    pub(crate) fn get_nodes(self, agent: &Agent) -> &AstNodes<'a> {
+        &agent[self].nodes
+    }
+
     pub(crate) fn get_index(self) -> usize {
         self.0.into_index()
     }

--- a/nova_vm/src/ecmascript/syntax_directed_operations/function_definitions.rs
+++ b/nova_vm/src/ecmascript/syntax_directed_operations/function_definitions.rs
@@ -29,6 +29,7 @@ use crate::{
             set_function_name,
         },
         execution::{Agent, Environment, JsResult, PrivateEnvironment, ProtoIntrinsics},
+        scripts_and_modules::source_code::SourceCode,
         types::{
             BUILTIN_STRING_MEMORY, IntoFunction, IntoObject, IntoValue, Object, PropertyDescriptor,
             PropertyKey, String, Value,
@@ -247,6 +248,7 @@ pub(crate) fn instantiate_ordinary_function_expression<'a>(
 pub(crate) struct CompileFunctionBodyData<'a> {
     pub(crate) params: &'a oxc_ast::ast::FormalParameters<'a>,
     pub(crate) body: &'a oxc_ast::ast::FunctionBody<'a>,
+    pub(crate) source_code: SourceCode<'a>,
     pub(crate) is_strict: bool,
     pub(crate) is_lexical: bool,
     pub(crate) is_concise_body: bool,
@@ -267,6 +269,7 @@ impl CompileFunctionBodyData<'_> {
         CompileFunctionBodyData {
             params,
             body,
+            source_code: ecmascript_function.source_code,
             is_strict: ecmascript_function.strict,
             is_lexical: ecmascript_function.this_mode == ThisMode::Lexical,
             is_concise_body: ecmascript_function.is_concise_arrow_function,

--- a/nova_vm/src/ecmascript/types/language.rs
+++ b/nova_vm/src/ecmascript/types/language.rs
@@ -34,7 +34,8 @@ pub use numeric::Numeric;
 pub(crate) use object::ScopedPropertyKey;
 pub use object::{
     GetCachedResult, InternalMethods, InternalSlots, IntoObject, NoCache, Object, ObjectHeapData,
-    OrdinaryObject, PropertyKey, PropertyKeySet, SetCachedProps, SetCachedResult,
+    OrdinaryObject, PropertyKey, PropertyKeySet, SetCachedProps, SetCachedResult, SetProps,
+    call_proxy_set,
 };
 pub(crate) use primitive::HeapPrimitive;
 pub use primitive::Primitive;

--- a/nova_vm/src/ecmascript/types/language/function/into_function.rs
+++ b/nova_vm/src/ecmascript/types/language/function/into_function.rs
@@ -9,8 +9,8 @@ use crate::{
     ecmascript::{
         builtins::ordinary::{
             caches::PropertyLookupCache, ordinary_define_own_property, ordinary_delete,
-            ordinary_get_own_property, ordinary_own_property_keys, ordinary_set, ordinary_try_get,
-            ordinary_try_set,
+            ordinary_get_own_property, ordinary_has_property, ordinary_own_property_keys,
+            ordinary_set, ordinary_try_get, ordinary_try_has_property, ordinary_try_set,
         },
         execution::{Agent, JsResult},
         types::{
@@ -193,7 +193,7 @@ pub(crate) fn function_try_has_property<'a>(
     gc: NoGcScope,
 ) -> TryResult<bool> {
     if let Some(backing_object) = func.get_backing_object(agent) {
-        backing_object.try_has_property(agent, property_key, gc)
+        ordinary_try_has_property(agent, func.into_object(), backing_object, property_key, gc)
     } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length)
         || property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name)
     {
@@ -214,7 +214,13 @@ pub(crate) fn function_internal_has_property<'a, 'gc>(
 ) -> JsResult<'gc, bool> {
     let property_key = property_key.bind(gc.nogc());
     if let Some(backing_object) = func.get_backing_object(agent) {
-        backing_object.internal_has_property(agent, property_key.unbind(), gc)
+        ordinary_has_property(
+            agent,
+            func.into_object(),
+            backing_object,
+            property_key.unbind(),
+            gc,
+        )
     } else if property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.length)
         || property_key == PropertyKey::from(BUILTIN_STRING_MEMORY.name)
     {

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -122,7 +122,8 @@ use crate::{
 use ahash::AHashMap;
 pub use data::ObjectHeapData;
 pub use internal_methods::{
-    GetCachedResult, InternalMethods, NoCache, SetCachedProps, SetCachedResult,
+    GetCachedResult, InternalMethods, NoCache, SetCachedProps, SetCachedResult, SetProps,
+    call_proxy_set,
 };
 pub use internal_slots::InternalSlots;
 pub use into_object::IntoObject;

--- a/nova_vm/src/ecmascript/types/language/object.rs
+++ b/nova_vm/src/ecmascript/types/language/object.rs
@@ -4956,7 +4956,8 @@ impl TryFrom<HeapRootData> for Object<'_> {
             | HeapRootData::GlobalEnvironment(_)
             | HeapRootData::ModuleEnvironment(_)
             | HeapRootData::ObjectEnvironment(_)
-            | HeapRootData::PrivateEnvironment(_) => Err(()),
+            | HeapRootData::PrivateEnvironment(_)
+            | HeapRootData::PropertyLookupCache(_) => Err(()),
         }
     }
 }

--- a/nova_vm/src/ecmascript/types/language/object/internal_methods.rs
+++ b/nova_vm/src/ecmascript/types/language/object/internal_methods.rs
@@ -267,9 +267,13 @@ where
     ) -> TryResult<bool> {
         // 1. Return ? OrdinaryHasProperty(O, P).
         match self.get_backing_object(agent) {
-            Some(backing_object) => {
-                ordinary_try_has_property(agent, backing_object, property_key, gc)
-            }
+            Some(backing_object) => ordinary_try_has_property(
+                agent,
+                self.into_object(),
+                backing_object,
+                property_key,
+                gc,
+            ),
             None => {
                 // 3. Let parent be ? O.[[GetPrototypeOf]]().
                 let parent = self.try_get_prototype_of(agent, gc)?;
@@ -296,9 +300,13 @@ where
         let property_key = property_key.bind(gc.nogc());
         // 1. Return ? OrdinaryHasProperty(O, P).
         match self.get_backing_object(agent) {
-            Some(backing_object) => {
-                ordinary_has_property(agent, backing_object, property_key.unbind(), gc)
-            }
+            Some(backing_object) => ordinary_has_property(
+                agent,
+                self.into_object(),
+                backing_object,
+                property_key.unbind(),
+                gc,
+            ),
             None => {
                 let property_key = property_key.scope(agent, gc.nogc());
                 // 3. Let parent be ? O.[[GetPrototypeOf]]().
@@ -622,6 +630,8 @@ where
 /// and the normal \[\[Get]] method variant need not be entered.
 #[derive(Debug)]
 pub enum GetCachedResult<'a> {
+    /// No property exists in the object or its prototype chain.
+    Unset,
     /// A data property was found.
     Value(Value<'a>),
     /// A getter call is needed.

--- a/nova_vm/src/ecmascript/types/language/object/internal_methods.rs
+++ b/nova_vm/src/ecmascript/types/language/object/internal_methods.rs
@@ -20,7 +20,7 @@ use crate::{
             proxy::Proxy,
         },
         execution::{Agent, JsResult},
-        types::{Function, PropertyDescriptor, Value},
+        types::{Function, IntoValue, PropertyDescriptor, Value, throw_cannot_set_property},
     },
     engine::{
         TryResult,
@@ -722,4 +722,68 @@ unsafe impl Bindable for SetCachedResult<'_> {
     fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
         unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
     }
+}
+
+pub struct SetProps<'a> {
+    pub receiver: Value<'a>,
+    pub p: PropertyKey<'a>,
+    pub value: Value<'a>,
+    pub strict: bool,
+}
+
+// SAFETY: Property implemented as a lifetime transmute.
+unsafe impl Bindable for SetProps<'_> {
+    type Of<'a> = SetProps<'a>;
+
+    #[inline(always)]
+    fn unbind(self) -> Self::Of<'static> {
+        unsafe { core::mem::transmute::<Self, Self::Of<'static>>(self) }
+    }
+
+    #[inline(always)]
+    fn bind<'a>(self, _gc: NoGcScope<'a, '_>) -> Self::Of<'a> {
+        unsafe { core::mem::transmute::<Self, Self::Of<'a>>(self) }
+    }
+}
+
+/// Helper function for calling a Proxy [[Set]] trap when triggered by finding
+/// a Proxy used as a prototype.
+pub fn call_proxy_set<'a>(
+    agent: &mut Agent,
+    proxy: Proxy,
+    props: &SetProps,
+    mut gc: GcScope<'a, '_>,
+) -> JsResult<'a, ()> {
+    let proxy = proxy.unbind();
+    let receiver = props.receiver.unbind();
+    let p = props.p.unbind();
+    let value = props.value.unbind();
+    if props.strict {
+        let scoped_p = p.scope(agent, gc.nogc());
+        let scoped_o = receiver.scope(agent, gc.nogc());
+        let succeeded = proxy.internal_set(agent, p, value, receiver.into_value(), gc.reborrow());
+        // SAFETY: not shared.
+        let o = unsafe { scoped_o.take(agent) };
+        let succeeded = succeeded.unbind()?;
+        if !succeeded {
+            // d. If succeeded is false and V.[[Strict]] is true, throw a TypeError exception.
+            let o = o
+                .into_value()
+                .string_repr(agent, gc.reborrow())
+                .unbind()
+                .bind(gc.nogc());
+            // SAFETY: not shared.
+            let p = unsafe { scoped_p.take(agent) }.bind(gc.nogc());
+            return Err(throw_cannot_set_property(
+                agent,
+                o.into_value().unbind(),
+                p.unbind(),
+                gc.into_nogc(),
+            ));
+        }
+    } else {
+        // In sloppy mode we don't care about the result.
+        let _ = proxy.internal_set(agent, p, value, receiver.into_value(), gc)?;
+    }
+    Ok(())
 }

--- a/nova_vm/src/ecmascript/types/language/value.rs
+++ b/nova_vm/src/ecmascript/types/language/value.rs
@@ -1527,7 +1527,8 @@ impl Rootable for Value<'_> {
             | HeapRootData::GlobalEnvironment(_)
             | HeapRootData::ModuleEnvironment(_)
             | HeapRootData::ObjectEnvironment(_)
-            | HeapRootData::PrivateEnvironment(_) => None,
+            | HeapRootData::PrivateEnvironment(_)
+            | HeapRootData::PropertyLookupCache(_) => None,
             // Note: Do not use _ => Err(()) to make sure any added
             // HeapRootData Value variants cause compile errors if not handled.
         }

--- a/nova_vm/src/engine/bytecode/bytecode_compiler.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler.rs
@@ -1934,15 +1934,13 @@ pub(super) fn compile_expression_get_value<'s, 'gc>(
 pub(super) fn compile_expression_get_value_keep_reference<'s, 'gc>(
     expr: &'s ast::Expression<'s>,
     ctx: &mut CompileContext<'_, 's, 'gc, '_>,
-) -> Option<ExpressionOutput<'gc>> {
+) {
     let output = expr.compile(ctx);
     if let Some(ExpressionOutput::Place(property_key)) = output {
-        let cache = ctx.create_property_lookup_cache(property_key);
-        ctx.add_instruction_with_cache(Instruction::GetValueWithCacheKeepReference, cache);
+        compile_get_value_keep_reference(ctx, Some(property_key));
     } else if is_reference(expr) {
-        ctx.add_instruction(Instruction::GetValueKeepReference);
+        compile_get_value_keep_reference(ctx, None);
     }
-    output
 }
 
 pub(super) fn compile_put_value<'gc>(

--- a/nova_vm/src/engine/bytecode/bytecode_compiler/assignment.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler/assignment.rs
@@ -23,6 +23,7 @@ impl<'a, 's, 'gc, 'scope> CompileEvaluation<'a, 's, 'gc, 'scope> for ast::Assign
         // 1. Let lref be ? Evaluation of LeftHandSideExpression.
         let lref = match &self.left {
             ast::AssignmentTarget::AssignmentTargetIdentifier(identifier) => {
+                let name = identifier.compile(ctx);
                 if is_anonymous_function_definition(&self.right)
                 // NOTE: If the left hand side does not constitute the start of
                 // the assignment expression span, then it means that the left
@@ -30,9 +31,7 @@ impl<'a, 's, 'gc, 'scope> CompileEvaluation<'a, 's, 'gc, 'scope> for ast::Assign
                 // happen.
                     && self.span.start == identifier.span.start
                 {
-                    named_evaluation_identifier = Some(identifier.compile(ctx));
-                } else {
-                    identifier.compile(ctx);
+                    named_evaluation_identifier = Some(name);
                 }
                 None
             }

--- a/nova_vm/src/engine/bytecode/bytecode_compiler/assignment.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler/assignment.rs
@@ -30,12 +30,7 @@ impl<'a, 's, 'gc, 'scope> CompileEvaluation<'a, 's, 'gc, 'scope> for ast::Assign
                 // happen.
                     && self.span.start == identifier.span.start
                 {
-                    let identifier = ctx.create_string(identifier.name.as_str());
-                    ctx.add_instruction_with_identifier(
-                        Instruction::ResolveBinding,
-                        identifier.to_property_key(),
-                    );
-                    named_evaluation_identifier = Some(identifier);
+                    named_evaluation_identifier = Some(identifier.compile(ctx));
                 } else {
                     identifier.compile(ctx);
                 }

--- a/nova_vm/src/engine/bytecode/bytecode_compiler/class_definition_evaluation.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler/class_definition_evaluation.rs
@@ -569,8 +569,9 @@ impl<'a, 's, 'gc, 'scope> CompileEvaluation<'a, 's, 'gc, 'scope> for ast::Class<
         // 28. Set F.[[PrivateMethods]] to instancePrivateMethods.
         // 29. Set F.[[Fields]] to instanceFields.
         if has_instance_private_fields_or_methods || !instance_fields.is_empty() {
+            let source_code = ctx.get_source_code();
             let (agent, gc) = ctx.get_agent_and_gc();
-            let mut constructor_ctx = CompileContext::new(agent, gc);
+            let mut constructor_ctx = CompileContext::new(agent, source_code, gc);
             // Resolve 'this' into the stack.
             constructor_ctx.add_instruction(Instruction::ResolveThisBinding);
             constructor_ctx.add_instruction(Instruction::Load);
@@ -598,10 +599,12 @@ impl<'a, 's, 'gc, 'scope> CompileEvaluation<'a, 's, 'gc, 'scope> for ast::Class<
             }
             // Pop the `this` value off the stack.
             constructor_ctx.add_instruction(Instruction::Store);
+            let source_code = constructor_ctx.get_source_code();
             if let Some(constructor) = constructor {
                 let constructor_data = CompileFunctionBodyData {
                     body: constructor.value.body.as_ref().unwrap(),
                     params: &constructor.value.params,
+                    source_code,
                     is_concise_body: false,
                     is_lexical: false,
                     // Class code is always strict.

--- a/nova_vm/src/engine/bytecode/bytecode_compiler/class_definition_evaluation.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler/class_definition_evaluation.rs
@@ -1041,13 +1041,9 @@ impl<'a, 's, 'gc, 'scope> CompileEvaluation<'a, 's, 'gc, 'scope> for ast::Static
             // b. Let fo be InstantiateFunctionObject of f with arguments lexEnv and privateEnv.
             f.compile(ctx);
             // a. Let fn be the sole element of the BoundNames of f.
-            let f_name = ctx.create_string(&f.id.as_ref().unwrap().name);
+            f.id.as_ref().unwrap().compile(ctx);
             // c. Perform ! varEnv.SetMutableBinding(fn, fo, false).
             // TODO: This compilation is incorrect if !strict, when varEnv != lexEnv.
-            ctx.add_instruction_with_identifier(
-                Instruction::ResolveBinding,
-                f_name.to_property_key(),
-            );
             ctx.add_instruction(Instruction::PutValue);
         }
 

--- a/nova_vm/src/engine/bytecode/bytecode_compiler/compile_context.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler/compile_context.rs
@@ -978,6 +978,19 @@ impl<'agent, 'script, 'gc, 'scope> CompileContext<'agent, 'script, 'gc, 'scope> 
             .add_instruction_with_cache(instruction, cache);
     }
 
+    pub(super) fn add_instruction_with_identifier_and_cache(
+        &mut self,
+        instruction: Instruction,
+        identifier: String<'gc>,
+        cache: PropertyLookupCache<'gc>,
+    ) {
+        self.executable.add_instruction_with_identifier_and_cache(
+            instruction,
+            identifier.to_property_key(),
+            cache,
+        );
+    }
+
     pub(super) fn add_instruction_with_identifier_and_constant(
         &mut self,
         instruction: Instruction,

--- a/nova_vm/src/engine/bytecode/bytecode_compiler/compile_context.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler/compile_context.rs
@@ -12,6 +12,7 @@ use crate::{
             regexp::RegExp,
         },
         execution::Agent,
+        scripts_and_modules::source_code::SourceCode,
         syntax_directed_operations::function_definitions::CompileFunctionBodyData,
         types::{BigInt, Number, PropertyKey, String, Value},
     },
@@ -100,6 +101,7 @@ pub(crate) enum GeneratorKind {
 ///   tracks it.
 pub(crate) struct CompileContext<'agent, 'script, 'gc, 'scope> {
     executable: ExecutableContext<'agent, 'gc, 'scope>,
+    source_code: SourceCode<'gc>,
     /// NamedEvaluation name parameter
     pub(super) name_identifier: Option<NamedEvaluationParameter>,
     /// If true, indicates that all bindings being created are lexical.
@@ -122,10 +124,12 @@ pub(crate) struct CompileContext<'agent, 'script, 'gc, 'scope> {
 impl<'agent, 'script, 'gc, 'scope> CompileContext<'agent, 'script, 'gc, 'scope> {
     pub(crate) fn new(
         agent: &'agent mut Agent,
+        source_code: SourceCode<'gc>,
         gc: NoGcScope<'gc, 'scope>,
     ) -> CompileContext<'agent, 'script, 'gc, 'scope> {
         CompileContext {
             executable: ExecutableContext::new(agent, gc),
+            source_code,
             name_identifier: None,
             lexical_binding_state: false,
             optional_chains: None,
@@ -160,6 +164,11 @@ impl<'agent, 'script, 'gc, 'scope> CompileContext<'agent, 'script, 'gc, 'scope> 
     /// Get shared access to the Agent through the context.
     pub(crate) fn get_agent(&self) -> &Agent {
         self.executable.get_agent()
+    }
+
+    /// Get the SourceCode being compiled.
+    pub(crate) fn get_source_code(&self) -> SourceCode<'gc> {
+        self.source_code
     }
 
     /// Get exclusive access to the Agent through the context as mutable.

--- a/nova_vm/src/engine/bytecode/bytecode_compiler/executable_context.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler/executable_context.rs
@@ -285,6 +285,21 @@ impl<'agent, 'gc, 'scope> ExecutableContext<'agent, 'gc, 'scope> {
         self.add_index(cache);
     }
 
+    pub(super) fn add_instruction_with_identifier_and_cache(
+        &mut self,
+        instruction: Instruction,
+        identifier: PropertyKey<'gc>,
+        cache: PropertyLookupCache<'gc>,
+    ) {
+        debug_assert_eq!(instruction.argument_count(), 2);
+        debug_assert!(instruction.has_identifier_index() && instruction.has_cache_index());
+        self.push_instruction(instruction);
+        let identifier = self.add_identifier(identifier);
+        self.add_index(identifier);
+        let cache = self.add_cache(cache);
+        self.add_index(cache);
+    }
+
     pub(super) fn add_instruction_with_identifier_and_constant(
         &mut self,
         instruction: Instruction,

--- a/nova_vm/src/engine/bytecode/bytecode_compiler/function_declaration_instantiation.rs
+++ b/nova_vm/src/engine/bytecode/bytecode_compiler/function_declaration_instantiation.rs
@@ -427,10 +427,9 @@ pub(crate) fn instantiation<'s>(
         //    and privateEnv.
         f.compile(ctx);
         // a. Let fn be the sole element of the BoundNames of f.
-        let f_name = ctx.create_string(&f.id.as_ref().unwrap().name);
         // c. Perform ! varEnv.SetMutableBinding(fn, fo, false).
         // TODO: This compilation is incorrect if !strict, when varEnv != lexEnv.
-        ctx.add_instruction_with_identifier(Instruction::ResolveBinding, f_name.to_property_key());
+        f.id.as_ref().unwrap().compile(ctx);
         ctx.add_instruction(Instruction::PutValue);
     }
 }

--- a/nova_vm/src/engine/bytecode/instructions.rs
+++ b/nova_vm/src/engine/bytecode/instructions.rs
@@ -259,6 +259,9 @@ pub enum Instruction {
     PutValueWithCache,
     /// Store ResolveBinding() in the reference register.
     ResolveBinding,
+    /// Store ResolveBinding() in the reference register using a property
+    /// lookup cache.
+    ResolveBindingWithCache,
     /// Store ResolveThisBinding() in the result register.
     ResolveThisBinding,
     /// Stop bytecode execution, indicating a return from the current function.
@@ -520,7 +523,8 @@ impl Instruction {
             | Self::ObjectDefineGetter
             | Self::ObjectDefineMethod
             | Self::ObjectDefineSetter
-            | Self::PushExceptionJumpTarget => 2,
+            | Self::PushExceptionJumpTarget
+            | Self::ResolveBindingWithCache => 2,
             Self::ArrayCreate
             | Self::BeginSimpleObjectBindingPattern
             | Self::BindingPatternBind
@@ -573,6 +577,7 @@ impl Instruction {
             Self::GetValueWithCache
                 | Self::GetValueWithCacheKeepReference
                 | Self::PutValueWithCache
+                | Self::ResolveBindingWithCache
         )
     }
 
@@ -604,6 +609,7 @@ impl Instruction {
                 | Self::MakePrivateReference
                 | Self::MakeSuperPropertyReferenceWithIdentifierKey
                 | Self::ResolveBinding
+                | Self::ResolveBindingWithCache
                 | Self::VerifyIsObject
         );
 
@@ -968,6 +974,7 @@ impl Instr {
             Instruction::ObjectDefineGetter => "get function() {}".to_string(),
             Instruction::ObjectDefineMethod => "function() {}".to_string(),
             Instruction::ObjectDefineSetter => "set function() {}".to_string(),
+            Instruction::ResolveBindingWithCache => "ResolveBindingWithCache {}".to_string(),
             _ => unreachable!("{kind:?}"),
         }
     }
@@ -1233,6 +1240,7 @@ impl TryFrom<u8> for Instruction {
         const PUTVALUE: u8 = Instruction::PutValue.as_u8();
         const PUTVALUEWITHCACHE: u8 = Instruction::PutValueWithCache.as_u8();
         const RESOLVEBINDING: u8 = Instruction::ResolveBinding.as_u8();
+        const RESOLVEBINDINGWITHCACHE: u8 = Instruction::ResolveBindingWithCache.as_u8();
         const RESOLVETHISBINDING: u8 = Instruction::ResolveThisBinding.as_u8();
         const RETURN: u8 = Instruction::Return.as_u8();
         const STORE: u8 = Instruction::Store.as_u8();
@@ -1443,6 +1451,7 @@ impl TryFrom<u8> for Instruction {
             PUTVALUE => Ok(Instruction::PutValue),
             PUTVALUEWITHCACHE => Ok(Instruction::PutValueWithCache),
             RESOLVEBINDING => Ok(Instruction::ResolveBinding),
+            RESOLVEBINDINGWITHCACHE => Ok(Instruction::ResolveBindingWithCache),
             RESOLVETHISBINDING => Ok(Instruction::ResolveThisBinding),
             RETURN => Ok(Instruction::Return),
             STORE => Ok(Instruction::Store),

--- a/nova_vm/src/engine/bytecode/vm/binding_methods.rs
+++ b/nova_vm/src/engine/bytecode/vm/binding_methods.rs
@@ -144,6 +144,7 @@ pub(super) fn execute_simple_array_binding<'a>(
                         let lhs = resolve_binding(
                             agent,
                             binding_id.unbind(),
+                            None,
                             environment.as_ref().map(|v| v.get(agent)),
                             gc.reborrow(),
                         )
@@ -272,6 +273,7 @@ pub(super) fn execute_simple_object_binding<'a>(
                         let lhs = resolve_binding(
                             agent,
                             binding_id.unbind(),
+                            None,
                             environment.as_ref().map(|v| v.get(agent)),
                             gc.reborrow(),
                         )
@@ -338,10 +340,10 @@ pub(super) fn execute_simple_object_binding<'a>(
                         // 1. Let lhs be ? ResolveBinding(StringValue of BindingIdentifier, environment).
                         let binding_id =
                             executable.fetch_identifier(agent, instr.get_first_index(), gc.nogc());
-                        // TODO: Properly handle potential GC.
                         let lhs = resolve_binding(
                             agent,
                             binding_id.unbind(),
+                            None,
                             environment.as_ref().map(|v| v.get(agent)),
                             gc.reborrow(),
                         )


### PR DESCRIPTION
Introducing OXC semantic data usage to the bytecode compiler! Property lookup compilation now checks if we're looking for a (possibly) global property, and performs object property lookup for these properties (since the global object is a just an object like any other).