### PR TITLE
feat(cli): add now builtin function

### DIFF
--- a/nova_vm/src/ecmascript/types/language/bigint.rs
+++ b/nova_vm/src/ecmascript/types/language/bigint.rs
@@ -208,6 +208,30 @@ impl<'a> BigInt<'a> {
     }
 
     #[inline]
+    pub fn from_i128(agent: &mut Agent, value: i128, gc: NoGcScope<'a, '_>) -> Self {
+        if let Ok(result) = SmallBigInt::try_from(value) {
+            Self::SmallBigInt(result)
+        } else {
+            agent
+                .heap
+                .create(BigIntHeapData { data: value.into() })
+                .bind(gc)
+        }
+    }
+
+    #[inline]
+    pub fn from_u128(agent: &mut Agent, value: u128, gc: NoGcScope<'a, '_>) -> Self {
+        if let Ok(result) = SmallBigInt::try_from(value) {
+            Self::SmallBigInt(result)
+        } else {
+            agent
+                .heap
+                .create(BigIntHeapData { data: value.into() })
+                .bind(gc)
+        }
+    }
+
+    #[inline]
     pub(crate) fn from_num_bigint(agent: &mut Agent, value: num_bigint::BigInt) -> Self {
         if let Ok(result) = SmallBigInt::try_from(&value) {
             Self::SmallBigInt(result)

--- a/nova_vm/src/engine/context.rs
+++ b/nova_vm/src/engine/context.rs
@@ -437,6 +437,8 @@ trivially_bindable!(i32);
 trivially_bindable!(u32);
 trivially_bindable!(i64);
 trivially_bindable!(u64);
+trivially_bindable!(i128);
+trivially_bindable!(u128);
 trivially_bindable!(isize);
 trivially_bindable!(usize);
 #[cfg(feature = "proposal-float16array")]

--- a/nova_vm/src/engine/small_bigint.rs
+++ b/nova_vm/src/engine/small_bigint.rs
@@ -188,6 +188,18 @@ impl TryFrom<u64> for SmallBigInt {
     }
 }
 
+impl TryFrom<u128> for SmallBigInt {
+    type Error = ();
+    fn try_from(value: u128) -> Result<Self, Self::Error> {
+        if (Self::MIN as u128..=Self::MAX as u128).contains(&value) {
+            // SAFETY: Checked to be in range.
+            Ok(unsafe { Self::from_i64_unchecked(value as i64) })
+        } else {
+            Err(())
+        }
+    }
+}
+
 impl TryFrom<usize> for SmallBigInt {
     type Error = ();
     fn try_from(value: usize) -> Result<Self, Self::Error> {


### PR DESCRIPTION
Adds a `now()` builtin function that returns the time since unix epoch in nanoseconds as `SmallBigInt`.

