### PR TITLE
chore(just): Add just

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,13 @@ expectations. You can do this with the following command:
 cargo build --profile dev-fast && cargo run --bin test262 --profile dev-fast -- -u
 ```
 
+Or you can use command via [just](https://github.com/casey/just).
+(Please see `justfile` if you want to know available commands )
+
+```sh
+just build-and-test262-update
+```
+
 This will build you a "dev-fast" version of Nova, and run the test262
 conformance using that executable. At the end of the run, it will record the
 results `expectations.json`.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,19 @@
+build profile="dev-fast":
+  cargo build --profile {{ profile }}
+
+test262 profile="dev-fast":
+  cargo run --bin test262 --profile {{ profile }}
+
+test262-update profile="dev-fast":
+  cargo run --bin test262 --profile {{ profile }} -- -u
+
+build-and-test262 profile="dev-fast":
+  just build {{ profile }}
+  just test262 {{ profile }}
+
+build-and-test262-update profile="dev-fast":
+  just build {{ profile }}
+  just test262-update {{ profile }}
+
+test262-eval-test path profile="dev-fast":
+  cargo run --bin test262 --profile {{ profile }} -- eval-test {{ path }}


### PR DESCRIPTION
# Background
When I execute commands like `cargo build --profile dev-fast && cargo run --bin test262 --profile dev-fast -- -u`, I check https://github.com/trynova/nova/blob/main/CONTRIBUTING.md everytime because I cannot remember commands.


# Proposal
Introduce just for improving developer experience when executing commands like build,run test262, and so on...
If we can use just, we can check essential commands for contributing like below :).


https://github.com/user-attachments/assets/5831bed8-79df-4733-bd12-a595e8a85177



